### PR TITLE
Add test cases for metadata region access

### DIFF
--- a/test-data/packet.yaml
+++ b/test-data/packet.yaml
@@ -195,3 +195,60 @@ code:
 post: ["r0.type=number",
        "r6.type=ctx", "r6.ctx_offset=0",
        "r7.type=number", "r7.svalue=23", "r7.uvalue=23"]
+---
+test-case: meta_offset lower bound access
+
+pre: ["meta_offset=-8", "packet_size=0",
+      "r1.type=packet", "r1.packet_offset=0", "r1.svalue=[4098, 2147418112]", "r1.uvalue=[4098, 2147418112]"]
+
+code:
+  <start>: |
+    r2 = *(u64 *)(r1 - 8)
+
+post: ["meta_offset=-8", "packet_size=0",
+       "r1.type=packet", "r1.packet_offset=0", "r1.svalue=[4098, 2147418112]", "r1.uvalue=[4098, 2147418112]",
+       "r2.type=number"]
+messages: []
+---
+test-case: meta_offset lower bound incorrect access
+
+pre: ["meta_offset=0", "packet_size=8",
+      "r1.type=packet", "r1.packet_offset=0", "r1.svalue=[4098, 2147418112]", "r1.uvalue=[4098, 2147418112]"]
+
+code:
+  <start>: |
+    r2 = *(u64 *)(r1 - 8)
+
+post: ["meta_offset=0", "packet_size=8",
+       "r1.type=packet", "r1.packet_offset=0", "r1.svalue=[4098, 2147418112]", "r1.uvalue=[4098, 2147418112]",
+       "r2.type=number"]
+messages:
+  - "0: Lower bound must be at least meta_offset (valid_access(r1.offset-8, width=8) for read)"
+---
+test-case: meta_offset upper bound incorrect access
+
+pre: ["meta_offset=-8", "packet_size=0",
+      "r1.type=packet", "r1.packet_offset=-8", "r1.svalue=[4098, 2147418112]", "r1.uvalue=[4098, 2147418112]"]
+
+code:
+  <start>: |
+    r2 = *(u64 *)(r1 + 8)
+
+post: ["meta_offset=-8", "packet_size=0",
+       "r1.type=packet", "r1.packet_offset=-8", "r1.svalue=[4098, 2147418112]", "r1.uvalue=[4098, 2147418112]",
+       "r2.type=number"]
+messages:
+  - "0: Upper bound must be at most packet_size (valid_access(r1.offset+8, width=8) for read)"
+---
+test-case: meta_offset upper bound access
+
+pre: ["meta_offset=-8", "packet_size=0",
+      "r1.type=packet", "r1.packet_offset=-8", "r1.svalue=[4098, 2147418112]", "r1.uvalue=[4098, 2147418112]"]
+
+code:
+  <start>: |
+    r2 = *(u64 *)(r1 + 0)
+
+post: ["meta_offset=-8", "packet_size=0",
+       "r1.type=packet", "r1.packet_offset=-8", "r1.svalue=[4098, 2147418112]", "r1.uvalue=[4098, 2147418112]",
+       "r2.type=number"]


### PR DESCRIPTION
This pull request introduces new test cases to the `test-data/packet.yaml` file. These test cases are designed to validate the behavior of `meta_offset` and `packet_offset` under various conditions, ensuring that access bounds are correctly enforced.

New test cases added:

* [`meta_offset lower bound access`](diffhunk://#diff-27d268c4660cf8d7b218d17a4fee7be727ee344c6c7cdf20b3260fa22a4f94e8R198-R254): Verifies that accessing memory at the lower bound of `meta_offset` is handled correctly.
* [`meta_offset lower bound incorrect access`](diffhunk://#diff-27d268c4660cf8d7b218d17a4fee7be727ee344c6c7cdf20b3260fa22a4f94e8R198-R254): Ensures that an error message is generated when accessing memory below the lower bound of `meta_offset`.
* [`meta_offset upper bound incorrect access`](diffhunk://#diff-27d268c4660cf8d7b218d17a4fee7be727ee344c6c7cdf20b3260fa22a4f94e8R198-R254): Ensures that an error message is generated when accessing memory above the upper bound of `packet_size`.
* [`meta_offset upper bound access`](diffhunk://#diff-27d268c4660cf8d7b218d17a4fee7be727ee344c6c7cdf20b3260fa22a4f94e8R198-R254): Verifies that accessing memory at the upper bound of `meta_offset` is handled correctly.