### PR TITLE
Rename ebpf_verifier to prevail in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if (POLICY CMP0167)
     cmake_policy(SET CMP0167 NEW)
 endif ()
 
-project(ebpf_verifier)
+project(prevail)
 
 include(FetchContent)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project name in the build configuration from "ebpf_verifier" to "prevail".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->