### PR TITLE
Bump Catch2 to 3.8.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ get_target_property(GSL_INCLUDE_DIRS Microsoft.GSL::GSL INTERFACE_INCLUDE_DIRECT
 if (VERIFIER_ENABLE_TESTS)
     FetchContent_Declare(Catch2
             GIT_REPOSITORY "https://github.com/catchorg/Catch2.git"
-            GIT_TAG "v3.8.0"
+            GIT_TAG "v3.8.1"
             GIT_SHALLOW ON
     )
     FetchContent_MakeAvailable(Catch2)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of the internal testing dependency to ensure our test suite remains current and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->