### PR TITLE
Rename namspace crab to prevail

### DIFF
--- a/src/asm_cfg.cpp
+++ b/src/asm_cfg.cpp
@@ -47,7 +47,7 @@ struct cfg_builder_t final {
         if (const auto it = prog.m_cfg.neighbours.find(_label); it != prog.m_cfg.neighbours.end()) {
             CRAB_ERROR("Label ", to_string(_label), " already exists");
         }
-        prog.m_cfg.neighbours.emplace(_label, crab::cfg_t::adjacent_t{});
+        prog.m_cfg.neighbours.emplace(_label, prevail::cfg_t::adjacent_t{});
         prog.m_instructions.emplace(_label, ins);
     }
 
@@ -83,7 +83,7 @@ struct cfg_builder_t final {
     }
 };
 
-using crab::basic_block_t;
+using prevail::basic_block_t;
 
 /// Get the inverse of a given comparison operation.
 static Condition::Op reverse(const Condition::Op op) {
@@ -301,7 +301,7 @@ Program Program::from_sequence(const InstructionSeq& inst_seq, const program_inf
     // hierarchical decomposition of the CFG that identifies all strongly connected components (cycles) and their entry
     // points. These entry points serve as natural locations for loop counters that help verify program termination.
     if (options.cfg_opts.check_for_termination) {
-        const crab::wto_t wto{builder.prog.cfg()};
+        const prevail::wto_t wto{builder.prog.cfg()};
         wto.for_each_loop_head([&](const label_t& label) -> void {
             builder.insert_after(label, label_t::make_increment_counter(label), IncrementLoopCounter{label});
         });
@@ -449,7 +449,7 @@ std::map<std::string, int> collect_stats(const Program& prog) {
     return res;
 }
 
-crab::cfg_t crab::cfg_from_adjacency_list(const std::map<label_t, std::vector<label_t>>& adj_list) {
+prevail::cfg_t prevail::cfg_from_adjacency_list(const std::map<label_t, std::vector<label_t>>& adj_list) {
     cfg_builder_t builder;
     for (const auto& label : std::views::keys(adj_list)) {
         if (label == label_t::entry || label == label_t::exit) {

--- a/src/asm_marshal.cpp
+++ b/src/asm_marshal.cpp
@@ -296,7 +296,7 @@ struct MarshalVisitor {
 };
 
 vector<ebpf_inst> marshal(const Instruction& ins, const pc_t pc) {
-    return std::visit(MarshalVisitor{crab::label_to_offset16(pc), crab::label_to_offset32(pc)}, ins);
+    return std::visit(MarshalVisitor{prevail::label_to_offset16(pc), prevail::label_to_offset32(pc)}, ins);
 }
 
 int asm_syntax::size(const Instruction& inst) {

--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -18,12 +18,12 @@
 #include "platform.hpp"
 #include "spec_type_descriptors.hpp"
 
-using crab::TypeGroup;
+using prevail::TypeGroup;
 using std::optional;
 using std::string;
 using std::vector;
 
-namespace crab {
+namespace prevail {
 
 std::ostream& operator<<(std::ostream& o, const interval_t& interval) {
     if (interval.is_bottom()) {
@@ -69,7 +69,7 @@ string to_string(label_t const& label) {
     return str.str();
 }
 
-} // namespace crab
+} // namespace prevail
 
 struct LineInfoPrinter {
     std::ostream& os;
@@ -108,7 +108,7 @@ void print_jump(std::ostream& o, const std::string& direction, const std::set<la
 void print_program(const Program& prog, std::ostream& os, const bool simplify, const printfunc& prefunc,
                    const printfunc& postfunc) {
     LineInfoPrinter printer{os};
-    for (const crab::basic_block_t& bb : crab::basic_block_t::collect_basic_blocks(prog.cfg(), simplify)) {
+    for (const prevail::basic_block_t& bb : prevail::basic_block_t::collect_basic_blocks(prog.cfg(), simplify)) {
         prefunc(os, bb.first_label());
         print_jump(os, "from", prog.cfg().parents_of(bb.first_label()));
         os << bb.first_label() << ":\n";
@@ -314,10 +314,12 @@ struct AssertionPrinterVisitor {
     }
 
     void operator()(const BoundedLoopCount& a) {
-        _os << crab::variable_t::loop_counter(to_string(a.name)) << " < " << a.limit;
+        _os << prevail::variable_t::loop_counter(to_string(a.name)) << " < " << a.limit;
     }
 
-    static crab::variable_t typereg(const Reg& r) { return crab::variable_t::reg(crab::data_kind_t::types, r.v); }
+    static prevail::variable_t typereg(const Reg& r) {
+        return prevail::variable_t::reg(prevail::data_kind_t::types, r.v);
+    }
 
     void operator()(ValidSize const& a) {
         const auto op = a.can_be_zero ? " >= " : " > ";
@@ -335,7 +337,7 @@ struct AssertionPrinterVisitor {
     }
 
     void operator()(ZeroCtxOffset const& a) {
-        _os << crab::variable_t::reg(crab::data_kind_t::ctx_offsets, a.reg.v) << " == 0";
+        _os << prevail::variable_t::reg(prevail::data_kind_t::ctx_offsets, a.reg.v) << " == 0";
     }
 
     void operator()(Comparable const& a) {
@@ -528,7 +530,9 @@ struct CommandPrinterVisitor {
         print(b.cond);
     }
 
-    void operator()(IncrementLoopCounter const& a) { os_ << crab::variable_t::loop_counter(to_string(a.name)) << "++"; }
+    void operator()(IncrementLoopCounter const& a) {
+        os_ << prevail::variable_t::loop_counter(to_string(a.name)) << "++";
+    }
 };
 // ReSharper restore CppMemberFunctionMayBeConst
 
@@ -592,7 +596,7 @@ void print(const InstructionSeq& insts, std::ostream& out, const std::optional<c
             }
             if (const auto jmp = std::get_if<Jmp>(&ins)) {
                 if (!pc_of_label.contains(jmp->target)) {
-                    throw std::runtime_error(string("Cannot find label ") + crab::to_string(jmp->target));
+                    throw std::runtime_error(string("Cannot find label ") + prevail::to_string(jmp->target));
                 }
                 const pc_t target_pc = pc_of_label.at(jmp->target);
                 visitor(*jmp, target_pc - static_cast<int>(pc) - 1);

--- a/src/asm_parse.cpp
+++ b/src/asm_parse.cpp
@@ -18,9 +18,9 @@
 using std::regex;
 using std::regex_match;
 
-using crab::linear_constraint_t;
-using crab::linear_expression_t;
-using crab::number_t;
+using prevail::linear_constraint_t;
+using prevail::linear_expression_t;
+using prevail::number_t;
 
 #define REG R"_(\s*(r\d\d?)\s*)_"
 #define WREG R"_(\s*([wr]\d\d?)\s*)_"
@@ -279,21 +279,21 @@ static InstructionSeq parse_program(std::istream& is) {
 
 static uint8_t regnum(const std::string& s) { return static_cast<uint8_t>(boost::lexical_cast<uint16_t>(s.substr(1))); }
 
-static crab::variable_t special_var(const std::string& s) {
+static prevail::variable_t special_var(const std::string& s) {
     if (s == "packet_size") {
-        return crab::variable_t::packet_size();
+        return prevail::variable_t::packet_size();
     }
     if (s == "meta_offset") {
-        return crab::variable_t::meta_offset();
+        return prevail::variable_t::meta_offset();
     }
     throw std::runtime_error(std::string() + "Bad special variable: " + s);
 }
 
 std::vector<linear_constraint_t> parse_linear_constraints(const std::set<std::string>& constraints,
-                                                          std::vector<crab::interval_t>& numeric_ranges) {
-    using namespace crab::dsl_syntax;
-    using crab::regkind;
-    using crab::variable_t;
+                                                          std::vector<prevail::interval_t>& numeric_ranges) {
+    using namespace prevail::dsl_syntax;
+    using prevail::regkind;
+    using prevail::variable_t;
 
     std::vector<linear_constraint_t> res;
     for (const std::string& cst_text : constraints) {
@@ -321,8 +321,8 @@ std::vector<linear_constraint_t> parse_linear_constraints(const std::set<std::st
         } else if (regex_match(cst_text, m,
                                regex(REG DOT "type"
                                              "=" TYPE))) {
-            variable_t d = variable_t::reg(crab::data_kind_t::types, regnum(m[1]));
-            res.push_back(d == crab::string_to_type_encoding(m[2]));
+            variable_t d = variable_t::reg(prevail::data_kind_t::types, regnum(m[1]));
+            res.push_back(d == prevail::string_to_type_encoding(m[2]));
         } else if (regex_match(cst_text, m, regex(REG DOT KIND "=" IMM))) {
             variable_t d = variable_t::reg(regkind(m[2]), regnum(m[1]));
             number_t value;
@@ -352,13 +352,13 @@ std::vector<linear_constraint_t> parse_linear_constraints(const std::set<std::st
         } else if (regex_match(cst_text, m,
                                regex("s" ARRAY_RANGE DOT "type"
                                      "=" TYPE))) {
-            crab::type_encoding_t type = crab::string_to_type_encoding(m[3]);
-            if (type == crab::type_encoding_t::T_NUM) {
+            prevail::type_encoding_t type = prevail::string_to_type_encoding(m[3]);
+            if (type == prevail::type_encoding_t::T_NUM) {
                 numeric_ranges.emplace_back(signed_number(m[1]), signed_number(m[2]));
             } else {
                 number_t lb = signed_number(m[1]);
                 number_t ub = signed_number(m[2]);
-                variable_t d = variable_t::cell_var(crab::data_kind_t::types, lb, ub - lb + 1);
+                variable_t d = variable_t::cell_var(prevail::data_kind_t::types, lb, ub - lb + 1);
                 res.push_back(d == type);
             }
         } else if (regex_match(cst_text, m,
@@ -366,14 +366,14 @@ std::vector<linear_constraint_t> parse_linear_constraints(const std::set<std::st
                                      "=" IMM))) {
             number_t lb = signed_number(m[1]);
             number_t ub = signed_number(m[2]);
-            variable_t d = variable_t::cell_var(crab::data_kind_t::svalues, lb, ub - lb + 1);
+            variable_t d = variable_t::cell_var(prevail::data_kind_t::svalues, lb, ub - lb + 1);
             res.push_back(d == signed_number(m[3]));
         } else if (regex_match(cst_text, m,
                                regex("s" ARRAY_RANGE DOT "uvalue"
                                      "=" IMM))) {
             number_t lb = signed_number(m[1]);
             number_t ub = signed_number(m[2]);
-            variable_t d = variable_t::cell_var(crab::data_kind_t::uvalues, lb, ub - lb + 1);
+            variable_t d = variable_t::cell_var(prevail::data_kind_t::uvalues, lb, ub - lb + 1);
             res.push_back(d == unsigned_number(m[3]));
         } else {
             throw std::runtime_error(std::string("Unknown constraint: ") + cst_text);

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -15,7 +15,7 @@
 #include "crab_utils/num_safety.hpp"
 #include "spec_type_descriptors.hpp"
 
-using crab::label_t;
+using prevail::label_t;
 
 // Assembly syntax.
 namespace asm_syntax {
@@ -332,7 +332,7 @@ struct ValidStore {
     constexpr bool operator==(const ValidStore&) const = default;
 };
 
-using crab::TypeGroup;
+using prevail::TypeGroup;
 struct TypeConstraint {
     Reg reg;
     TypeGroup types;
@@ -368,7 +368,7 @@ std::string to_string(Instruction const& ins);
 std::ostream& operator<<(std::ostream& os, Bin::Op op);
 std::ostream& operator<<(std::ostream& os, Condition::Op op);
 
-inline std::ostream& operator<<(std::ostream& os, const Imm imm) { return os << crab::to_signed(imm.v); }
+inline std::ostream& operator<<(std::ostream& os, const Imm imm) { return os << prevail::to_signed(imm.v); }
 inline std::ostream& operator<<(std::ostream& os, Reg const& a) { return os << "r" << gsl::narrow<int>(a.v); }
 inline std::ostream& operator<<(std::ostream& os, Value const& a) {
     if (const auto pa = std::get_if<Imm>(&a)) {
@@ -388,7 +388,7 @@ int size(const Instruction& inst);
 } // namespace asm_syntax
 
 using namespace asm_syntax;
-using crab::pc_t;
+using prevail::pc_t;
 
 template <class... Ts>
 struct overloaded : Ts... {

--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -234,9 +234,9 @@ struct Unmarshaller {
         throw InvalidInstruction(pc, "unsupported immediate");
     }
 
-    static uint64_t sign_extend(const int32_t imm) { return crab::to_unsigned(int64_t{imm}); }
+    static uint64_t sign_extend(const int32_t imm) { return prevail::to_unsigned(int64_t{imm}); }
 
-    static uint64_t zero_extend(const int32_t imm) { return uint64_t{crab::to_unsigned(imm)}; }
+    static uint64_t zero_extend(const int32_t imm) { return uint64_t{prevail::to_unsigned(imm)}; }
 
     static auto getBinValue(const pc_t pc, const ebpf_inst inst) -> Value {
         if (inst.opcode & INST_SRC_REG) {
@@ -417,8 +417,8 @@ struct Unmarshaller {
     }
 
     [[nodiscard]]
-    auto makeLddw(const ebpf_inst inst, const int32_t next_imm, const vector<ebpf_inst>& insts,
-                  const pc_t pc) const -> Instruction {
+    auto makeLddw(const ebpf_inst inst, const int32_t next_imm, const vector<ebpf_inst>& insts, const pc_t pc) const
+        -> Instruction {
         if (!info.platform->supports_group(bpf_conformance_groups_t::base64)) {
             throw InvalidInstruction{pc, inst.opcode};
         }

--- a/src/assertions.cpp
+++ b/src/assertions.cpp
@@ -9,7 +9,7 @@
 #include "crab/cfg.hpp"
 #include "platform.hpp"
 
-using crab::TypeGroup;
+using prevail::TypeGroup;
 using std::string;
 using std::to_string;
 using std::vector;

--- a/src/crab/add_bottom.hpp
+++ b/src/crab/add_bottom.hpp
@@ -6,7 +6,7 @@
 
 #include "crab/finite_domain.hpp"
 
-namespace crab::domains {
+namespace prevail {
 
 class AddBottom final {
     using T = FiniteDomain;
@@ -224,4 +224,4 @@ class AddBottom final {
     }
 }; // class AddBottom
 
-} // namespace crab::domains
+} // namespace prevail

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -18,7 +18,7 @@
 #include "crab_utils/num_safety.hpp"
 #include "spec_type_descriptors.hpp"
 
-namespace crab::domains {
+namespace prevail {
 
 using index_t = uint64_t;
 
@@ -874,4 +874,4 @@ array_domain_t array_domain_t::narrow(const array_domain_t& other) const {
 }
 
 std::ostream& operator<<(std::ostream& o, const array_domain_t& dom) { return o << dom.num_bytes; }
-} // namespace crab::domains
+} // namespace prevail

--- a/src/crab/array_domain.hpp
+++ b/src/crab/array_domain.hpp
@@ -29,7 +29,7 @@
 #include "crab/bitset_domain.hpp"
 #include "crab/variable.hpp"
 
-namespace crab::domains {
+namespace prevail {
 
 // Numerical abstract domain.
 using NumAbsDomain = AddBottom;
@@ -89,4 +89,4 @@ class array_domain_t final {
     void initialize_numbers(int lb, int width);
 };
 
-} // namespace crab::domains
+} // namespace prevail

--- a/src/crab/cfg.hpp
+++ b/src/crab/cfg.hpp
@@ -17,7 +17,7 @@
 #include "crab/label.hpp"
 #include "crab_utils/debug.hpp"
 struct cfg_builder_t;
-namespace crab {
+namespace prevail {
 
 /// Control-Flow Graph
 class cfg_t final {
@@ -183,4 +183,4 @@ class basic_block_t final {
 
 cfg_t cfg_from_adjacency_list(const std::map<label_t, std::vector<label_t>>& adj_list);
 
-} // end namespace crab
+} // end namespace prevail

--- a/src/crab/dsl_syntax.hpp
+++ b/src/crab/dsl_syntax.hpp
@@ -5,7 +5,7 @@
 #include "crab/cfg.hpp"
 #include "crab/linear_constraint.hpp"
 
-namespace crab::dsl_syntax {
+namespace prevail::dsl_syntax {
 
 inline linear_expression_t operator-(const linear_expression_t& e) { return e.negate(); }
 
@@ -34,12 +34,12 @@ inline linear_constraint_t operator>=(const linear_expression_t& e1, const linea
 inline linear_constraint_t operator>(const linear_expression_t& e1, const linear_expression_t& e2) { return e2 < e1; }
 
 inline linear_constraint_t eq(const variable_t a, const variable_t b) {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     return {a - b, constraint_kind_t::EQUALS_ZERO};
 }
 
 inline linear_constraint_t neq(const variable_t a, const variable_t b) {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     return {a - b, constraint_kind_t::NOT_ZERO};
 }
 
@@ -51,4 +51,4 @@ inline linear_constraint_t operator!=(const linear_expression_t& e1, const linea
     return linear_constraint_t(e1 - e2, constraint_kind_t::NOT_ZERO);
 }
 
-} // end namespace crab::dsl_syntax
+} // end namespace prevail::dsl_syntax

--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -17,8 +17,8 @@
 #include "program.hpp"
 #include "string_constraints.hpp"
 
-using crab::domains::NumAbsDomain;
-namespace crab {
+using prevail::NumAbsDomain;
+namespace prevail {
 
 static bool check_require(const NumAbsDomain& inv, const linear_constraint_t& cst) {
     if (inv.is_bottom()) {
@@ -86,7 +86,7 @@ class ebpf_checker final {
     ebpf_domain_t& dom;
     // shorthands:
     NumAbsDomain& m_inv;
-    domains::array_domain_t& stack;
+    array_domain_t& stack;
     TypeDomain& type_inv;
 };
 
@@ -119,25 +119,25 @@ std::vector<std::string> ebpf_domain_check(const ebpf_domain_t& dom, const Asser
 }
 
 static linear_constraint_t type_is_pointer(const reg_pack_t& r) {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     return r.type >= T_CTX;
 }
 
 static linear_constraint_t type_is_number(const reg_pack_t& r) {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     return r.type == T_NUM;
 }
 
 static linear_constraint_t type_is_number(const Reg& r) { return type_is_number(reg_pack(r)); }
 
 static linear_constraint_t type_is_not_stack(const reg_pack_t& r) {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     return r.type != T_STACK;
 }
 
 void ebpf_checker::check_access_stack(NumAbsDomain& inv, const linear_expression_t& lb,
                                       const linear_expression_t& ub) const {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     const variable_t r10_stack_offset = reg_pack(R10_STACK_POINTER).stack_offset;
     const auto interval = inv.eval_interval(r10_stack_offset);
     if (interval.is_singleton()) {
@@ -150,7 +150,7 @@ void ebpf_checker::check_access_stack(NumAbsDomain& inv, const linear_expression
 
 void ebpf_checker::check_access_context(NumAbsDomain& inv, const linear_expression_t& lb,
                                         const linear_expression_t& ub) const {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     require(inv, lb >= 0, "Lower bound must be at least 0");
     require(inv, ub <= thread_local_program_info->type.context_descriptor->size,
             std::string("Upper bound must be at most ") +
@@ -159,7 +159,7 @@ void ebpf_checker::check_access_context(NumAbsDomain& inv, const linear_expressi
 
 void ebpf_checker::check_access_packet(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub,
                                        const std::optional<variable_t> packet_size) const {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     require(inv, lb >= variable_t::meta_offset(), "Lower bound must be at least meta_offset");
     if (packet_size) {
         require(inv, ub <= *packet_size, "Upper bound must be at most packet_size");
@@ -171,13 +171,13 @@ void ebpf_checker::check_access_packet(NumAbsDomain& inv, const linear_expressio
 
 void ebpf_checker::check_access_shared(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub,
                                        const variable_t shared_region_size) const {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     require(inv, lb >= 0, "Lower bound must be at least 0");
     require(inv, ub <= shared_region_size, std::string("Upper bound must be at most ") + shared_region_size.name());
 }
 
 void ebpf_checker::operator()(const Comparable& s) const {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     if (type_inv.same_type(m_inv, s.r1, s.r2)) {
         // Same type. If both are numbers, that's okay. Otherwise:
         const auto inv = m_inv.when(reg_pack(s.r2).type != T_NUM);
@@ -204,7 +204,7 @@ void ebpf_checker::operator()(const Addable& s) const {
 }
 
 void ebpf_checker::operator()(const ValidDivisor& s) const {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     const auto reg = reg_pack(s.reg);
     if (!type_inv.implies_type(m_inv, type_is_pointer(reg), type_is_number(s.reg))) {
         require("Only numbers can be used as divisors");
@@ -230,7 +230,7 @@ void ebpf_checker::operator()(const TypeConstraint& s) const {
 void ebpf_checker::operator()(const BoundedLoopCount& s) const {
     // Enforces an upper bound on loop iterations by checking that the loop counter
     // does not exceed the specified limit
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     const auto counter = variable_t::loop_counter(to_string(s.name));
     require(m_inv, counter <= s.limit, "Loop counter is too large");
 }
@@ -262,7 +262,7 @@ void ebpf_checker::operator()(const FuncConstraint& s) const {
 }
 
 void ebpf_checker::operator()(const ValidSize& s) const {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     const auto r = reg_pack(s.reg);
     require(m_inv, s.can_be_zero ? r.svalue >= 0 : r.svalue > 0, "Invalid size");
 }
@@ -278,7 +278,7 @@ void ebpf_checker::operator()(const ValidCall& s) const {
 }
 
 void ebpf_checker::operator()(const ValidMapKeyValue& s) const {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
 
     const auto fd_type = dom.get_map_type(s.map_fd_reg);
 
@@ -352,7 +352,7 @@ void ebpf_checker::operator()(const ValidMapKeyValue& s) const {
 
 static std::tuple<linear_expression_t, linear_expression_t> lb_ub_access_pair(const ValidAccess& s,
                                                                               const variable_t offset_var) {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     linear_expression_t lb = offset_var + s.offset;
     linear_expression_t ub = std::holds_alternative<Imm>(s.width) ? lb + std::get<Imm>(s.width).v
                                                                   : lb + reg_pack(std::get<Reg>(s.width)).svalue;
@@ -360,7 +360,7 @@ static std::tuple<linear_expression_t, linear_expression_t> lb_ub_access_pair(co
 }
 
 void ebpf_checker::operator()(const ValidAccess& s) const {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
 
     const bool is_comparison_check = s.width == Value{Imm{0}};
 
@@ -435,9 +435,9 @@ void ebpf_checker::operator()(const ValidAccess& s) const {
 }
 
 void ebpf_checker::operator()(const ZeroCtxOffset& s) const {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     const auto reg = reg_pack(s.reg);
     require(m_inv, reg.ctx_offset == 0, "Nonzero context offset");
 }
 
-} // namespace crab
+} // namespace prevail

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -16,8 +16,8 @@
 #include "dsl_syntax.hpp"
 #include "string_constraints.hpp"
 
-using crab::domains::NumAbsDomain;
-namespace crab {
+using prevail::NumAbsDomain;
+namespace prevail {
 
 std::optional<variable_t> ebpf_domain_t::get_type_offset_variable(const Reg& reg, const int type) {
     reg_pack_t r = reg_pack(reg);
@@ -56,8 +56,7 @@ ebpf_domain_t ebpf_domain_t::bottom() {
 
 ebpf_domain_t::ebpf_domain_t() : m_inv(NumAbsDomain::top()) {}
 
-ebpf_domain_t::ebpf_domain_t(NumAbsDomain inv, domains::array_domain_t stack)
-    : m_inv(std::move(inv)), stack(std::move(stack)) {}
+ebpf_domain_t::ebpf_domain_t(NumAbsDomain inv, array_domain_t stack) : m_inv(std::move(inv)), stack(std::move(stack)) {}
 
 void ebpf_domain_t::set_to_top() {
     m_inv.set_to_top();
@@ -115,7 +114,7 @@ ebpf_domain_t ebpf_domain_t::operator&(const ebpf_domain_t& other) const {
 
 ebpf_domain_t ebpf_domain_t::calculate_constant_limits() {
     ebpf_domain_t inv;
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     for (const int i : {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}) {
         const auto r = reg_pack(i);
         inv.add_constraint(r.svalue <= std::numeric_limits<int32_t>::max());
@@ -293,7 +292,7 @@ std::ostream& operator<<(std::ostream& o, const ebpf_domain_t& dom) {
 }
 
 void ebpf_domain_t::initialize_packet() {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     ebpf_domain_t& inv = *this;
     inv.havoc(variable_t::packet_size());
     inv.havoc(variable_t::meta_offset());
@@ -328,7 +327,7 @@ ebpf_domain_t ebpf_domain_t::from_constraints(const std::set<std::string>& const
 }
 
 ebpf_domain_t ebpf_domain_t::setup_entry(const bool init_r1) {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
 
     ebpf_domain_t inv;
     const auto r10 = reg_pack(R10_STACK_POINTER);
@@ -353,4 +352,4 @@ ebpf_domain_t ebpf_domain_t::setup_entry(const bool init_r1) {
     return inv;
 }
 
-} // namespace crab
+} // namespace prevail

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -11,7 +11,7 @@
 #include "crab/variable.hpp"
 #include "string_constraints.hpp"
 
-namespace crab {
+namespace prevail {
 
 // Pointers in the BPF VM are defined to be 64 bits.  Some contexts, like
 // data, data_end, and meta in Linux's struct xdp_md are only 32 bit offsets
@@ -39,7 +39,7 @@ class ebpf_domain_t final {
 
   public:
     ebpf_domain_t();
-    ebpf_domain_t(NumAbsDomain inv, domains::array_domain_t stack);
+    ebpf_domain_t(NumAbsDomain inv, array_domain_t stack);
 
     // Generic abstract domain operations
     static ebpf_domain_t top();
@@ -104,9 +104,9 @@ class ebpf_domain_t final {
     /// Represents the stack as a memory region, i.e., an array of bytes,
     /// allowing mapping to variable in the m_inv numeric domains
     /// while dealing with overlapping byte ranges.
-    domains::array_domain_t stack;
+    array_domain_t stack;
 
     TypeDomain type_inv;
 };
 
-} // namespace crab
+} // namespace prevail

--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -19,14 +19,14 @@
 #include "platform.hpp"
 #include "string_constraints.hpp"
 
-using crab::domains::NumAbsDomain;
-namespace crab {
+using prevail::NumAbsDomain;
+namespace prevail {
 
 class ebpf_transformer final {
     ebpf_domain_t& dom;
     // shorthands:
     NumAbsDomain& m_inv;
-    domains::array_domain_t& stack;
+    array_domain_t& stack;
     TypeDomain& type_inv;
 
   public:
@@ -170,7 +170,7 @@ void ebpf_transformer::havoc_subprogram_stack(const std::string& prefix) {
 }
 
 void ebpf_transformer::forget_packet_pointers() {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
 
     for (const variable_t type_variable : variable_t::get_type_variables()) {
         if (type_inv.has_type(m_inv, type_variable, T_PACKET)) {
@@ -184,21 +184,21 @@ void ebpf_transformer::forget_packet_pointers() {
     dom.initialize_packet();
 }
 
-void ebpf_transformer::havoc_offsets(const Reg& reg) { crab::havoc_offsets(m_inv, reg); }
+void ebpf_transformer::havoc_offsets(const Reg& reg) { prevail::havoc_offsets(m_inv, reg); }
 static linear_constraint_t type_is_pointer(const reg_pack_t& r) {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     return r.type >= T_CTX;
 }
 
 static linear_constraint_t type_is_number(const reg_pack_t& r) {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     return r.type == T_NUM;
 }
 
 static linear_constraint_t type_is_number(const Reg& r) { return type_is_number(reg_pack(r)); }
 
 static linear_constraint_t type_is_not_stack(const reg_pack_t& r) {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     return r.type != T_STACK;
 }
 
@@ -206,7 +206,7 @@ static linear_constraint_t type_is_not_stack(const reg_pack_t& r) {
  */
 static linear_constraint_t assume_cst_offsets_reg(const Condition::Op op, const variable_t dst_offset,
                                                   const variable_t src_offset) {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     using Op = Condition::Op;
     switch (op) {
     case Op::EQ: return eq(dst_offset, src_offset);
@@ -398,7 +398,7 @@ void ebpf_transformer::operator()(const Packet& a) {
 void ebpf_transformer::do_load_stack(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr,
                                      const int width, const Reg& src_reg) {
     type_inv.assign_type(inv, target_reg, stack.load(inv, data_kind_t::types, addr, width));
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     if (inv.entail(width <= reg_pack(src_reg).stack_numeric_size)) {
         type_inv.assign_type(inv, target_reg, T_NUM);
     }
@@ -437,7 +437,7 @@ void ebpf_transformer::do_load_stack(NumAbsDomain& inv, const Reg& target_reg, c
 
 void ebpf_transformer::do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr_vague,
                                    const int width) {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     if (inv.is_bottom()) {
         return;
     }
@@ -521,7 +521,7 @@ void ebpf_transformer::do_load_packet_or_shared(NumAbsDomain& inv, const Reg& ta
 }
 
 void ebpf_transformer::do_load(const Mem& b, const Reg& target_reg) {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
 
     const auto mem_reg = reg_pack(b.access.basereg);
     const int width = b.access.width;
@@ -651,7 +651,7 @@ void ebpf_transformer::do_store_stack(NumAbsDomain& inv, const linear_expression
         const variable_t stack_numeric_size_variable =
             variable_t::kind_var(data_kind_t::stack_numeric_sizes, type_variable);
 
-        using namespace crab::dsl_syntax;
+        using namespace prevail::dsl_syntax;
         // See if the variable's numeric interval overlaps with changed bytes.
         if (m_inv.intersect(dsl_syntax::operator<=(addr, stack_offset_variable + stack_numeric_size_variable)) &&
             m_inv.intersect(operator>=(addr + width, stack_offset_variable))) {
@@ -773,7 +773,7 @@ void ebpf_transformer::operator()(const Atomic& a) {
 }
 
 void ebpf_transformer::operator()(const Call& call) {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     if (m_inv.is_bottom()) {
         return;
     }
@@ -871,7 +871,7 @@ out:
 }
 
 void ebpf_transformer::operator()(const CallLocal& call) {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     if (m_inv.is_bottom()) {
         return;
     }
@@ -883,7 +883,7 @@ void ebpf_transformer::operator()(const CallLocal& call) {
 }
 
 void ebpf_transformer::operator()(const Callx& callx) {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     if (m_inv.is_bottom()) {
         return;
     }
@@ -948,7 +948,7 @@ void ebpf_transformer::operator()(const LoadMapAddress& ins) {
 }
 
 void ebpf_transformer::assign_valid_ptr(const Reg& dst_reg, const bool maybe_null) {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     const reg_pack_t& reg = reg_pack(dst_reg);
     m_inv.havoc(reg.svalue);
     m_inv.havoc(reg.uvalue);
@@ -1063,7 +1063,7 @@ void ebpf_transformer::operator()(const Bin& bin) {
     if (m_inv.is_bottom()) {
         return;
     }
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
 
     auto dst = reg_pack(bin.dst);
     int finite_width = bin.is64 ? 64 : 32;
@@ -1199,7 +1199,7 @@ void ebpf_transformer::operator()(const Bin& bin) {
                                                    src.svalue);
                                         if (dst_type == T_STACK) {
                                             // Reduce the numeric size.
-                                            using namespace crab::dsl_syntax;
+                                            using namespace prevail::dsl_syntax;
                                             if (inv.intersect(src.svalue < 0)) {
                                                 inv.havoc(dst.stack_numeric_size);
                                                 recompute_stack_numeric_size(inv, dst.type);
@@ -1238,7 +1238,7 @@ void ebpf_transformer::operator()(const Bin& bin) {
                         inv->apply_signed(arith_binop_t::SUB, dst.svalue, dst.uvalue, dst.svalue, src.svalue,
                                           finite_width);
                         type_inv.assign_type(inv, bin.dst, T_NUM);
-                        crab::havoc_offsets(inv, bin.dst);
+                        prevail::havoc_offsets(inv, bin.dst);
                         break;
                     default:
                         // ptr -= ptr
@@ -1248,7 +1248,7 @@ void ebpf_transformer::operator()(const Bin& bin) {
                                               dom.get_type_offset_variable(src_reg, type).value(), finite_width);
                             inv.havoc(dst_offset.value());
                         }
-                        crab::havoc_offsets(inv, bin.dst);
+                        prevail::havoc_offsets(inv, bin.dst);
                         type_inv.assign_type(inv, bin.dst, T_NUM);
                         break;
                     }
@@ -1267,7 +1267,7 @@ void ebpf_transformer::operator()(const Bin& bin) {
                         m_inv->sub(dst_offset.value(), src.svalue);
                         if (type_inv.has_type(m_inv, dst.type, T_STACK)) {
                             // Reduce the numeric size.
-                            using namespace crab::dsl_syntax;
+                            using namespace prevail::dsl_syntax;
                             if (m_inv.intersect(src.svalue > 0)) {
                                 m_inv.havoc(dst.stack_numeric_size);
                                 recompute_stack_numeric_size(m_inv, dst.type);
@@ -1457,4 +1457,4 @@ void ebpf_domain_initialize_loop_counter(ebpf_domain_t& dom, const label_t& labe
     ebpf_transformer{dom}.initialize_loop_counter(label);
 }
 
-} // namespace crab
+} // namespace prevail

--- a/src/crab/finite_domain.cpp
+++ b/src/crab/finite_domain.cpp
@@ -12,14 +12,14 @@
 #include "crab/variable.hpp"
 #include "string_constraints.hpp"
 
-namespace crab::domains {
+namespace prevail {
 
 using NumAbsDomain = SplitDBM;
 
 std::vector<linear_constraint_t> FiniteDomain::assume_bit_cst_interval(Condition::Op op, bool is64,
                                                                        interval_t dst_interval,
                                                                        interval_t src_interval) const {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     using Op = Condition::Op;
 
     const auto dst_n = dst_interval.singleton();
@@ -51,7 +51,7 @@ std::vector<linear_constraint_t> FiniteDomain::assume_signed_64bit_eq(const vari
                                                                       const interval_t& right_interval,
                                                                       const linear_expression_t& right_svalue,
                                                                       const linear_expression_t& right_uvalue) const {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     if (right_interval <= interval_t::nonnegative(64) && !right_interval.is_singleton()) {
         return {(left_svalue == right_svalue), (left_uvalue == right_uvalue), eq(left_svalue, left_uvalue)};
     } else {
@@ -62,7 +62,7 @@ std::vector<linear_constraint_t> FiniteDomain::assume_signed_64bit_eq(const vari
 std::vector<linear_constraint_t> FiniteDomain::assume_signed_32bit_eq(const variable_t left_svalue,
                                                                       const variable_t left_uvalue,
                                                                       const interval_t& right_interval) const {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
 
     if (const auto rn = right_interval.singleton()) {
         const auto left_svalue_interval = eval_interval(left_svalue);
@@ -115,8 +115,8 @@ void FiniteDomain::get_signed_intervals(bool is64, const variable_t left_svalue,
                                         const linear_expression_t& right_svalue, interval_t& left_interval,
                                         interval_t& right_interval, interval_t& left_interval_positive,
                                         interval_t& left_interval_negative) const {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
+    using prevail::interval_t;
+    using namespace prevail::dsl_syntax;
 
     // Get intervals as 32-bit or 64-bit as appropriate.
     left_interval = eval_interval(left_svalue);
@@ -161,8 +161,8 @@ void FiniteDomain::get_unsigned_intervals(bool is64, const variable_t left_svalu
                                           const linear_expression_t& right_uvalue, interval_t& left_interval,
                                           interval_t& right_interval, interval_t& left_interval_low,
                                           interval_t& left_interval_high) const {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
+    using prevail::interval_t;
+    using namespace prevail::dsl_syntax;
 
     // Get intervals as 32-bit or 64-bit as appropriate.
     left_interval = eval_interval(left_uvalue);
@@ -204,8 +204,8 @@ FiniteDomain::assume_signed_64bit_lt(const bool strict, const variable_t left_sv
                                      const interval_t& left_interval_positive, const interval_t& left_interval_negative,
                                      const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
                                      const interval_t& right_interval) const {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
+    using prevail::interval_t;
+    using namespace prevail::dsl_syntax;
 
     if (right_interval <= interval_t::negative(64)) {
         // Interval can be represented as both an svalue and a uvalue since it fits in [INT_MIN, -1].
@@ -227,8 +227,8 @@ FiniteDomain::assume_signed_32bit_lt(const bool strict, const variable_t left_sv
                                      const interval_t& left_interval_positive, const interval_t& left_interval_negative,
                                      const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
                                      const interval_t& right_interval) const {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
+    using prevail::interval_t;
+    using namespace prevail::dsl_syntax;
 
     if (right_interval <= interval_t::negative(32)) {
         // Interval can be represented as both an svalue and a uvalue since it fits in [INT_MIN, -1],
@@ -262,8 +262,8 @@ FiniteDomain::assume_signed_64bit_gt(const bool strict, const variable_t left_sv
                                      const interval_t& left_interval_positive, const interval_t& left_interval_negative,
                                      const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
                                      const interval_t& right_interval) const {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
+    using prevail::interval_t;
+    using namespace prevail::dsl_syntax;
 
     if (right_interval <= interval_t::nonnegative(64)) {
         // Interval can be represented as both an svalue and a uvalue since it fits in [0, INT_MAX].
@@ -293,8 +293,8 @@ FiniteDomain::assume_signed_32bit_gt(const bool strict, const variable_t left_sv
                                      const interval_t& left_interval_positive, const interval_t& left_interval_negative,
                                      const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
                                      const interval_t& right_interval) const {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
+    using prevail::interval_t;
+    using namespace prevail::dsl_syntax;
 
     if (right_interval <= interval_t::nonnegative(32)) {
         // Interval can be represented as both an svalue and a uvalue since it fits in [0, INT_MAX].
@@ -327,8 +327,8 @@ std::vector<linear_constraint_t>
 FiniteDomain::assume_signed_cst_interval(Condition::Op op, bool is64, variable_t left_svalue, variable_t left_uvalue,
                                          const linear_expression_t& right_svalue,
                                          const linear_expression_t& right_uvalue) const {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
+    using prevail::interval_t;
+    using namespace prevail::dsl_syntax;
 
     interval_t left_interval = interval_t::bottom();
     interval_t right_interval = interval_t::bottom();
@@ -394,8 +394,8 @@ FiniteDomain::assume_unsigned_64bit_lt(bool strict, variable_t left_svalue, vari
                                        const interval_t& left_interval_low, const interval_t& left_interval_high,
                                        const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
                                        const interval_t& right_interval) const {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
+    using prevail::interval_t;
+    using namespace prevail::dsl_syntax;
 
     auto rub = right_interval.ub();
     auto lllb = left_interval_low.truncate_to<uint64_t>().lb();
@@ -443,8 +443,8 @@ std::vector<linear_constraint_t> FiniteDomain::assume_unsigned_32bit_lt(const bo
                                                                         const variable_t left_uvalue,
                                                                         const linear_expression_t& right_svalue,
                                                                         const linear_expression_t& right_uvalue) const {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
+    using prevail::interval_t;
+    using namespace prevail::dsl_syntax;
 
     if (eval_interval(left_uvalue) <= interval_t::nonnegative(32) &&
         eval_interval(right_uvalue) <= interval_t::nonnegative(32)) {
@@ -471,8 +471,8 @@ FiniteDomain::assume_unsigned_64bit_gt(const bool strict, const variable_t left_
                                        const interval_t& left_interval_low, const interval_t& left_interval_high,
                                        const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
                                        const interval_t& right_interval) const {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
+    using prevail::interval_t;
+    using namespace prevail::dsl_syntax;
 
     const auto rlb = right_interval.lb();
     const auto llub = left_interval_low.truncate_to<uint64_t>().ub();
@@ -504,8 +504,8 @@ FiniteDomain::assume_unsigned_32bit_gt(const bool strict, const variable_t left_
                                        const interval_t& left_interval_low, const interval_t& left_interval_high,
                                        const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
                                        const interval_t& right_interval) const {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
+    using prevail::interval_t;
+    using namespace prevail::dsl_syntax;
 
     if (right_interval <= interval_t::unsigned_high(32)) {
         // Interval can be represented as both an svalue and a uvalue since it fits in [INT_MAX+1, UINT_MAX].
@@ -525,8 +525,8 @@ std::vector<linear_constraint_t>
 FiniteDomain::assume_unsigned_cst_interval(Condition::Op op, bool is64, variable_t left_svalue, variable_t left_uvalue,
                                            const linear_expression_t& right_svalue,
                                            const linear_expression_t& right_uvalue) const {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
+    using prevail::interval_t;
+    using namespace prevail::dsl_syntax;
 
     interval_t left_interval = interval_t::bottom();
     interval_t right_interval = interval_t::bottom();
@@ -603,7 +603,7 @@ FiniteDomain::assume_unsigned_cst_interval(Condition::Op op, bool is64, variable
 std::vector<linear_constraint_t> FiniteDomain::assume_cst_imm(const Condition::Op op, const bool is64,
                                                               const variable_t dst_svalue, const variable_t dst_uvalue,
                                                               const int64_t imm) const {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     using Op = Condition::Op;
     switch (op) {
     case Op::EQ:
@@ -630,7 +630,7 @@ std::vector<linear_constraint_t> FiniteDomain::assume_cst_reg(const Condition::O
                                                               const variable_t dst_svalue, const variable_t dst_uvalue,
                                                               const variable_t src_svalue,
                                                               const variable_t src_uvalue) const {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     using Op = Condition::Op;
     if (is64) {
         switch (op) {
@@ -709,7 +709,7 @@ void FiniteDomain::apply(binop_t op, variable_t x, variable_t y, variable_t z, i
 }
 
 void FiniteDomain::overflow_bounds(variable_t lhs, int finite_width, bool issigned) {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     auto interval = eval_interval(lhs);
     if (interval.size() >= interval_t::unsigned_int(finite_width).size()) {
         // Interval covers the full space.
@@ -982,4 +982,4 @@ void FiniteDomain::sign_extend(const variable_t svalue, const variable_t uvalue,
     overflow_bounds(svalue, uvalue, target_width);
 }
 
-} // namespace crab::domains
+} // namespace prevail

--- a/src/crab/finite_domain.hpp
+++ b/src/crab/finite_domain.hpp
@@ -14,7 +14,7 @@
 #include "crab/variable.hpp"
 #include "string_constraints.hpp"
 
-namespace crab::domains {
+namespace prevail {
 class FiniteDomain {
     SplitDBM dom;
 
@@ -248,4 +248,4 @@ class FiniteDomain {
                                                     variable_t dst_uvalue, variable_t src_svalue,
                                                     variable_t src_uvalue) const;
 };
-} // namespace crab::domains
+} // namespace prevail

--- a/src/crab/fwd_analyzer.cpp
+++ b/src/crab/fwd_analyzer.cpp
@@ -10,7 +10,7 @@
 #include "crab/wto.hpp"
 #include "program.hpp"
 
-namespace crab {
+namespace prevail {
 
 class interleaved_fwd_fixpoint_iterator_t final {
     const Program& _prog;
@@ -196,4 +196,4 @@ void interleaved_fwd_fixpoint_iterator_t::operator()(const std::shared_ptr<wto_c
     }
 }
 
-} // namespace crab
+} // namespace prevail

--- a/src/crab/fwd_analyzer.hpp
+++ b/src/crab/fwd_analyzer.hpp
@@ -7,7 +7,7 @@
 #include "crab/ebpf_domain.hpp"
 #include "program.hpp"
 
-namespace crab {
+namespace prevail {
 
 struct invariant_map_pair {
     ebpf_domain_t pre;
@@ -17,4 +17,4 @@ using invariant_table_t = std::map<label_t, invariant_map_pair>;
 
 invariant_table_t run_forward_analyzer(const Program& prog, ebpf_domain_t entry_inv);
 
-} // namespace crab
+} // namespace prevail

--- a/src/crab/interval.cpp
+++ b/src/crab/interval.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "crab/interval.hpp"
 
-namespace crab {
+namespace prevail {
 
 static interval_t make_dividend_when_both_nonzero(const interval_t& dividend, const interval_t& divisor) {
     if (dividend.ub() >= 0) {
@@ -406,4 +406,4 @@ interval_t interval_t::zero_extend(const int width) const {
     // [0b1111..., 0b0000...] is in the original range, so the result is [0b0000..., 0b1111...] which is the full
     return full_range;
 }
-} // namespace crab
+} // namespace prevail

--- a/src/crab/interval.hpp
+++ b/src/crab/interval.hpp
@@ -15,7 +15,7 @@
 #include "crab_utils/num_extended.hpp"
 #include "crab_utils/stats.hpp"
 
-namespace crab {
+namespace prevail {
 
 using bound_t = extended_number;
 
@@ -370,6 +370,6 @@ inline interval_t operator-(const interval_t& x, const number_t& c) { return x -
 
 } // namespace interval_operators
 
-} // namespace crab
+} // namespace prevail
 
-std::string to_string(const crab::interval_t& interval) noexcept;
+std::string to_string(const prevail::interval_t& interval) noexcept;

--- a/src/crab/label.hpp
+++ b/src/crab/label.hpp
@@ -16,7 +16,7 @@
 
 constexpr char STACK_FRAME_DELIMITER = '/';
 
-namespace crab {
+namespace prevail {
 struct label_t {
     std::string stack_frame_prefix; ///< Variable prefix when calling this label.
     int from{};                     ///< Jump source, or simply index of instruction
@@ -91,4 +91,4 @@ inline std::function<int32_t(label_t)> label_to_offset32(const pc_t pc) {
     };
 }
 
-} // namespace crab
+} // namespace prevail

--- a/src/crab/linear_constraint.hpp
+++ b/src/crab/linear_constraint.hpp
@@ -8,7 +8,7 @@
 
 // A linear constraint is of the form:
 //    <linear expression> <operator> 0
-namespace crab {
+namespace prevail {
 
 enum class constraint_kind_t { EQUALS_ZERO, LESS_THAN_OR_EQUALS_ZERO, LESS_THAN_ZERO, NOT_ZERO };
 
@@ -102,4 +102,4 @@ inline std::ostream& operator<<(std::ostream& o, const linear_constraint_t& cons
     return o;
 }
 
-} // namespace crab
+} // namespace prevail

--- a/src/crab/linear_expression.hpp
+++ b/src/crab/linear_expression.hpp
@@ -7,7 +7,7 @@
 #include "crab/variable.hpp"
 #include "crab_utils/num_big.hpp"
 
-namespace crab {
+namespace prevail {
 // A linear expression is of the form: Ax + By + Cz + ... + N.
 // That is, a sum of terms where each term is either a
 // coefficient * variable, or simply a coefficient
@@ -164,4 +164,4 @@ inline std::ostream& operator<<(std::ostream& o, const linear_expression_t& expr
     return o;
 }
 
-} // namespace crab
+} // namespace prevail

--- a/src/crab/split_dbm.cpp
+++ b/src/crab/split_dbm.cpp
@@ -11,7 +11,7 @@
 #include "string_constraints.hpp"
 #include "type_encoding.hpp"
 
-namespace crab::domains {
+namespace prevail {
 
 static std::optional<SplitDBM::vert_id> try_at(const SplitDBM::vert_map_t& map, const variable_t v) {
     const auto it = map.find(v);
@@ -1266,7 +1266,7 @@ SplitDBM::Weight SplitDBM::pot_value(const variable_t v) const {
 }
 
 interval_t SplitDBM::eval_interval(const linear_expression_t& e) const {
-    using namespace crab::interval_operators;
+    using namespace prevail::interval_operators;
     interval_t r{e.constant_term()};
     for (const auto& [variable, coefficient] : e.variable_terms()) {
         r += coefficient * operator[](variable);
@@ -1362,9 +1362,9 @@ static interval_t get_interval(const SplitDBM::vert_map_t& m, const SplitDBM::gr
 }
 
 interval_t SplitDBM::get_interval(const variable_t x, const int finite_width) const {
-    return domains::get_interval(vert_map, g, x, finite_width);
+    return prevail::get_interval(vert_map, g, x, finite_width);
 }
 
-interval_t SplitDBM::operator[](const variable_t x) const { return domains::get_interval(vert_map, g, x, 0); }
+interval_t SplitDBM::operator[](const variable_t x) const { return prevail::get_interval(vert_map, g, x, 0); }
 
-} // namespace crab::domains
+} // namespace prevail

--- a/src/crab/split_dbm.hpp
+++ b/src/crab/split_dbm.hpp
@@ -37,13 +37,11 @@
 
 #include "string_constraints.hpp"
 
-namespace crab {
+namespace prevail {
 
 enum class arith_binop_t { ADD, SUB, MUL, SDIV, UDIV, SREM, UREM };
 enum class bitwise_binop_t { AND, OR, XOR, SHL, LSHR, ASHR };
 using binop_t = std::variant<arith_binop_t, bitwise_binop_t>;
-
-namespace domains {
 
 class SplitDBM final {
   public:
@@ -304,5 +302,4 @@ class SplitDBM final {
     static void clear_thread_local_state();
 }; // class SplitDBM
 
-} // namespace domains
-} // namespace crab
+} // namespace prevail

--- a/src/crab/thresholds.cpp
+++ b/src/crab/thresholds.cpp
@@ -4,7 +4,7 @@
 #include "crab/cfg.hpp"
 #include "crab/label.hpp"
 
-namespace crab {
+namespace prevail {
 
 inline namespace iterators {
 
@@ -95,4 +95,4 @@ std::ostream& operator<<(std::ostream& o, const wto_thresholds_t& t) {
 }
 } // namespace iterators
 
-} // namespace crab
+} // namespace prevail

--- a/src/crab/thresholds.hpp
+++ b/src/crab/thresholds.hpp
@@ -13,7 +13,7 @@
 #include "crab/wto.hpp"
 #include "crab_utils/debug.hpp"
 
-namespace crab {
+namespace prevail {
 
 inline namespace iterators {
 
@@ -72,4 +72,4 @@ class wto_thresholds_t final {
 }; // class wto_thresholds_t
 
 } // end namespace iterators
-} // end namespace crab
+} // end namespace prevail

--- a/src/crab/type_domain.cpp
+++ b/src/crab/type_domain.cpp
@@ -15,7 +15,7 @@
 #include "crab_utils/debug.hpp"
 #include "dsl_syntax.hpp"
 
-namespace crab {
+namespace prevail {
 
 template <is_enum T>
 static void operator++(T& t) {
@@ -274,7 +274,7 @@ NumAbsDomain TypeDomain::join_by_if_else(const NumAbsDomain& inv, const linear_c
 }
 
 static linear_constraint_t eq_types(const Reg& a, const Reg& b) {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     return eq(reg_pack(a).type, reg_pack(b).type);
 }
 
@@ -288,7 +288,7 @@ bool TypeDomain::implies_type(const NumAbsDomain& inv, const linear_constraint_t
 }
 
 bool TypeDomain::is_in_group(const NumAbsDomain& inv, const Reg& r, const TypeGroup group) const {
-    using namespace crab::dsl_syntax;
+    using namespace prevail::dsl_syntax;
     const variable_t t = reg_pack(r).type;
     switch (group) {
     case TypeGroup::number: return inv.entail(t == T_NUM);
@@ -335,7 +335,7 @@ bool is_singleton_type(const TypeGroup t) {
 }
 
 std::ostream& operator<<(std::ostream& os, const TypeGroup ts) {
-    using namespace crab;
+    using namespace prevail;
     static const std::map<TypeGroup, std::string> string_to_type{
         {TypeGroup::number, S_NUM},
         {TypeGroup::map_fd, S_MAP},
@@ -357,4 +357,4 @@ std::ostream& operator<<(std::ostream& os, const TypeGroup ts) {
     CRAB_ERROR("Unsupported type group", ts);
 }
 
-} // namespace crab
+} // namespace prevail

--- a/src/crab/type_domain.hpp
+++ b/src/crab/type_domain.hpp
@@ -14,9 +14,7 @@
 
 #include "asm_syntax.hpp" // for Reg
 
-namespace crab {
-
-using domains::NumAbsDomain;
+namespace prevail {
 
 struct reg_pack_t {
     variable_t svalue; // int64_t value.
@@ -72,4 +70,4 @@ struct TypeDomain {
     bool is_in_group(const NumAbsDomain& inv, const Reg& r, TypeGroup group) const;
 };
 
-} // namespace crab
+} // namespace prevail

--- a/src/crab/type_encoding.hpp
+++ b/src/crab/type_encoding.hpp
@@ -5,7 +5,7 @@
 
 #include <string>
 
-namespace crab {
+namespace prevail {
 
 // data_kind_t is eBPF-specific.
 enum class data_kind_t {
@@ -67,4 +67,4 @@ enum class TypeGroup {
 
 bool is_singleton_type(TypeGroup t);
 std::ostream& operator<<(std::ostream& os, TypeGroup ts);
-} // namespace crab
+} // namespace prevail

--- a/src/crab/var_factory.cpp
+++ b/src/crab/var_factory.cpp
@@ -8,7 +8,7 @@
 #include "crab/variable.hpp"
 #include "crab_utils/lazy_allocator.hpp"
 
-namespace crab {
+namespace prevail {
 
 variable_t variable_t::make(const std::string& name) {
     const auto it = std::find(names->begin(), names->end(), name);
@@ -201,4 +201,4 @@ std::vector<variable_t> variable_t::get_loop_counters() {
     }
     return res;
 }
-} // end namespace crab
+} // end namespace prevail

--- a/src/crab/variable.hpp
+++ b/src/crab/variable.hpp
@@ -11,11 +11,11 @@
 #include "crab_utils/lazy_allocator.hpp"
 #include "crab_utils/num_big.hpp"
 
-namespace crab {
+namespace prevail {
 
 std::vector<std::string> default_variable_names();
 
-// Wrapper for typed variables used by the crab abstract domains and linear_constraints.
+// Wrapper for typed variables used by the abstract domains and linear_constraints.
 // Being a class (instead of a type alias) enables overloading in dsl_syntax
 class variable_t final {
     uint64_t _id;
@@ -81,4 +81,4 @@ class variable_t final {
     static bool printing_order(const variable_t& a, const variable_t& b);
 }; // class variable_t
 
-} // namespace crab
+} // namespace prevail

--- a/src/crab/wto.cpp
+++ b/src/crab/wto.cpp
@@ -10,7 +10,7 @@
 // where _visit_stack is roughly equivalent to a stack trace in the recursive algorithm.
 // However, this scales much higher since it does not run out of stack memory.
 
-namespace crab {
+namespace prevail {
 
 bool is_component_member(const label_t& label, const cycle_or_label& component) {
     if (const auto plabel = std::get_if<label_t>(&component)) {
@@ -59,7 +59,7 @@ struct visit_args_t {
     std::weak_ptr<wto_cycle_t> containing_cycle;
 
     visit_args_t(const visit_task_type_t t, label_t v, wto_partition_t& p, std::weak_ptr<wto_cycle_t> cc)
-        : type(t), vertex(std::move(v)), partition(p), containing_cycle(std::move(cc)){};
+        : type(t), vertex(std::move(v)), partition(p), containing_cycle(std::move(cc)) {};
 };
 
 struct wto_vertex_data_t {
@@ -308,4 +308,4 @@ const wto_nesting_t& wto_t::nesting(const label_t& label) const {
     }
     return _nesting.at(label);
 }
-} // namespace crab
+} // namespace prevail

--- a/src/crab/wto.hpp
+++ b/src/crab/wto.hpp
@@ -23,15 +23,15 @@
 // single vertex such as 8, or a cycle such as (5 6).
 
 #include <memory>
+#include <optional>
 #include <stack>
 #include <utility>
 #include <vector>
-#include <optional>
 
 #include "crab/cfg.hpp"
 #include "crab/label.hpp"
 
-namespace crab {
+namespace prevail {
 
 // Bourdoncle, "Efficient chaotic iteration strategies with widenings", 1993
 // uses the notation w(c) to refer to the set of heads of the nested components
@@ -148,4 +148,4 @@ class wto_t final {
         }
     }
 };
-} // namespace crab
+} // namespace prevail

--- a/src/crab_utils/adapt_sgraph.hpp
+++ b/src/crab_utils/adapt_sgraph.hpp
@@ -8,7 +8,7 @@
 
 #include "crab_utils/num_safeint.hpp"
 
-namespace crab {
+namespace prevail {
 
 class TreeSMap final {
   public:
@@ -502,4 +502,4 @@ class AdaptGraph final {
     std::vector<vert_id> free_id{};
     std::vector<size_t> free_widx{};
 };
-} // namespace crab
+} // namespace prevail

--- a/src/crab_utils/debug.cpp
+++ b/src/crab_utils/debug.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "debug.hpp"
 
-namespace crab {
+namespace prevail {
 bool CrabLogFlag = false;
 std::set<std::string> CrabLog;
 
@@ -11,4 +11,4 @@ unsigned CrabVerbosity = 0;
 bool CrabWarningFlag = false;
 void CrabEnableWarningMsg(const bool b) { CrabWarningFlag = b; }
 
-} // namespace crab
+} // namespace prevail

--- a/src/crab_utils/debug.hpp
+++ b/src/crab_utils/debug.hpp
@@ -12,23 +12,23 @@
 #include <stdarg.h>
 #include <string>
 
-namespace crab {
+namespace prevail {
 
-#define CRAB_LOG(TAG, CODE)                                      \
-    do {                                                         \
-        if (crab::CrabLogFlag && crab::CrabLog.count(TAG) > 0) { \
-            CODE;                                                \
-        }                                                        \
+#define CRAB_LOG(TAG, CODE)                                            \
+    do {                                                               \
+        if (prevail::CrabLogFlag && prevail::CrabLog.count(TAG) > 0) { \
+            CODE;                                                      \
+        }                                                              \
     } while (0)
 extern bool CrabLogFlag;
 extern std::set<std::string> CrabLog;
 
 extern unsigned CrabVerbosity;
-#define CRAB_VERBOSE_IF(LEVEL, CODE)        \
-    do {                                    \
-        if (crab::CrabVerbosity >= LEVEL) { \
-            CODE;                           \
-        }                                   \
+#define CRAB_VERBOSE_IF(LEVEL, CODE)           \
+    do {                                       \
+        if (prevail::CrabVerbosity >= LEVEL) { \
+            CODE;                              \
+        }                                      \
     } while (0)
 
 template <typename... ArgTypes>
@@ -43,14 +43,14 @@ void ___print___(std::ostream& os, ArgTypes... args) {
     (void)expand_variadic_pack{0, ((os << args), void(), 0)...};
 }
 
-#define CRAB_ERROR(...)                                                      \
-    do {                                                                     \
-        std::ostringstream os;                                               \
-        os << "CRAB ERROR: ";                                                \
-        crab::___print___(os, __VA_ARGS__);                                  \
-        crab::___print___(os, "; function ", __func__, ", line ", __LINE__); \
-        os << "\n";                                                          \
-        throw std::runtime_error(os.str());                                  \
+#define CRAB_ERROR(...)                                                         \
+    do {                                                                        \
+        std::ostringstream os;                                                  \
+        os << "CRAB ERROR: ";                                                   \
+        prevail::___print___(os, __VA_ARGS__);                                  \
+        prevail::___print___(os, "; function ", __func__, ", line ", __LINE__); \
+        os << "\n";                                                             \
+        throw std::runtime_error(os.str());                                     \
     } while (0)
 
 extern bool CrabWarningFlag;
@@ -58,7 +58,7 @@ void CrabEnableWarningMsg(bool b);
 
 #define CRAB_WARN(...)                           \
     do {                                         \
-        if (crab::CrabWarningFlag) {             \
+        if (prevail::CrabWarningFlag) {          \
             std::cerr << "CRAB WARNING: ";       \
             ___print___(std::cerr, __VA_ARGS__); \
             std::cerr << "\n";                   \
@@ -67,4 +67,4 @@ void CrabEnableWarningMsg(bool b);
 
 constexpr bool CrabSanityCheckFlag = false;
 
-} // end namespace crab
+} // end namespace prevail

--- a/src/crab_utils/graph_ops.hpp
+++ b/src/crab_utils/graph_ops.hpp
@@ -13,7 +13,7 @@
 #include "crab_utils/lazy_allocator.hpp"
 #include "crab_utils/num_safety.hpp"
 
-namespace crab {
+namespace prevail {
 // Graph views - for when we want to traverse some mutation
 // of the graph without actually constructing it.
 // ============
@@ -1194,4 +1194,4 @@ class GraphOps {
     }
 };
 
-} // namespace crab
+} // namespace prevail

--- a/src/crab_utils/heap.hpp
+++ b/src/crab_utils/heap.hpp
@@ -23,7 +23,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ******************************************************************************************/
 #include <vector>
 
-namespace crab {
+namespace prevail {
 
 // A heap implementation with support for decrease/increase key.
 class Heap {
@@ -118,4 +118,4 @@ class Heap {
         return x;
     }
 };
-} // namespace crab
+} // namespace prevail

--- a/src/crab_utils/lazy_allocator.hpp
+++ b/src/crab_utils/lazy_allocator.hpp
@@ -4,7 +4,7 @@
 
 #include <optional>
 
-namespace crab {
+namespace prevail {
 
 /**
  * @brief Lazy allocator for objects of type T. The allocator does not allocate the object until it is first accessed.
@@ -75,4 +75,4 @@ class lazy_allocator {
         return get();
     }
 };
-} // namespace crab
+} // namespace prevail

--- a/src/crab_utils/num_big.hpp
+++ b/src/crab_utils/num_big.hpp
@@ -14,7 +14,7 @@
 
 using boost::multiprecision::cpp_int;
 
-namespace crab {
+namespace prevail {
 
 class number_t final {
     cpp_int _n{};
@@ -110,7 +110,7 @@ class number_t final {
     }
 
     // Allow truncating to signed int as needed for finite width operations.
-    // Unlike casting, sign_extend will not throw a crab error if the number doesn't fit.
+    // Unlike casting, sign_extend will not throw a prevail error if the number doesn't fit.
     [[nodiscard]]
     number_t sign_extend(const int width) const {
         using namespace boost::multiprecision;
@@ -132,7 +132,7 @@ class number_t final {
     }
 
     // Allow truncating to unsigned int as needed for finite width operations.
-    // Unlike casting, zero_extend will not throw a crab error if the number doesn't fit.
+    // Unlike casting, zero_extend will not throw a prevail error if the number doesn't fit.
     [[nodiscard]]
     number_t zero_extend(const int width) const {
         using namespace boost::multiprecision;
@@ -286,4 +286,4 @@ bool operator<=(is_enum auto left, const number_t& rhs) { return rhs >= left; }
 template <typename T>
 concept finite_integral = std::integral<T> || std::is_same_v<T, number_t>;
 
-} // namespace crab
+} // namespace prevail

--- a/src/crab_utils/num_extended.hpp
+++ b/src/crab_utils/num_extended.hpp
@@ -9,7 +9,7 @@
 #include "crab_utils/num_big.hpp"
 #include "crab_utils/stats.hpp"
 
-namespace crab {
+namespace prevail {
 
 class extended_number final {
     bool _is_infinite;
@@ -252,4 +252,4 @@ class extended_number final {
 
 }; // class extended_number
 
-} // namespace crab
+} // namespace prevail

--- a/src/crab_utils/num_safeint.hpp
+++ b/src/crab_utils/num_safeint.hpp
@@ -14,7 +14,7 @@
 
 #include "crab_utils/num_big.hpp"
 
-namespace crab {
+namespace prevail {
 
 class safe_i64 {
     // Current implementation is based on
@@ -136,4 +136,4 @@ class safe_i64 {
     int64_t m_num;
 };
 
-} // end namespace crab
+} // end namespace prevail

--- a/src/crab_utils/num_safety.hpp
+++ b/src/crab_utils/num_safety.hpp
@@ -6,7 +6,7 @@
 
 #include <gsl/narrow>
 
-namespace crab {
+namespace prevail {
 
 template <typename T>
 concept is_enum = std::is_enum_v<T>;
@@ -27,4 +27,4 @@ constexpr auto keep_signed(std::signed_integral auto x) -> decltype(x) { return 
 
 // a guard to ensure that the signedness of the result is the same as the input
 constexpr auto keep_unsigned(std::unsigned_integral auto x) -> decltype(x) { return x; }
-} // namespace crab
+} // namespace prevail

--- a/src/crab_utils/stats.cpp
+++ b/src/crab_utils/stats.cpp
@@ -11,10 +11,10 @@
 #include <sys/time.h>
 #endif
 
-namespace crab {
+namespace prevail {
 
-thread_local crab::lazy_allocator<std::map<std::string, unsigned>> CrabStats::counters;
-thread_local crab::lazy_allocator<std::map<std::string, Stopwatch>> CrabStats::sw;
+thread_local prevail::lazy_allocator<std::map<std::string, unsigned>> CrabStats::counters;
+thread_local prevail::lazy_allocator<std::map<std::string, Stopwatch>> CrabStats::sw;
 
 void CrabStats::clear_thread_local_state() {
     counters.clear();
@@ -135,4 +135,4 @@ ScopedCrabStats::ScopedCrabStats(const std::string& name, const bool reset) : m_
 
 ScopedCrabStats::~ScopedCrabStats() { CrabStats::stop(m_name); }
 
-} // namespace crab
+} // namespace prevail

--- a/src/crab_utils/stats.hpp
+++ b/src/crab_utils/stats.hpp
@@ -8,7 +8,7 @@
 #include "crab/variable.hpp"
 #include "crab_utils/lazy_allocator.hpp"
 
-namespace crab {
+namespace prevail {
 
 class Stopwatch {
     long started;
@@ -83,4 +83,4 @@ class ScopedCrabStats {
     explicit ScopedCrabStats(const std::string& name, bool reset = false);
     ~ScopedCrabStats();
 };
-} // namespace crab
+} // namespace prevail

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -17,10 +17,10 @@
 #include "crab_verifier.hpp"
 #include "string_constraints.hpp"
 
-using crab::ebpf_domain_t;
+using prevail::ebpf_domain_t;
 using std::string;
 
-thread_local crab::lazy_allocator<program_info> thread_local_program_info;
+thread_local prevail::lazy_allocator<program_info> thread_local_program_info;
 thread_local ebpf_verifier_options_t thread_local_options;
 void ebpf_verifier_clear_before_analysis();
 
@@ -32,10 +32,10 @@ bool Invariants::is_valid_after(const label_t& label, const string_invariant& st
 
 string_invariant Invariants::invariant_at(const label_t& label) const { return invariants.at(label).post.to_set(); }
 
-crab::interval_t Invariants::exit_value() const { return invariants.at(label_t::exit).post.get_r0(); }
+prevail::interval_t Invariants::exit_value() const { return invariants.at(label_t::exit).post.get_r0(); }
 
 int Invariants::max_loop_count() const {
-    crab::extended_number max_loop_count{0};
+    prevail::extended_number max_loop_count{0};
     // Gather the upper bound of loop counts from post-invariants.
     for (const auto& inv_pair : std::views::values(invariants)) {
         max_loop_count = std::max(max_loop_count, inv_pair.post.get_loop_count_upper_bound());
@@ -99,13 +99,13 @@ Report Invariants::check_assertions(const Program& prog) const {
 }
 
 void ebpf_verifier_clear_before_analysis() {
-    crab::domains::clear_thread_local_state();
-    crab::variable_t::clear_thread_local_state();
+    prevail::clear_thread_local_state();
+    prevail::variable_t::clear_thread_local_state();
 }
 
 void ebpf_verifier_clear_thread_local_state() {
-    crab::CrabStats::clear_thread_local_state();
+    prevail::CrabStats::clear_thread_local_state();
     thread_local_program_info.clear();
-    crab::domains::clear_thread_local_state();
-    crab::domains::SplitDBM::clear_thread_local_state();
+    prevail::clear_thread_local_state();
+    prevail::SplitDBM::clear_thread_local_state();
 }

--- a/src/crab_verifier.hpp
+++ b/src/crab_verifier.hpp
@@ -50,10 +50,10 @@ class Report final {
 };
 
 class Invariants final {
-    crab::invariant_table_t invariants;
+    prevail::invariant_table_t invariants;
 
   public:
-    explicit Invariants(crab::invariant_table_t&& invariants) : invariants(std::move(invariants)) {}
+    explicit Invariants(prevail::invariant_table_t&& invariants) : invariants(std::move(invariants)) {}
     Invariants(Invariants&& invariants) = default;
     Invariants(const Invariants& invariants) = default;
 
@@ -61,7 +61,7 @@ class Invariants final {
 
     string_invariant invariant_at(const label_t& label) const;
 
-    crab::interval_t exit_value() const;
+    prevail::interval_t exit_value() const;
 
     int max_loop_count() const;
     bool verified(const Program& prog) const;

--- a/src/linux/linux_platform.cpp
+++ b/src/linux/linux_platform.cpp
@@ -3,15 +3,11 @@
 #include <stdexcept>
 #if __linux__
 #include <linux/bpf.h>
-#define PTYPE(name, descr, native_type, prefixes) \
-    { name, descr, native_type, prefixes }
-#define PTYPE_PRIVILEGED(name, descr, native_type, prefixes) \
-    { name, descr, native_type, prefixes, true }
+#define PTYPE(name, descr, native_type, prefixes) {name, descr, native_type, prefixes}
+#define PTYPE_PRIVILEGED(name, descr, native_type, prefixes) {name, descr, native_type, prefixes, true}
 #else
-#define PTYPE(name, descr, native_type, prefixes) \
-    { name, descr, 0, prefixes }
-#define PTYPE_PRIVILEGED(name, descr, native_type, prefixes) \
-    { name, descr, 0, prefixes, true }
+#define PTYPE(name, descr, native_type, prefixes) {name, descr, 0, prefixes}
+#define PTYPE_PRIVILEGED(name, descr, native_type, prefixes) {name, descr, 0, prefixes, true}
 #endif
 #include "crab_verifier.hpp"
 #include "linux/gpl/spec_type_descriptors.hpp"
@@ -202,7 +198,7 @@ static int create_map_linux(const uint32_t map_type, const uint32_t key_size, co
     }
 
 #if __linux__
-    union bpf_attr attr {};
+    union bpf_attr attr{};
     memset(&attr, '\0', sizeof(attr));
     attr.map_type = map_type;
     attr.key_size = key_size;

--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -71,7 +71,7 @@ int main(int argc, char** argv) {
 
     ebpf_verifier_options_t ebpf_verifier_options;
 
-    crab::CrabEnableWarningMsg(false);
+    prevail::CrabEnableWarningMsg(false);
 
     // Parse command line arguments:
 

--- a/src/main/linux_verifier.cpp
+++ b/src/main/linux_verifier.cpp
@@ -24,7 +24,7 @@ std::tuple<bool, double> bpf_verify_program(const EbpfProgramType& type, const s
     buf[0] = 0;
     std::memset(buf.data(), '\0', buf.size());
 
-    union bpf_attr attr {};
+    union bpf_attr attr{};
     std::memset(&attr, '\0', sizeof(attr));
     attr.prog_type = gsl::narrow<__u32>(type.platform_specific_data);
     attr.insn_cnt = gsl::narrow<__u32>(raw_prog.size());

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -18,12 +18,12 @@ class Program {
 
     // This is a cache. The assertions can also be computed on the fly.
     std::map<label_t, std::vector<Assertion>> m_assertions{{label_t::entry, {}}, {label_t::exit, {}}};
-    crab::cfg_t m_cfg;
+    prevail::cfg_t m_cfg;
 
     // TODO: add program_info field
 
   public:
-    const crab::cfg_t& cfg() const { return m_cfg; }
+    const prevail::cfg_t& cfg() const { return m_cfg; }
 
     //! return a view of the labels, including entry and exit
     [[nodiscard]]

--- a/src/spec_type_descriptors.hpp
+++ b/src/spec_type_descriptors.hpp
@@ -76,4 +76,4 @@ void print_map_descriptors(const std::vector<EbpfMapDescriptor>& descriptors, st
 
 std::ostream& operator<<(std::ostream& os, const btf_line_info_t& line_info);
 
-extern thread_local crab::lazy_allocator<program_info> thread_local_program_info;
+extern thread_local prevail::lazy_allocator<program_info> thread_local_program_info;

--- a/src/string_constraints.hpp
+++ b/src/string_constraints.hpp
@@ -16,7 +16,7 @@ struct string_invariant {
 
     string_invariant() = default;
 
-    explicit string_invariant(std::set<std::string> inv) : maybe_inv(std::move(inv)){};
+    explicit string_invariant(std::set<std::string> inv) : maybe_inv(std::move(inv)) {};
 
     string_invariant(const string_invariant& inv) = default;
     string_invariant& operator=(const string_invariant& inv) = default;
@@ -54,5 +54,5 @@ struct string_invariant {
     friend std::ostream& operator<<(std::ostream&, const string_invariant& inv);
 };
 
-std::vector<crab::linear_constraint_t> parse_linear_constraints(const std::set<std::string>& constraints,
-                                                                std::vector<crab::interval_t>& numeric_ranges);
+std::vector<prevail::linear_constraint_t> parse_linear_constraints(const std::set<std::string>& constraints,
+                                                                   std::vector<prevail::interval_t>& numeric_ranges);

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -138,7 +138,7 @@ static RawTestCase parse_case(const YAML::Node& case_node) {
 }
 
 static InstructionSeq raw_cfg_to_instruction_seq(const vector<std::tuple<string, vector<string>>>& raw_blocks) {
-    std::map<string, crab::label_t> label_name_to_label;
+    std::map<string, prevail::label_t> label_name_to_label;
 
     int label_index = 0;
     for (const auto& [label_name, raw_block] : raw_blocks) {

--- a/src/test/ebpf_yaml.hpp
+++ b/src/test/ebpf_yaml.hpp
@@ -36,7 +36,7 @@ std::optional<Failure> run_yaml_test_case(TestCase test_case, bool debug = false
 
 struct ConformanceTestResult {
     bool success{};
-    crab::interval_t r0_value = crab::interval_t::top();
+    prevail::interval_t r0_value = prevail::interval_t::top();
 };
 
 ConformanceTestResult run_conformance_test_case(const std::vector<std::byte>& memory_bytes,

--- a/src/test/test_sign_extension.cpp
+++ b/src/test/test_sign_extension.cpp
@@ -7,7 +7,7 @@
 
 #include "crab/interval.hpp"
 
-using crab::interval_t;
+using prevail::interval_t;
 
 TEST_CASE("sign_extend 1 bit positive-positive", "[sign_extension]") {
     // no actual sign extension needed

--- a/src/test/test_wto.cpp
+++ b/src/test/test_wto.cpp
@@ -5,21 +5,21 @@
 #include "crab/cfg.hpp"
 #include "crab/wto.hpp"
 
-using crab::label_t;
-using crab::wto_t;
+using prevail::label_t;
+using prevail::wto_t;
 
 TEST_CASE("wto figure 1", "[wto]") {
     // Construct the example graph in figure 1 of Bourdoncle,
     // "Efficient chaotic iteration strategies with widenings", 1993.
-    const wto_t wto(crab::cfg_from_adjacency_list({{label_t::entry, {label_t{1}}},
-                                                   {label_t{1}, {label_t{2}}},
-                                                   {label_t{2}, {label_t{3}}},
-                                                   {label_t{3}, {label_t{4}}},
-                                                   {label_t{4}, {label_t{5}, label_t{7}}},
-                                                   {label_t{5}, {label_t{6}}},
-                                                   {label_t{6}, {label_t{5}, label_t{7}}},
-                                                   {label_t{7}, {label_t{3}, label_t{8}}},
-                                                   {label_t{8}, {label_t::exit}}}));
+    const wto_t wto(prevail::cfg_from_adjacency_list({{label_t::entry, {label_t{1}}},
+                                                      {label_t{1}, {label_t{2}}},
+                                                      {label_t{2}, {label_t{3}}},
+                                                      {label_t{3}, {label_t{4}}},
+                                                      {label_t{4}, {label_t{5}, label_t{7}}},
+                                                      {label_t{5}, {label_t{6}}},
+                                                      {label_t{6}, {label_t{5}, label_t{7}}},
+                                                      {label_t{7}, {label_t{3}, label_t{8}}},
+                                                      {label_t{8}, {label_t::exit}}}));
 
     std::ostringstream os;
     os << wto;
@@ -29,12 +29,12 @@ TEST_CASE("wto figure 1", "[wto]") {
 TEST_CASE("wto figure 2a", "[wto]") {
     // Construct the example graph in figure 2a of Bourdoncle,
     // "Efficient chaotic iteration strategies with widenings", 1993.
-    const wto_t wto(crab::cfg_from_adjacency_list({{label_t::entry, {label_t{1}}},
-                                                   {label_t{1}, {label_t{2}, label_t{4}}},
-                                                   {label_t{2}, {label_t{3}}},
-                                                   {label_t{3}, {label_t::exit}},
-                                                   {label_t{4}, {label_t{3}, label_t{5}}},
-                                                   {label_t{5}, {label_t{4}}}}));
+    const wto_t wto(prevail::cfg_from_adjacency_list({{label_t::entry, {label_t{1}}},
+                                                      {label_t{1}, {label_t{2}, label_t{4}}},
+                                                      {label_t{2}, {label_t{3}}},
+                                                      {label_t{3}, {label_t::exit}},
+                                                      {label_t{4}, {label_t{3}, label_t{5}}},
+                                                      {label_t{5}, {label_t{4}}}}));
 
     std::ostringstream os;
     os << wto;
@@ -44,11 +44,11 @@ TEST_CASE("wto figure 2a", "[wto]") {
 TEST_CASE("wto figure 2b", "[wto]") {
     // Construct the example graph in figure 2b of Bourdoncle,
     // "Efficient chaotic iteration strategies with widenings", 1993.
-    const wto_t wto(crab::cfg_from_adjacency_list({{label_t::entry, {label_t{1}}},
-                                                   {label_t{1}, {label_t{2}, label_t{4}}},
-                                                   {label_t{2}, {label_t{3}}},
-                                                   {label_t{3}, {label_t{1}, label_t::exit}},
-                                                   {label_t{4}, {label_t{3}}}}));
+    const wto_t wto(prevail::cfg_from_adjacency_list({{label_t::entry, {label_t{1}}},
+                                                      {label_t{1}, {label_t{2}, label_t{4}}},
+                                                      {label_t{2}, {label_t{3}}},
+                                                      {label_t{3}, {label_t{1}, label_t::exit}},
+                                                      {label_t{4}, {label_t{3}}}}));
 
     std::ostringstream os;
     os << wto;


### PR DESCRIPTION
Also remove inner namespace crab::domains.

This is part of #861 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized and unified internal naming and module organization across the codebase.
  - Consolidated interfaces in configuration, logging, parsing, and analysis components for improved consistency.

- **Chore**
  - Modified internal identifiers and formatting with no visible change to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->