### PR TITLE
Add cmake_policy(SET CMP0167 NEW)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: MIT
 # Set cmake version to 3.16 to use CMP0091 aka MSVC_RUNTIME_LIBRARY property.
 cmake_minimum_required(VERSION 3.16)
+if (POLICY CMP0167)
+    cmake_policy(SET CMP0167 NEW)
+endif ()
 
 project(ebpf_verifier)
 


### PR DESCRIPTION
See https://stackoverflow.com/questions/79146083/finding-boost-without-cmake-find-module-cmp0167
Without it, you get 
```
CMake Warning (dev) at CMakeLists.txt:44 (find_package):
  Policy CMP0167 is not set: The FindBoost module is removed.
  Run "cmake --help-policy CMP0167" for policy details.
  Use the cmake_policy command to set the policy and suppress this warning.
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated build configuration to improve compatibility with newer CMake policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->