### PR TITLE
Wrap namespace prevail everywhere

### DIFF
--- a/src/asm_cfg.cpp
+++ b/src/asm_cfg.cpp
@@ -19,6 +19,7 @@ using std::string;
 using std::to_string;
 using std::vector;
 
+namespace prevail {
 struct cfg_builder_t final {
     Program prog;
 
@@ -46,7 +47,7 @@ struct cfg_builder_t final {
         if (const auto it = prog.m_cfg.neighbours.find(_label); it != prog.m_cfg.neighbours.end()) {
             CRAB_ERROR("Label ", to_string(_label), " already exists");
         }
-        prog.m_cfg.neighbours.emplace(_label, prevail::cfg_t::adjacent_t{});
+        prog.m_cfg.neighbours.emplace(_label, cfg_t::adjacent_t{});
         prog.m_instructions.emplace(_label, ins);
     }
 
@@ -81,8 +82,6 @@ struct cfg_builder_t final {
         prog.m_assertions.insert_or_assign(label, assertions);
     }
 };
-
-using prevail::basic_block_t;
 
 /// Get the inverse of a given comparison operation.
 static Condition::Op reverse(const Condition::Op op) {
@@ -300,7 +299,7 @@ Program Program::from_sequence(const InstructionSeq& inst_seq, const program_inf
     // hierarchical decomposition of the CFG that identifies all strongly connected components (cycles) and their entry
     // points. These entry points serve as natural locations for loop counters that help verify program termination.
     if (options.cfg_opts.check_for_termination) {
-        const prevail::wto_t wto{builder.prog.cfg()};
+        const wto_t wto{builder.prog.cfg()};
         wto.for_each_loop_head([&](const label_t& label) -> void {
             builder.insert_after(label, label_t::make_increment_counter(label), IncrementLoopCounter{label});
         });
@@ -448,7 +447,7 @@ std::map<std::string, int> collect_stats(const Program& prog) {
     return res;
 }
 
-prevail::cfg_t prevail::cfg_from_adjacency_list(const std::map<label_t, std::vector<label_t>>& adj_list) {
+cfg_t cfg_from_adjacency_list(const std::map<label_t, std::vector<label_t>>& adj_list) {
     cfg_builder_t builder;
     for (const auto& label : std::views::keys(adj_list)) {
         if (label == label_t::entry || label == label_t::exit) {
@@ -463,3 +462,4 @@ prevail::cfg_t prevail::cfg_from_adjacency_list(const std::map<label_t, std::vec
     }
     return builder.prog.cfg();
 }
+} // namespace prevail

--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -16,6 +16,8 @@
 #include "crab_utils/num_safety.hpp"
 #include "platform.hpp"
 
+namespace prevail {
+
 template <typename T>
     requires std::is_trivially_copyable_v<T>
 static std::vector<T> vector_of(const char* data, const ELFIO::Elf_Xword size) {
@@ -646,3 +648,4 @@ std::vector<raw_program> read_elf(std::istream& input_stream, const std::string&
     program_reader.read_programs();
     return std::move(program_reader.raw_programs);
 }
+} // namespace prevail

--- a/src/asm_files.hpp
+++ b/src/asm_files.hpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 #include "platform.hpp"
-
+namespace prevail {
 class UnmarshalError final : public std::runtime_error {
   public:
     explicit UnmarshalError(const std::string& what) : std::runtime_error(what) {}
@@ -23,3 +23,4 @@ std::vector<raw_program> read_elf(std::istream& input_stream, const std::string&
 void write_binary_file(std::string path, const char* data, size_t size);
 
 std::ifstream open_asm_file(std::string path);
+} // namespace prevail

--- a/src/asm_marshal.cpp
+++ b/src/asm_marshal.cpp
@@ -10,6 +10,8 @@
 
 using std::vector;
 
+namespace prevail {
+
 static uint8_t op(const Condition::Op op) {
     using Op = Condition::Op;
     switch (op) {
@@ -296,10 +298,10 @@ struct MarshalVisitor {
 };
 
 vector<ebpf_inst> marshal(const Instruction& ins, const pc_t pc) {
-    return std::visit(MarshalVisitor{prevail::label_to_offset16(pc), prevail::label_to_offset32(pc)}, ins);
+    return std::visit(MarshalVisitor{label_to_offset16(pc), label_to_offset32(pc)}, ins);
 }
 
-int asm_syntax::size(const Instruction& inst) {
+int size(const Instruction& inst) {
     if (const auto pins = std::get_if<Bin>(&inst)) {
         if (pins->lddw) {
             return 2;
@@ -340,3 +342,4 @@ vector<ebpf_inst> marshal(const InstructionSeq& insts) {
     }
     return res;
 }
+} // namespace prevail

--- a/src/asm_marshal.hpp
+++ b/src/asm_marshal.hpp
@@ -7,5 +7,9 @@
 #include "asm_syntax.hpp"
 #include "ebpf_vm_isa.hpp"
 
+namespace prevail {
+
 std::vector<ebpf_inst> marshal(const Instruction& ins, pc_t pc);
 // TODO marshal to ostream?
+
+} // namespace prevail

--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -18,7 +18,6 @@
 #include "platform.hpp"
 #include "spec_type_descriptors.hpp"
 
-using prevail::TypeGroup;
 using std::optional;
 using std::string;
 using std::vector;
@@ -69,8 +68,6 @@ string to_string(label_t const& label) {
     return str.str();
 }
 
-} // namespace prevail
-
 struct LineInfoPrinter {
     std::ostream& os;
     std::string previous_source_line;
@@ -108,7 +105,7 @@ void print_jump(std::ostream& o, const std::string& direction, const std::set<la
 void print_program(const Program& prog, std::ostream& os, const bool simplify, const printfunc& prefunc,
                    const printfunc& postfunc) {
     LineInfoPrinter printer{os};
-    for (const prevail::basic_block_t& bb : prevail::basic_block_t::collect_basic_blocks(prog.cfg(), simplify)) {
+    for (const basic_block_t& bb : basic_block_t::collect_basic_blocks(prog.cfg(), simplify)) {
         prefunc(os, bb.first_label());
         print_jump(os, "from", prog.cfg().parents_of(bb.first_label()));
         os << bb.first_label() << ":\n";
@@ -195,7 +192,6 @@ void print_invariants(std::ostream& os, const Program& prog, const bool simplify
         });
 }
 
-namespace asm_syntax {
 std::ostream& operator<<(std::ostream& os, const ArgSingle::Kind kind) {
     switch (kind) {
     case ArgSingle::Kind::ANYTHING: return os << "uint64_t";
@@ -314,12 +310,10 @@ struct AssertionPrinterVisitor {
     }
 
     void operator()(const BoundedLoopCount& a) {
-        _os << prevail::variable_t::loop_counter(to_string(a.name)) << " < " << a.limit;
+        _os << variable_t::loop_counter(to_string(a.name)) << " < " << a.limit;
     }
 
-    static prevail::variable_t typereg(const Reg& r) {
-        return prevail::variable_t::reg(prevail::data_kind_t::types, r.v);
-    }
+    static variable_t typereg(const Reg& r) { return variable_t::reg(data_kind_t::types, r.v); }
 
     void operator()(ValidSize const& a) {
         const auto op = a.can_be_zero ? " >= " : " > ";
@@ -336,9 +330,7 @@ struct AssertionPrinterVisitor {
             << "))";
     }
 
-    void operator()(ZeroCtxOffset const& a) {
-        _os << prevail::variable_t::reg(prevail::data_kind_t::ctx_offsets, a.reg.v) << " == 0";
-    }
+    void operator()(ZeroCtxOffset const& a) { _os << variable_t::reg(data_kind_t::ctx_offsets, a.reg.v) << " == 0"; }
 
     void operator()(Comparable const& a) {
         if (a.or_r2_is_number) {
@@ -530,9 +522,7 @@ struct CommandPrinterVisitor {
         print(b.cond);
     }
 
-    void operator()(IncrementLoopCounter const& a) {
-        os_ << prevail::variable_t::loop_counter(to_string(a.name)) << "++";
-    }
+    void operator()(IncrementLoopCounter const& a) { os_ << variable_t::loop_counter(to_string(a.name)) << "++"; }
 };
 // ReSharper restore CppMemberFunctionMayBeConst
 
@@ -596,7 +586,7 @@ void print(const InstructionSeq& insts, std::ostream& out, const std::optional<c
             }
             if (const auto jmp = std::get_if<Jmp>(&ins)) {
                 if (!pc_of_label.contains(jmp->target)) {
-                    throw std::runtime_error(string("Cannot find label ") + prevail::to_string(jmp->target));
+                    throw std::runtime_error(string("Cannot find label ") + to_string(jmp->target));
                 }
                 const pc_t target_pc = pc_of_label.at(jmp->target);
                 visitor(*jmp, target_pc - static_cast<int>(pc) - 1);
@@ -608,8 +598,6 @@ void print(const InstructionSeq& insts, std::ostream& out, const std::optional<c
         pc += size(ins);
     }
 }
-
-} // namespace asm_syntax
 
 std::ostream& operator<<(std::ostream& o, const EbpfMapDescriptor& desc) {
     return o << "(" << "original_fd = " << desc.original_fd << ", " << "inner_map_fd = " << desc.inner_map_fd << ", "
@@ -630,3 +618,4 @@ std::ostream& operator<<(std::ostream& os, const btf_line_info_t& line_info) {
     os << "; " << line_info.source_line << "\n";
     return os;
 }
+} // namespace prevail

--- a/src/asm_parse.hpp
+++ b/src/asm_parse.hpp
@@ -6,4 +6,8 @@
 
 #include "asm_syntax.hpp"
 
+namespace prevail {
+
 Instruction parse_instruction(const std::string& line, const std::map<std::string, label_t>& label_name_to_label);
+
+}

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -15,10 +15,8 @@
 #include "crab_utils/num_safety.hpp"
 #include "spec_type_descriptors.hpp"
 
-using prevail::label_t;
-
 // Assembly syntax.
-namespace asm_syntax {
+namespace prevail {
 
 /// Immediate argument.
 struct Imm {
@@ -332,7 +330,6 @@ struct ValidStore {
     constexpr bool operator==(const ValidStore&) const = default;
 };
 
-using prevail::TypeGroup;
 struct TypeConstraint {
     Reg reg;
     TypeGroup types;
@@ -368,7 +365,7 @@ std::string to_string(Instruction const& ins);
 std::ostream& operator<<(std::ostream& os, Bin::Op op);
 std::ostream& operator<<(std::ostream& os, Condition::Op op);
 
-inline std::ostream& operator<<(std::ostream& os, const Imm imm) { return os << prevail::to_signed(imm.v); }
+inline std::ostream& operator<<(std::ostream& os, const Imm imm) { return os << to_signed(imm.v); }
 inline std::ostream& operator<<(std::ostream& os, Reg const& a) { return os << "r" << gsl::narrow<int>(a.v); }
 inline std::ostream& operator<<(std::ostream& os, Value const& a) {
     if (const auto pa = std::get_if<Imm>(&a)) {
@@ -385,12 +382,9 @@ void print(const InstructionSeq& insts, std::ostream& out, const std::optional<c
 
 int size(const Instruction& inst);
 
-} // namespace asm_syntax
-
-using namespace asm_syntax;
-using prevail::pc_t;
-
 template <class... Ts>
 struct overloaded : Ts... {
     using Ts::operator()...;
 };
+
+} // namespace prevail

--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -13,6 +13,7 @@
 using std::string;
 using std::vector;
 
+namespace prevail {
 int opcode_to_width(const uint8_t opcode) {
     switch (opcode & INST_SIZE_MASK) {
     case INST_SIZE_B: return 1;
@@ -234,9 +235,9 @@ struct Unmarshaller {
         throw InvalidInstruction(pc, "unsupported immediate");
     }
 
-    static uint64_t sign_extend(const int32_t imm) { return prevail::to_unsigned(int64_t{imm}); }
+    static uint64_t sign_extend(const int32_t imm) { return to_unsigned(int64_t{imm}); }
 
-    static uint64_t zero_extend(const int32_t imm) { return uint64_t{prevail::to_unsigned(imm)}; }
+    static uint64_t zero_extend(const int32_t imm) { return uint64_t{to_unsigned(imm)}; }
 
     static auto getBinValue(const pc_t pc, const ebpf_inst inst) -> Value {
         if (inst.opcode & INST_SRC_REG) {
@@ -819,3 +820,4 @@ Call make_call(const int imm, const ebpf_platform_t& platform) {
     const program_info info{.platform = &platform};
     return Unmarshaller{notes, info}.makeCall(imm);
 }
+} // namespace prevail

--- a/src/asm_unmarshal.hpp
+++ b/src/asm_unmarshal.hpp
@@ -10,6 +10,8 @@
 #include "platform.hpp"
 #include "spec_type_descriptors.hpp"
 
+namespace prevail {
+
 /** Translate a sequence of eBPF instructions (elf binary format) to a sequence
  *  of Instructions.
  *
@@ -20,4 +22,6 @@
 std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog,
                                                     std::vector<std::vector<std::string>>& notes);
 std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog);
+
 Call make_call(int func, const ebpf_platform_t& platform);
+} // namespace prevail

--- a/src/assertions.cpp
+++ b/src/assertions.cpp
@@ -9,11 +9,11 @@
 #include "cfg/cfg.hpp"
 #include "platform.hpp"
 
-using prevail::TypeGroup;
 using std::string;
 using std::to_string;
 using std::vector;
 
+namespace prevail {
 class AssertExtractor {
     program_info info;
     std::optional<label_t> current_label; ///< Pre-simplification label this assert is part of.
@@ -284,8 +284,8 @@ class AssertExtractor {
             }
             return {Assertion{TypeConstraint{ins.dst, TypeGroup::number}}};
         }
-        // For all other binary operations, the destination register must be a number and the source must either be an
-        // immediate or a number.
+            // For all other binary operations, the destination register must be a number and the source must either be
+            // an immediate or a number.
         default:
             if (const auto src = std::get_if<Reg>(&ins.v)) {
                 return {Assertion{TypeConstraint{ins.dst, TypeGroup::number}},
@@ -306,3 +306,4 @@ class AssertExtractor {
 vector<Assertion> get_assertions(Instruction ins, const program_info& info, const std::optional<label_t>& label) {
     return std::visit(AssertExtractor{info, label}, ins);
 }
+} // namespace prevail

--- a/src/cfg/cfg.hpp
+++ b/src/cfg/cfg.hpp
@@ -5,21 +5,19 @@
 /*
  * a CFG to interface with the fixpoint iterators.
  */
-#include <cassert>
 #include <map>
-#include <memory>
 #include <ranges>
 #include <set>
 #include <vector>
 
 #include "cfg/label.hpp"
 #include "crab_utils/debug.hpp"
-struct cfg_builder_t;
+
 namespace prevail {
 
 /// Control-Flow Graph
 class cfg_t final {
-    friend struct ::cfg_builder_t;
+    friend struct cfg_builder_t;
 
     // the choice to use set means that unmarshaling a conditional jump to the same target may be different
     using label_vec_t = std::set<label_t>;

--- a/src/cfg/label.hpp
+++ b/src/cfg/label.hpp
@@ -12,9 +12,10 @@
 
 #include "crab_utils/num_safety.hpp"
 
+namespace prevail {
+
 constexpr char STACK_FRAME_DELIMITER = '/';
 
-namespace prevail {
 struct label_t {
     std::string stack_frame_prefix; ///< Variable prefix when calling this label.
     int from{};                     ///< Jump source, or simply index of instruction

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+namespace prevail {
 struct prepare_cfg_options {
     /// When true, verifies that the program terminates.
     bool check_for_termination = false;
@@ -57,3 +58,4 @@ struct ebpf_verifier_stats_t {
 };
 
 extern thread_local ebpf_verifier_options_t thread_local_options;
+} // namespace prevail

--- a/src/crab/bitset_domain.cpp
+++ b/src/crab/bitset_domain.cpp
@@ -4,6 +4,7 @@
 
 #include "bitset_domain.hpp"
 
+namespace prevail {
 std::ostream& operator<<(std::ostream& o, const bitset_domain_t& b) {
     o << "Numbers -> {";
     bool first = true;
@@ -61,3 +62,4 @@ string_invariant bitset_domain_t::to_set() const {
     }
     return string_invariant{result};
 }
+} // namespace prevail

--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -7,6 +7,7 @@
 #include "ebpf_base.h" // for EBPF_TOTAL_STACK_SIZE constant
 #include "string_constraints.hpp"
 
+namespace prevail {
 class bitset_domain_t final {
   private:
     using bits_t = std::bitset<EBPF_TOTAL_STACK_SIZE>;
@@ -122,3 +123,4 @@ class bitset_domain_t final {
         return true;
     }
 };
+} // namespace prevail

--- a/src/crab/dsl_syntax.hpp
+++ b/src/crab/dsl_syntax.hpp
@@ -33,12 +33,12 @@ inline linear_constraint_t operator>=(const linear_expression_t& e1, const linea
 inline linear_constraint_t operator>(const linear_expression_t& e1, const linear_expression_t& e2) { return e2 < e1; }
 
 inline linear_constraint_t eq(const variable_t a, const variable_t b) {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
     return {a - b, constraint_kind_t::EQUALS_ZERO};
 }
 
 inline linear_constraint_t neq(const variable_t a, const variable_t b) {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
     return {a - b, constraint_kind_t::NOT_ZERO};
 }
 

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -16,7 +16,6 @@
 #include "crab/ebpf_domain.hpp"
 #include "string_constraints.hpp"
 
-using prevail::NumAbsDomain;
 namespace prevail {
 
 std::optional<variable_t> ebpf_domain_t::get_type_offset_variable(const Reg& reg, const int type) {
@@ -114,7 +113,7 @@ ebpf_domain_t ebpf_domain_t::operator&(const ebpf_domain_t& other) const {
 
 ebpf_domain_t ebpf_domain_t::calculate_constant_limits() {
     ebpf_domain_t inv;
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
     for (const int i : {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}) {
         const auto r = reg_pack(i);
         inv.add_constraint(r.svalue <= std::numeric_limits<int32_t>::max());
@@ -292,7 +291,7 @@ std::ostream& operator<<(std::ostream& o, const ebpf_domain_t& dom) {
 }
 
 void ebpf_domain_t::initialize_packet() {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
     ebpf_domain_t& inv = *this;
     inv.havoc(variable_t::packet_size());
     inv.havoc(variable_t::meta_offset());
@@ -327,7 +326,7 @@ ebpf_domain_t ebpf_domain_t::from_constraints(const std::set<std::string>& const
 }
 
 ebpf_domain_t ebpf_domain_t::setup_entry(const bool init_r1) {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
 
     ebpf_domain_t inv;
     const auto r10 = reg_pack(R10_STACK_POINTER);

--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -19,7 +19,6 @@
 #include "platform.hpp"
 #include "string_constraints.hpp"
 
-using prevail::NumAbsDomain;
 namespace prevail {
 
 class ebpf_transformer final {
@@ -170,7 +169,7 @@ void ebpf_transformer::havoc_subprogram_stack(const std::string& prefix) {
 }
 
 void ebpf_transformer::forget_packet_pointers() {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
 
     for (const variable_t type_variable : variable_t::get_type_variables()) {
         if (type_inv.has_type(m_inv, type_variable, T_PACKET)) {
@@ -185,20 +184,21 @@ void ebpf_transformer::forget_packet_pointers() {
 }
 
 void ebpf_transformer::havoc_offsets(const Reg& reg) { prevail::havoc_offsets(m_inv, reg); }
+
 static linear_constraint_t type_is_pointer(const reg_pack_t& r) {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
     return r.type >= T_CTX;
 }
 
 static linear_constraint_t type_is_number(const reg_pack_t& r) {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
     return r.type == T_NUM;
 }
 
 static linear_constraint_t type_is_number(const Reg& r) { return type_is_number(reg_pack(r)); }
 
 static linear_constraint_t type_is_not_stack(const reg_pack_t& r) {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
     return r.type != T_STACK;
 }
 
@@ -206,7 +206,7 @@ static linear_constraint_t type_is_not_stack(const reg_pack_t& r) {
  */
 static linear_constraint_t assume_cst_offsets_reg(const Condition::Op op, const variable_t dst_offset,
                                                   const variable_t src_offset) {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
     using Op = Condition::Op;
     switch (op) {
     case Op::EQ: return eq(dst_offset, src_offset);
@@ -398,7 +398,7 @@ void ebpf_transformer::operator()(const Packet& a) {
 void ebpf_transformer::do_load_stack(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr,
                                      const int width, const Reg& src_reg) {
     type_inv.assign_type(inv, target_reg, stack.load(inv, data_kind_t::types, addr, width));
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
     if (inv.entail(width <= reg_pack(src_reg).stack_numeric_size)) {
         type_inv.assign_type(inv, target_reg, T_NUM);
     }
@@ -437,7 +437,7 @@ void ebpf_transformer::do_load_stack(NumAbsDomain& inv, const Reg& target_reg, c
 
 void ebpf_transformer::do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr_vague,
                                    const int width) {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
     if (inv.is_bottom()) {
         return;
     }
@@ -521,7 +521,7 @@ void ebpf_transformer::do_load_packet_or_shared(NumAbsDomain& inv, const Reg& ta
 }
 
 void ebpf_transformer::do_load(const Mem& b, const Reg& target_reg) {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
 
     const auto mem_reg = reg_pack(b.access.basereg);
     const int width = b.access.width;
@@ -651,7 +651,7 @@ void ebpf_transformer::do_store_stack(NumAbsDomain& inv, const linear_expression
         const variable_t stack_numeric_size_variable =
             variable_t::kind_var(data_kind_t::stack_numeric_sizes, type_variable);
 
-        using namespace prevail::dsl_syntax;
+        using namespace dsl_syntax;
         // See if the variable's numeric interval overlaps with changed bytes.
         if (m_inv.intersect(dsl_syntax::operator<=(addr, stack_offset_variable + stack_numeric_size_variable)) &&
             m_inv.intersect(operator>=(addr + width, stack_offset_variable))) {
@@ -773,7 +773,7 @@ void ebpf_transformer::operator()(const Atomic& a) {
 }
 
 void ebpf_transformer::operator()(const Call& call) {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
     if (m_inv.is_bottom()) {
         return;
     }
@@ -871,7 +871,7 @@ out:
 }
 
 void ebpf_transformer::operator()(const CallLocal& call) {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
     if (m_inv.is_bottom()) {
         return;
     }
@@ -883,7 +883,7 @@ void ebpf_transformer::operator()(const CallLocal& call) {
 }
 
 void ebpf_transformer::operator()(const Callx& callx) {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
     if (m_inv.is_bottom()) {
         return;
     }
@@ -948,7 +948,7 @@ void ebpf_transformer::operator()(const LoadMapAddress& ins) {
 }
 
 void ebpf_transformer::assign_valid_ptr(const Reg& dst_reg, const bool maybe_null) {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
     const reg_pack_t& reg = reg_pack(dst_reg);
     m_inv.havoc(reg.svalue);
     m_inv.havoc(reg.uvalue);
@@ -1063,7 +1063,7 @@ void ebpf_transformer::operator()(const Bin& bin) {
     if (m_inv.is_bottom()) {
         return;
     }
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
 
     auto dst = reg_pack(bin.dst);
     int finite_width = bin.is64 ? 64 : 32;
@@ -1199,7 +1199,7 @@ void ebpf_transformer::operator()(const Bin& bin) {
                                                    src.svalue);
                                         if (dst_type == T_STACK) {
                                             // Reduce the numeric size.
-                                            using namespace prevail::dsl_syntax;
+                                            using namespace dsl_syntax;
                                             if (inv.intersect(src.svalue < 0)) {
                                                 inv.havoc(dst.stack_numeric_size);
                                                 recompute_stack_numeric_size(inv, dst.type);
@@ -1267,7 +1267,7 @@ void ebpf_transformer::operator()(const Bin& bin) {
                         m_inv->sub(dst_offset.value(), src.svalue);
                         if (type_inv.has_type(m_inv, dst.type, T_STACK)) {
                             // Reduce the numeric size.
-                            using namespace prevail::dsl_syntax;
+                            using namespace dsl_syntax;
                             if (m_inv.intersect(src.svalue > 0)) {
                                 m_inv.havoc(dst.stack_numeric_size);
                                 recompute_stack_numeric_size(m_inv, dst.type);

--- a/src/crab/finite_domain.cpp
+++ b/src/crab/finite_domain.cpp
@@ -19,7 +19,7 @@ using NumAbsDomain = SplitDBM;
 std::vector<linear_constraint_t> FiniteDomain::assume_bit_cst_interval(Condition::Op op, bool is64,
                                                                        interval_t dst_interval,
                                                                        interval_t src_interval) const {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
     using Op = Condition::Op;
 
     const auto dst_n = dst_interval.singleton();
@@ -51,7 +51,7 @@ std::vector<linear_constraint_t> FiniteDomain::assume_signed_64bit_eq(const vari
                                                                       const interval_t& right_interval,
                                                                       const linear_expression_t& right_svalue,
                                                                       const linear_expression_t& right_uvalue) const {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
     if (right_interval <= interval_t::nonnegative(64) && !right_interval.is_singleton()) {
         return {(left_svalue == right_svalue), (left_uvalue == right_uvalue), eq(left_svalue, left_uvalue)};
     } else {
@@ -62,7 +62,7 @@ std::vector<linear_constraint_t> FiniteDomain::assume_signed_64bit_eq(const vari
 std::vector<linear_constraint_t> FiniteDomain::assume_signed_32bit_eq(const variable_t left_svalue,
                                                                       const variable_t left_uvalue,
                                                                       const interval_t& right_interval) const {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
 
     if (const auto rn = right_interval.singleton()) {
         const auto left_svalue_interval = eval_interval(left_svalue);
@@ -115,8 +115,8 @@ void FiniteDomain::get_signed_intervals(bool is64, const variable_t left_svalue,
                                         const linear_expression_t& right_svalue, interval_t& left_interval,
                                         interval_t& right_interval, interval_t& left_interval_positive,
                                         interval_t& left_interval_negative) const {
-    using prevail::interval_t;
-    using namespace prevail::dsl_syntax;
+
+    using namespace dsl_syntax;
 
     // Get intervals as 32-bit or 64-bit as appropriate.
     left_interval = eval_interval(left_svalue);
@@ -161,8 +161,8 @@ void FiniteDomain::get_unsigned_intervals(bool is64, const variable_t left_svalu
                                           const linear_expression_t& right_uvalue, interval_t& left_interval,
                                           interval_t& right_interval, interval_t& left_interval_low,
                                           interval_t& left_interval_high) const {
-    using prevail::interval_t;
-    using namespace prevail::dsl_syntax;
+
+    using namespace dsl_syntax;
 
     // Get intervals as 32-bit or 64-bit as appropriate.
     left_interval = eval_interval(left_uvalue);
@@ -204,8 +204,8 @@ FiniteDomain::assume_signed_64bit_lt(const bool strict, const variable_t left_sv
                                      const interval_t& left_interval_positive, const interval_t& left_interval_negative,
                                      const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
                                      const interval_t& right_interval) const {
-    using prevail::interval_t;
-    using namespace prevail::dsl_syntax;
+
+    using namespace dsl_syntax;
 
     if (right_interval <= interval_t::negative(64)) {
         // Interval can be represented as both an svalue and a uvalue since it fits in [INT_MIN, -1].
@@ -227,8 +227,8 @@ FiniteDomain::assume_signed_32bit_lt(const bool strict, const variable_t left_sv
                                      const interval_t& left_interval_positive, const interval_t& left_interval_negative,
                                      const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
                                      const interval_t& right_interval) const {
-    using prevail::interval_t;
-    using namespace prevail::dsl_syntax;
+
+    using namespace dsl_syntax;
 
     if (right_interval <= interval_t::negative(32)) {
         // Interval can be represented as both an svalue and a uvalue since it fits in [INT_MIN, -1],
@@ -262,8 +262,8 @@ FiniteDomain::assume_signed_64bit_gt(const bool strict, const variable_t left_sv
                                      const interval_t& left_interval_positive, const interval_t& left_interval_negative,
                                      const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
                                      const interval_t& right_interval) const {
-    using prevail::interval_t;
-    using namespace prevail::dsl_syntax;
+
+    using namespace dsl_syntax;
 
     if (right_interval <= interval_t::nonnegative(64)) {
         // Interval can be represented as both an svalue and a uvalue since it fits in [0, INT_MAX].
@@ -293,8 +293,8 @@ FiniteDomain::assume_signed_32bit_gt(const bool strict, const variable_t left_sv
                                      const interval_t& left_interval_positive, const interval_t& left_interval_negative,
                                      const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
                                      const interval_t& right_interval) const {
-    using prevail::interval_t;
-    using namespace prevail::dsl_syntax;
+
+    using namespace dsl_syntax;
 
     if (right_interval <= interval_t::nonnegative(32)) {
         // Interval can be represented as both an svalue and a uvalue since it fits in [0, INT_MAX].
@@ -327,8 +327,8 @@ std::vector<linear_constraint_t>
 FiniteDomain::assume_signed_cst_interval(Condition::Op op, bool is64, variable_t left_svalue, variable_t left_uvalue,
                                          const linear_expression_t& right_svalue,
                                          const linear_expression_t& right_uvalue) const {
-    using prevail::interval_t;
-    using namespace prevail::dsl_syntax;
+
+    using namespace dsl_syntax;
 
     interval_t left_interval = interval_t::bottom();
     interval_t right_interval = interval_t::bottom();
@@ -394,8 +394,8 @@ FiniteDomain::assume_unsigned_64bit_lt(bool strict, variable_t left_svalue, vari
                                        const interval_t& left_interval_low, const interval_t& left_interval_high,
                                        const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
                                        const interval_t& right_interval) const {
-    using prevail::interval_t;
-    using namespace prevail::dsl_syntax;
+
+    using namespace dsl_syntax;
 
     auto rub = right_interval.ub();
     auto lllb = left_interval_low.truncate_to<uint64_t>().lb();
@@ -443,8 +443,8 @@ std::vector<linear_constraint_t> FiniteDomain::assume_unsigned_32bit_lt(const bo
                                                                         const variable_t left_uvalue,
                                                                         const linear_expression_t& right_svalue,
                                                                         const linear_expression_t& right_uvalue) const {
-    using prevail::interval_t;
-    using namespace prevail::dsl_syntax;
+
+    using namespace dsl_syntax;
 
     if (eval_interval(left_uvalue) <= interval_t::nonnegative(32) &&
         eval_interval(right_uvalue) <= interval_t::nonnegative(32)) {
@@ -471,8 +471,8 @@ FiniteDomain::assume_unsigned_64bit_gt(const bool strict, const variable_t left_
                                        const interval_t& left_interval_low, const interval_t& left_interval_high,
                                        const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
                                        const interval_t& right_interval) const {
-    using prevail::interval_t;
-    using namespace prevail::dsl_syntax;
+
+    using namespace dsl_syntax;
 
     const auto rlb = right_interval.lb();
     const auto llub = left_interval_low.truncate_to<uint64_t>().ub();
@@ -504,8 +504,8 @@ FiniteDomain::assume_unsigned_32bit_gt(const bool strict, const variable_t left_
                                        const interval_t& left_interval_low, const interval_t& left_interval_high,
                                        const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
                                        const interval_t& right_interval) const {
-    using prevail::interval_t;
-    using namespace prevail::dsl_syntax;
+
+    using namespace dsl_syntax;
 
     if (right_interval <= interval_t::unsigned_high(32)) {
         // Interval can be represented as both an svalue and a uvalue since it fits in [INT_MAX+1, UINT_MAX].
@@ -525,8 +525,8 @@ std::vector<linear_constraint_t>
 FiniteDomain::assume_unsigned_cst_interval(Condition::Op op, bool is64, variable_t left_svalue, variable_t left_uvalue,
                                            const linear_expression_t& right_svalue,
                                            const linear_expression_t& right_uvalue) const {
-    using prevail::interval_t;
-    using namespace prevail::dsl_syntax;
+
+    using namespace dsl_syntax;
 
     interval_t left_interval = interval_t::bottom();
     interval_t right_interval = interval_t::bottom();
@@ -603,7 +603,7 @@ FiniteDomain::assume_unsigned_cst_interval(Condition::Op op, bool is64, variable
 std::vector<linear_constraint_t> FiniteDomain::assume_cst_imm(const Condition::Op op, const bool is64,
                                                               const variable_t dst_svalue, const variable_t dst_uvalue,
                                                               const int64_t imm) const {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
     using Op = Condition::Op;
     switch (op) {
     case Op::EQ:
@@ -630,7 +630,7 @@ std::vector<linear_constraint_t> FiniteDomain::assume_cst_reg(const Condition::O
                                                               const variable_t dst_svalue, const variable_t dst_uvalue,
                                                               const variable_t src_svalue,
                                                               const variable_t src_uvalue) const {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
     using Op = Condition::Op;
     if (is64) {
         switch (op) {
@@ -709,7 +709,7 @@ void FiniteDomain::apply(binop_t op, variable_t x, variable_t y, variable_t z, i
 }
 
 void FiniteDomain::overflow_bounds(variable_t lhs, int finite_width, bool issigned) {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
     auto interval = eval_interval(lhs);
     if (interval.size() >= interval_t::unsigned_int(finite_width).size()) {
         // Interval covers the full space.

--- a/src/crab/finite_domain.hpp
+++ b/src/crab/finite_domain.hpp
@@ -15,6 +15,7 @@
 #include "string_constraints.hpp"
 
 namespace prevail {
+
 class FiniteDomain {
     SplitDBM dom;
 

--- a/src/crab/interval.hpp
+++ b/src/crab/interval.hpp
@@ -370,6 +370,6 @@ inline interval_t operator-(const interval_t& x, const number_t& c) { return x -
 
 } // namespace interval_operators
 
-} // namespace prevail
+std::string to_string(const interval_t& interval) noexcept;
 
-std::string to_string(const prevail::interval_t& interval) noexcept;
+} // namespace prevail

--- a/src/crab/linear_expression.hpp
+++ b/src/crab/linear_expression.hpp
@@ -8,6 +8,7 @@
 #include "crab_utils/num_big.hpp"
 
 namespace prevail {
+
 // A linear expression is of the form: Ax + By + Cz + ... + N.
 // That is, a sum of terms where each term is either a
 // coefficient * variable, or simply a coefficient

--- a/src/crab/split_dbm.hpp
+++ b/src/crab/split_dbm.hpp
@@ -35,7 +35,6 @@
 #include "crab_utils/num_big.hpp"
 #include "crab_utils/num_safeint.hpp"
 #include "crab_utils/stats.hpp"
-
 #include "string_constraints.hpp"
 
 namespace prevail {
@@ -208,7 +207,7 @@ class SplitDBM final {
     SplitDBM widen(const SplitDBM& o) const;
 
     [[nodiscard]]
-    SplitDBM widening_thresholds(const SplitDBM& o, const iterators::thresholds_t&) const {
+    SplitDBM widening_thresholds(const SplitDBM& o, const thresholds_t&) const {
         // TODO: use thresholds. Threshold is anonymous until used to prevent unused parameter warning.
         return this->widen(o);
     }

--- a/src/crab/thresholds.cpp
+++ b/src/crab/thresholds.cpp
@@ -6,8 +6,6 @@
 
 namespace prevail {
 
-inline namespace iterators {
-
 void thresholds_t::add(const extended_number& v) {
     if (m_thresholds.size() < m_size) {
         if (std::ranges::find(m_thresholds, v) == m_thresholds.end()) {
@@ -93,6 +91,5 @@ std::ostream& operator<<(std::ostream& o, const wto_thresholds_t& t) {
     }
     return o;
 }
-} // namespace iterators
 
 } // namespace prevail

--- a/src/crab/thresholds.hpp
+++ b/src/crab/thresholds.hpp
@@ -12,8 +12,6 @@
 
 namespace prevail {
 
-inline namespace iterators {
-
 /**
     Class that represents a set of thresholds used by the widening operator
 **/
@@ -68,5 +66,4 @@ class wto_thresholds_t final {
 
 }; // class wto_thresholds_t
 
-} // end namespace iterators
 } // end namespace prevail

--- a/src/crab/type_domain.cpp
+++ b/src/crab/type_domain.cpp
@@ -8,12 +8,12 @@
 #include <optional>
 
 #include "crab/array_domain.hpp"
+#include "crab/dsl_syntax.hpp"
 #include "crab/split_dbm.hpp"
 #include "crab/type_domain.hpp"
 #include "crab/type_encoding.hpp"
 #include "crab/variable.hpp"
 #include "crab_utils/debug.hpp"
-#include "crab/dsl_syntax.hpp"
 
 namespace prevail {
 
@@ -274,7 +274,7 @@ NumAbsDomain TypeDomain::join_by_if_else(const NumAbsDomain& inv, const linear_c
 }
 
 static linear_constraint_t eq_types(const Reg& a, const Reg& b) {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
     return eq(reg_pack(a).type, reg_pack(b).type);
 }
 
@@ -288,7 +288,7 @@ bool TypeDomain::implies_type(const NumAbsDomain& inv, const linear_constraint_t
 }
 
 bool TypeDomain::is_in_group(const NumAbsDomain& inv, const Reg& r, const TypeGroup group) const {
-    using namespace prevail::dsl_syntax;
+    using namespace dsl_syntax;
     const variable_t t = reg_pack(r).type;
     switch (group) {
     case TypeGroup::number: return inv.entail(t == T_NUM);

--- a/src/crab/variable.hpp
+++ b/src/crab/variable.hpp
@@ -3,8 +3,6 @@
 #pragma once
 
 #include <iosfwd>
-#include <iostream>
-#include <memory>
 #include <vector>
 
 #include "crab/type_encoding.hpp"

--- a/src/crab_utils/debug.hpp
+++ b/src/crab_utils/debug.hpp
@@ -16,7 +16,7 @@ namespace prevail {
 
 #define CRAB_LOG(TAG, CODE)                                            \
     do {                                                               \
-        if (prevail::CrabLogFlag && prevail::CrabLog.count(TAG) > 0) { \
+        if (CrabLogFlag && CrabLog.count(TAG) > 0) { \
             CODE;                                                      \
         }                                                              \
     } while (0)
@@ -26,7 +26,7 @@ extern std::set<std::string> CrabLog;
 extern unsigned CrabVerbosity;
 #define CRAB_VERBOSE_IF(LEVEL, CODE)           \
     do {                                       \
-        if (prevail::CrabVerbosity >= LEVEL) { \
+        if (CrabVerbosity >= LEVEL) { \
             CODE;                              \
         }                                      \
     } while (0)
@@ -47,8 +47,8 @@ void ___print___(std::ostream& os, ArgTypes... args) {
     do {                                                                        \
         std::ostringstream os;                                                  \
         os << "CRAB ERROR: ";                                                   \
-        prevail::___print___(os, __VA_ARGS__);                                  \
-        prevail::___print___(os, "; function ", __func__, ", line ", __LINE__); \
+        ___print___(os, __VA_ARGS__);                                  \
+        ___print___(os, "; function ", __func__, ", line ", __LINE__); \
         os << "\n";                                                             \
         throw std::runtime_error(os.str());                                     \
     } while (0)
@@ -58,7 +58,7 @@ void CrabEnableWarningMsg(bool b);
 
 #define CRAB_WARN(...)                           \
     do {                                         \
-        if (prevail::CrabWarningFlag) {          \
+        if (CrabWarningFlag) {          \
             std::cerr << "CRAB WARNING: ";       \
             ___print___(std::cerr, __VA_ARGS__); \
             std::cerr << "\n";                   \

--- a/src/crab_utils/stats.cpp
+++ b/src/crab_utils/stats.cpp
@@ -13,8 +13,8 @@
 
 namespace prevail {
 
-thread_local prevail::lazy_allocator<std::map<std::string, unsigned>> CrabStats::counters;
-thread_local prevail::lazy_allocator<std::map<std::string, Stopwatch>> CrabStats::sw;
+thread_local lazy_allocator<std::map<std::string, unsigned>> CrabStats::counters;
+thread_local lazy_allocator<std::map<std::string, Stopwatch>> CrabStats::sw;
 
 void CrabStats::clear_thread_local_state() {
     counters.clear();

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -17,10 +17,10 @@
 #include "crab_verifier.hpp"
 #include "string_constraints.hpp"
 
-using prevail::ebpf_domain_t;
 using std::string;
 
-thread_local prevail::lazy_allocator<program_info> thread_local_program_info;
+namespace prevail {
+thread_local lazy_allocator<program_info> thread_local_program_info;
 thread_local ebpf_verifier_options_t thread_local_options;
 void ebpf_verifier_clear_before_analysis();
 
@@ -32,10 +32,10 @@ bool Invariants::is_valid_after(const label_t& label, const string_invariant& st
 
 string_invariant Invariants::invariant_at(const label_t& label) const { return invariants.at(label).post.to_set(); }
 
-prevail::interval_t Invariants::exit_value() const { return invariants.at(label_t::exit).post.get_r0(); }
+interval_t Invariants::exit_value() const { return invariants.at(label_t::exit).post.get_r0(); }
 
 int Invariants::max_loop_count() const {
-    prevail::extended_number max_loop_count{0};
+    extended_number max_loop_count{0};
     // Gather the upper bound of loop counts from post-invariants.
     for (const auto& inv_pair : std::views::values(invariants)) {
         max_loop_count = std::max(max_loop_count, inv_pair.post.get_loop_count_upper_bound());
@@ -99,13 +99,14 @@ Report Invariants::check_assertions(const Program& prog) const {
 }
 
 void ebpf_verifier_clear_before_analysis() {
-    prevail::clear_thread_local_state();
-    prevail::variable_t::clear_thread_local_state();
+    clear_thread_local_state();
+    variable_t::clear_thread_local_state();
 }
 
 void ebpf_verifier_clear_thread_local_state() {
-    prevail::CrabStats::clear_thread_local_state();
+    CrabStats::clear_thread_local_state();
     thread_local_program_info.clear();
-    prevail::clear_thread_local_state();
-    prevail::SplitDBM::clear_thread_local_state();
+    clear_thread_local_state();
+    SplitDBM::clear_thread_local_state();
 }
+} // namespace prevail

--- a/src/crab_verifier.hpp
+++ b/src/crab_verifier.hpp
@@ -8,6 +8,7 @@
 #include "spec_type_descriptors.hpp"
 #include "string_constraints.hpp"
 
+namespace prevail {
 class Report final {
     std::map<label_t, std::vector<std::string>> warnings;
     std::map<label_t, std::vector<std::string>> reachability;
@@ -50,10 +51,10 @@ class Report final {
 };
 
 class Invariants final {
-    prevail::invariant_table_t invariants;
+    invariant_table_t invariants;
 
   public:
-    explicit Invariants(prevail::invariant_table_t&& invariants) : invariants(std::move(invariants)) {}
+    explicit Invariants(invariant_table_t&& invariants) : invariants(std::move(invariants)) {}
     Invariants(Invariants&& invariants) = default;
     Invariants(const Invariants& invariants) = default;
 
@@ -61,7 +62,7 @@ class Invariants final {
 
     string_invariant invariant_at(const label_t& label) const;
 
-    prevail::interval_t exit_value() const;
+    interval_t exit_value() const;
 
     int max_loop_count() const;
     bool verified(const Program& prog) const;
@@ -80,3 +81,4 @@ int create_map_crab(const EbpfMapType& map_type, uint32_t key_size, uint32_t val
 EbpfMapDescriptor* find_map_descriptor(int map_fd);
 
 void ebpf_verifier_clear_thread_local_state();
+} // namespace prevail

--- a/src/ebpf_vm_isa.hpp
+++ b/src/ebpf_vm_isa.hpp
@@ -4,6 +4,7 @@
 #include <cinttypes>
 #include <tuple>
 
+namespace prevail {
 // Header describing the Instruction Set Architecture (ISA)
 // for the eBPF virtual machine.
 // See https://github.com/ebpffoundation/ebpf-docs/blob/update/rst/instruction-set.rst
@@ -117,3 +118,4 @@ inline uint64_t merge(const int32_t imm, const int32_t next_imm) {
 inline std::tuple<int32_t, int32_t> split(const uint64_t v) {
     return {static_cast<uint32_t>(v), static_cast<uint32_t>(v >> 32)};
 }
+} // namespace prevail

--- a/src/helpers.hpp
+++ b/src/helpers.hpp
@@ -4,6 +4,7 @@
 
 #include "ebpf_base.h"
 
+namespace prevail {
 // A helper function's prototype is expressed by this struct.
 struct EbpfHelperPrototype {
     const char* name;
@@ -20,3 +21,4 @@ struct EbpfHelperPrototype {
     // If R1 holds a context, then this holds a pointer to the context descriptor.
     const ebpf_context_descriptor_t* context_descriptor;
 };
+} // namespace prevail

--- a/src/linux/gpl/spec_prototypes.cpp
+++ b/src/linux/gpl/spec_prototypes.cpp
@@ -1,6 +1,7 @@
 #include "platform.hpp"
 #include "spec_type_descriptors.hpp"
 
+namespace prevail {
 #define EBPF_RETURN_TYPE_PTR_TO_SOCK_COMMON_OR_NULL EBPF_RETURN_TYPE_UNSUPPORTED
 #define EBPF_RETURN_TYPE_PTR_TO_SOCKET_OR_NULL EBPF_RETURN_TYPE_UNSUPPORTED
 #define EBPF_RETURN_TYPE_PTR_TO_TCP_SOCKET_OR_NULL EBPF_RETURN_TYPE_UNSUPPORTED
@@ -2294,3 +2295,4 @@ EbpfHelperPrototype get_helper_prototype_linux(const int32_t n) {
     }
     return prototypes[n];
 }
+} // namespace prevail

--- a/src/linux/gpl/spec_type_descriptors.hpp
+++ b/src/linux/gpl/spec_type_descriptors.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+namespace prevail {
 constexpr int NMAPS = 64;
 constexpr int NONMAPS = 5;
 constexpr int ALL_TYPES = NMAPS + NONMAPS;
@@ -50,3 +51,5 @@ extern const ebpf_context_descriptor_t g_sock_ops_descr;
 
 // And these were also interchangeable.
 #define g_xdp_descr g_xdp_md
+
+} // namespace prevail

--- a/src/linux/linux_platform.cpp
+++ b/src/linux/linux_platform.cpp
@@ -9,13 +9,13 @@
 #define PTYPE(name, descr, native_type, prefixes) {name, descr, 0, prefixes}
 #define PTYPE_PRIVILEGED(name, descr, native_type, prefixes) {name, descr, 0, prefixes, true}
 #endif
+#include "asm_files.hpp"
 #include "crab_verifier.hpp"
 #include "linux/gpl/spec_type_descriptors.hpp"
 #include "linux_platform.hpp"
 #include "platform.hpp"
 
-#include <asm_files.hpp>
-
+namespace prevail {
 // Map definitions as they appear in an ELF file, so field width matters.
 struct bpf_load_map_def {
     uint32_t type;
@@ -248,3 +248,4 @@ const ebpf_platform_t g_ebpf_platform_linux = {get_program_type_linux,
                                                resolve_inner_map_references_linux,
                                                bpf_conformance_groups_t::default_groups |
                                                    bpf_conformance_groups_t::packet};
+} // namespace prevail

--- a/src/linux/linux_platform.hpp
+++ b/src/linux/linux_platform.hpp
@@ -4,5 +4,7 @@
 
 #include "helpers.hpp"
 
+namespace prevail {
 EbpfHelperPrototype get_helper_prototype_linux(int32_t n);
 bool is_helper_usable_linux(int32_t n);
+} // namespace prevail

--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -19,6 +19,8 @@
 using std::string;
 using std::vector;
 
+using namespace prevail;
+
 static size_t hash(const raw_program& raw_prog) {
     const char* start = reinterpret_cast<const char*>(raw_prog.prog.data());
     const char* end = start + raw_prog.prog.size() * sizeof(ebpf_inst);
@@ -71,7 +73,7 @@ int main(int argc, char** argv) {
 
     ebpf_verifier_options_t ebpf_verifier_options;
 
-    prevail::CrabEnableWarningMsg(false);
+    CrabEnableWarningMsg(false);
 
     // Parse command line arguments:
 

--- a/src/main/linux_verifier.cpp
+++ b/src/main/linux_verifier.cpp
@@ -12,6 +12,7 @@
 #include "linux_verifier.hpp"
 #include "spec_type_descriptors.hpp"
 
+namespace prevail {
 static int do_bpf(const bpf_cmd cmd, union bpf_attr& attr) { return syscall(321, cmd, &attr, sizeof(attr)); }
 
 /** Run the built-in Linux verifier on a raw eBPF program.
@@ -53,4 +54,5 @@ std::tuple<bool, double> bpf_verify_program(const EbpfProgramType& type, const s
     }
     return {true, seconds};
 }
+} // namespace prevail
 #endif

--- a/src/main/linux_verifier.hpp
+++ b/src/main/linux_verifier.hpp
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "platform.hpp"
-
 #if __linux__
 
 #include <tuple>
@@ -14,13 +13,16 @@
 #include "linux/gpl/spec_type_descriptors.hpp"
 #include "spec_type_descriptors.hpp"
 
+namespace prevail {
 int create_map_linux(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries,
                      ebpf_verifier_options_t options);
 std::tuple<bool, double> bpf_verify_program(const EbpfProgramType& type, const std::vector<ebpf_inst>& raw_prog,
                                             ebpf_verifier_options_t* options);
 
+} // namespace prevail
 #else
 
+namespace prevail {
 #define create_map_linux (nullptr)
 
 inline std::tuple<bool, double> bpf_verify_program(EbpfProgramType type, const std::vector<ebpf_inst>& raw_prog,
@@ -29,4 +31,5 @@ inline std::tuple<bool, double> bpf_verify_program(EbpfProgramType type, const s
     exit(64);
     return {{}, {}};
 }
+} // namespace prevail
 #endif

--- a/src/main/memsize_linux.hpp
+++ b/src/main/memsize_linux.hpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <unistd.h>
 
+namespace prevail {
 inline long resident_set_size_kb() {
     std::string _{};
     unsigned long __{};
@@ -22,3 +23,4 @@ inline long resident_set_size_kb() {
     long page_size_kb = sysconf(_SC_PAGE_SIZE) / 1024; // in case x86-64 is configured to use 2MB pages
     return rss * page_size_kb;
 }
+} // namespace prevail

--- a/src/main/memsize_windows.hpp
+++ b/src/main/memsize_windows.hpp
@@ -7,8 +7,11 @@
 
 #include <Psapi.h>
 
+namespace prevail {
+
 inline long resident_set_size_kb() {
     PROCESS_MEMORY_COUNTERS info;
     BOOL ok = GetProcessMemoryInfo(GetCurrentProcess(), &info, sizeof(info));
     return (long)((ok) ? (info.WorkingSetSize / 1024) : 0);
 }
+} // namespace prevail

--- a/src/main/run_yaml.cpp
+++ b/src/main/run_yaml.cpp
@@ -8,6 +8,8 @@
 // Avoid affecting other headers by macros.
 #include "CLI11/CLI11.hpp"
 
+using namespace prevail;
+
 int main(int argc, char** argv) {
     CLI::App app{"Run YAML test cases"};
 

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -12,6 +12,7 @@
 #include "helpers.hpp"
 #include "spec_type_descriptors.hpp"
 
+namespace prevail {
 typedef EbpfProgramType (*ebpf_get_program_type_fn)(const std::string& section, const std::string& path);
 
 typedef EbpfMapType (*ebpf_get_map_type_fn)(uint32_t platform_specific_type);
@@ -54,3 +55,4 @@ struct ebpf_platform_t {
 };
 
 extern const ebpf_platform_t g_ebpf_platform_linux;
+} // namespace prevail

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -11,6 +11,7 @@
 #include "config.hpp"
 #include "crab_utils/debug.hpp"
 
+namespace prevail {
 class Program {
     friend struct cfg_builder_t;
 
@@ -18,12 +19,12 @@ class Program {
 
     // This is a cache. The assertions can also be computed on the fly.
     std::map<label_t, std::vector<Assertion>> m_assertions{{label_t::entry, {}}, {label_t::exit, {}}};
-    prevail::cfg_t m_cfg;
+    cfg_t m_cfg;
 
     // TODO: add program_info field
 
   public:
-    const prevail::cfg_t& cfg() const { return m_cfg; }
+    const cfg_t& cfg() const { return m_cfg; }
 
     //! return a view of the labels, including entry and exit
     [[nodiscard]]
@@ -71,3 +72,4 @@ void print_program(const Program& prog, std::ostream& os, bool simplify, const p
                    const printfunc& postfunc);
 void print_program(const Program& prog, std::ostream& os, bool simplify);
 void print_dot(const Program& prog, const std::string& outfile);
+} // namespace prevail

--- a/src/spec_type_descriptors.hpp
+++ b/src/spec_type_descriptors.hpp
@@ -10,6 +10,7 @@
 #include "ebpf_base.h"
 #include "ebpf_vm_isa.hpp"
 
+namespace prevail {
 enum class EbpfMapValueType { ANY, MAP, PROGRAM };
 
 struct EbpfMapType {
@@ -76,4 +77,5 @@ void print_map_descriptors(const std::vector<EbpfMapDescriptor>& descriptors, st
 
 std::ostream& operator<<(std::ostream& os, const btf_line_info_t& line_info);
 
-extern thread_local prevail::lazy_allocator<program_info> thread_local_program_info;
+extern thread_local lazy_allocator<program_info> thread_local_program_info;
+} // namespace prevail

--- a/src/string_constraints.hpp
+++ b/src/string_constraints.hpp
@@ -11,6 +11,7 @@
 #include "crab/interval.hpp"
 #include "crab/linear_constraint.hpp"
 
+namespace prevail {
 struct string_invariant {
     std::optional<std::set<std::string>> maybe_inv{};
 
@@ -54,5 +55,6 @@ struct string_invariant {
     friend std::ostream& operator<<(std::ostream&, const string_invariant& inv);
 };
 
-std::vector<prevail::linear_constraint_t> parse_linear_constraints(const std::set<std::string>& constraints,
-                                                                   std::vector<prevail::interval_t>& numeric_ranges);
+std::vector<linear_constraint_t> parse_linear_constraints(const std::set<std::string>& constraints,
+                                                          std::vector<interval_t>& numeric_ranges);
+} // namespace prevail

--- a/src/test/conformance_check.cpp
+++ b/src/test/conformance_check.cpp
@@ -15,6 +15,8 @@
 #include "ebpf_verifier.hpp"
 #include "ebpf_yaml.hpp"
 
+using namespace prevail;
+
 /**
  * @brief Read in a string of hex bytes and return a vector of bytes.
  *

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -20,6 +20,7 @@
 using std::string;
 using std::vector;
 
+namespace prevail {
 // The YAML tests for Call depend on Linux prototypes.
 // parse_instruction() in asm_parse.cpp explicitly uses
 // g_ebpf_platform_linux when parsing Call instructions
@@ -138,7 +139,7 @@ static RawTestCase parse_case(const YAML::Node& case_node) {
 }
 
 static InstructionSeq raw_cfg_to_instruction_seq(const vector<std::tuple<string, vector<string>>>& raw_blocks) {
-    std::map<string, prevail::label_t> label_name_to_label;
+    std::map<string, label_t> label_name_to_label;
 
     int label_index = 0;
     for (const auto& [label_name, raw_block] : raw_blocks) {
@@ -418,3 +419,4 @@ void foreach_suite(const string& path, const std::function<void(const TestCase&)
         f(test_case);
     }
 }
+} // namespace prevail

--- a/src/test/ebpf_yaml.hpp
+++ b/src/test/ebpf_yaml.hpp
@@ -7,6 +7,8 @@
 
 #include "crab_verifier.hpp"
 
+namespace prevail {
+
 struct TestCase {
     std::string name;
     ebpf_verifier_options_t options{};
@@ -36,10 +38,11 @@ std::optional<Failure> run_yaml_test_case(TestCase test_case, bool debug = false
 
 struct ConformanceTestResult {
     bool success{};
-    prevail::interval_t r0_value = prevail::interval_t::top();
+    interval_t r0_value = interval_t::top();
 };
 
 ConformanceTestResult run_conformance_test_case(const std::vector<std::byte>& memory_bytes,
                                                 const std::vector<std::byte>& program_bytes, bool debug);
 
 bool run_yaml(const std::string& path);
+} // namespace prevail

--- a/src/test/test_marshal.cpp
+++ b/src/test/test_marshal.cpp
@@ -5,6 +5,8 @@
 #include "asm_marshal.hpp"
 #include "asm_unmarshal.hpp"
 
+using namespace prevail;
+
 // Below we define a tample of instruction templates that specify
 // what values each field are allowed to contain.  We first define
 // a set of sentinel values that mean certain types of wildcards.

--- a/src/test/test_print.cpp
+++ b/src/test/test_print.cpp
@@ -19,6 +19,8 @@
 #define PRINT_CASE(file) \
     TEST_CASE("Print suite: " file, "[print]") { verify_printed_string(file); }
 
+using namespace prevail;
+
 void verify_printed_string(const std::string& file) {
     std::stringstream generated_output;
     auto raw_progs = read_elf(std::string(TEST_OBJECT_FILE_DIRECTORY) + file + ".o", "", {}, &g_ebpf_platform_linux);

--- a/src/test/test_sign_extension.cpp
+++ b/src/test/test_sign_extension.cpp
@@ -7,7 +7,7 @@
 
 #include "crab/interval.hpp"
 
-using prevail::interval_t;
+using namespace prevail;
 
 TEST_CASE("sign_extend 1 bit positive-positive", "[sign_extension]") {
     // no actual sign extension needed

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -5,6 +5,8 @@
 
 #include "ebpf_verifier.hpp"
 
+using namespace prevail;
+
 #define FAIL_LOAD_ELF(dirname, filename, sectionname)                                                \
     TEST_CASE("Try loading nonexisting program: " dirname "/" filename, "[elf]") {                   \
         try {                                                                                        \

--- a/src/test/test_wto.cpp
+++ b/src/test/test_wto.cpp
@@ -5,21 +5,20 @@
 #include "cfg/cfg.hpp"
 #include "cfg/wto.hpp"
 
-using prevail::label_t;
-using prevail::wto_t;
+using namespace prevail;
 
 TEST_CASE("wto figure 1", "[wto]") {
     // Construct the example graph in figure 1 of Bourdoncle,
     // "Efficient chaotic iteration strategies with widenings", 1993.
-    const wto_t wto(prevail::cfg_from_adjacency_list({{label_t::entry, {label_t{1}}},
-                                                      {label_t{1}, {label_t{2}}},
-                                                      {label_t{2}, {label_t{3}}},
-                                                      {label_t{3}, {label_t{4}}},
-                                                      {label_t{4}, {label_t{5}, label_t{7}}},
-                                                      {label_t{5}, {label_t{6}}},
-                                                      {label_t{6}, {label_t{5}, label_t{7}}},
-                                                      {label_t{7}, {label_t{3}, label_t{8}}},
-                                                      {label_t{8}, {label_t::exit}}}));
+    const wto_t wto(cfg_from_adjacency_list({{label_t::entry, {label_t{1}}},
+                                             {label_t{1}, {label_t{2}}},
+                                             {label_t{2}, {label_t{3}}},
+                                             {label_t{3}, {label_t{4}}},
+                                             {label_t{4}, {label_t{5}, label_t{7}}},
+                                             {label_t{5}, {label_t{6}}},
+                                             {label_t{6}, {label_t{5}, label_t{7}}},
+                                             {label_t{7}, {label_t{3}, label_t{8}}},
+                                             {label_t{8}, {label_t::exit}}}));
 
     std::ostringstream os;
     os << wto;
@@ -29,12 +28,12 @@ TEST_CASE("wto figure 1", "[wto]") {
 TEST_CASE("wto figure 2a", "[wto]") {
     // Construct the example graph in figure 2a of Bourdoncle,
     // "Efficient chaotic iteration strategies with widenings", 1993.
-    const wto_t wto(prevail::cfg_from_adjacency_list({{label_t::entry, {label_t{1}}},
-                                                      {label_t{1}, {label_t{2}, label_t{4}}},
-                                                      {label_t{2}, {label_t{3}}},
-                                                      {label_t{3}, {label_t::exit}},
-                                                      {label_t{4}, {label_t{3}, label_t{5}}},
-                                                      {label_t{5}, {label_t{4}}}}));
+    const wto_t wto(cfg_from_adjacency_list({{label_t::entry, {label_t{1}}},
+                                             {label_t{1}, {label_t{2}, label_t{4}}},
+                                             {label_t{2}, {label_t{3}}},
+                                             {label_t{3}, {label_t::exit}},
+                                             {label_t{4}, {label_t{3}, label_t{5}}},
+                                             {label_t{5}, {label_t{4}}}}));
 
     std::ostringstream os;
     os << wto;
@@ -44,11 +43,11 @@ TEST_CASE("wto figure 2a", "[wto]") {
 TEST_CASE("wto figure 2b", "[wto]") {
     // Construct the example graph in figure 2b of Bourdoncle,
     // "Efficient chaotic iteration strategies with widenings", 1993.
-    const wto_t wto(prevail::cfg_from_adjacency_list({{label_t::entry, {label_t{1}}},
-                                                      {label_t{1}, {label_t{2}, label_t{4}}},
-                                                      {label_t{2}, {label_t{3}}},
-                                                      {label_t{3}, {label_t{1}, label_t::exit}},
-                                                      {label_t{4}, {label_t{3}}}}));
+    const wto_t wto(cfg_from_adjacency_list({{label_t::entry, {label_t{1}}},
+                                             {label_t{1}, {label_t{2}, label_t{4}}},
+                                             {label_t{2}, {label_t{3}}},
+                                             {label_t{3}, {label_t{1}, label_t::exit}},
+                                             {label_t{4}, {label_t{3}}}}));
 
     std::ostringstream os;
     os << wto;

--- a/src/test/test_yaml.cpp
+++ b/src/test/test_yaml.cpp
@@ -7,6 +7,8 @@
 
 // TODO: move out of this framework
 
+using namespace prevail;
+
 #define YAML_CASE(path)                                                     \
     TEST_CASE("YAML suite: " path, "[yaml]") {                              \
         foreach_suite(path, [&](const TestCase& test_case) {                \


### PR DESCRIPTION
closes #861.

* Always do namespace prevail { }
* Remove unused namespaces: iterators, asm_syntax.
* `using namespace prevail;` in main files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Unified and encapsulated nearly all previously global declarations, types, constants, and functions under a single `prevail` namespace across the codebase.
  - Updated references throughout the code to use the new namespace context, reducing explicit namespace qualifiers.
  - Adjusted function and type signatures where necessary to reflect namespace scoping.
  - No changes to program logic, control flow, or user-facing features.

- **Style**
  - Improved code organization and maintainability by standardizing namespace usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->