### PR TITLE
Use PascalCase for type names

### DIFF
--- a/scripts/rename_classes.py
+++ b/scripts/rename_classes.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""
+Class Name Renaming Script
+
+This script automatically renames class names in a codebase according to a predefined mapping.
+It handles both class definitions and usages throughout the code.
+"""
+
+import os
+import re
+import sys
+from typing import Dict, List, Tuple
+import argparse
+
+# Define the mapping of old class names to new class names
+CLASS_MAPPING = {
+    # Arithmetic and Number Theory
+    "number_t": "Number",
+    "extended_number": "ExtendedNumber",
+    "safe_i64": "SafeI64",
+    "wideint_t": "WideInt",
+    "arith_binop_t": "ArithBinOp",
+    "bitwise_binop_t": "BitwiseBinOp",
+    "binop_t": "BinOp",
+    "bound_t": "Bound",
+    "index_t": "Index",  # Used for array indexing, related to numbers/offsets
+    "key_t": "Key",  # Used in maps, often numeric
+    "mut_val_ref_t": "MutValRef",  # Related to graph weights/values
+    "val_t": "Val",  # Generic value type
+
+    # Control Flow Graph (CFG) and Analysis
+    "adjacent_t": "Adjacent",  # CFG structure
+    "basic_block_t": "BasicBlock",
+    "cfg_t": "Cfg",
+    "cfg_builder_t": "CfgBuilder",
+    "label_t": "Label",
+    "label_vec_t": "LabelVec",  # Vector of labels
+    "stmt_list_t": "StmtList",  # List of statements (labels)
+    "pc_t": "Pc",  # Program Counter
+    "wto_t": "Wto",  # Weak Topological Ordering
+    "wto_builder_t": "WtoBuilder",
+    "wto_cycle_t": "WtoCycle",
+    "wto_nesting_t": "WtoNesting",
+    "wto_thresholds_t": "WtoThresholds",
+    "wto_vertex_data_t": "WtoVertexData",
+    "wto_partition_t": "WtoPartition",
+    "cycle_or_label": "CycleOrLabel",  # Variant used in WTO structure
+    "interleaved_fwd_fixpoint_iterator_t": "InterleavedFwdFixpointIterator",
+    "invariant_map_pair": "InvariantMapPair",  # Used in analysis results
+    "invariant_table_t": "InvariantTable",  # Table of invariants
+    "visit_args_t": "VisitArgs",  # Used in analysis traversal
+    "print_visitor": "PrintVisitor",  # Used for printing CFG/WTO
+
+    # Domains and Constraints
+    "array_domain_t": "ArrayDomain",
+    "bitset_domain_t": "BitsetDomain",
+    "ebpf_domain_t": "EbpfDomain",
+    "interval_t": "Interval",
+    "linear_constraint_t": "LinearConstraint",
+    "linear_expression_t": "LinearExpression",
+    "variable_t": "Variable",
+    "reg_pack_t": "RegPack",  # Structure for register components
+    "cell_t": "Cell",  # Used in array domain
+    "thresholds_t": "Thresholds",  # Used in widening
+    "string_invariant": "StringInvariant",  # Represents string-based invariants
+    "variable_terms_t": "VariableTerms",  # Part of linear expression
+    "variable_vector_t": "VariableVector",  # Vector of variables
+    "constraint_kind_t": "ConstraintKind",  # Enum for linear constraints
+    "data_kind_t": "DataKind",  # Enum for variable data kind
+    "type_domain_t": "TypeDomain",
+    "type_group_t": "TypeGroup",  # Enum for type groups
+    "type_encoding_t": "TypeEncoding",  # Enum for type encoding
+    "num_abs_domain_t": "NumAbsDomain",  # Numerical Abstract Domain
+
+    # Low-Level / Instruction Representation
+    "program_info": "ProgramInfo",
+    "raw_program": "RawProgram",
+    "function_relocation": "FunctionRelocation",  # Used in ELF parsing
+    "ebpf_inst": "EbpfInst",  # eBPF instruction struct
+    "ebpf_instruction_template_t": "EbpfInstructionTemplate",  # Used in testing
+    "bpf_load_map_def": "BpfLoadMapDef",  # ELF map definition struct
+    "map_offsets_t": "MapOffsets",  # Used in ELF parsing
+    "visit_task_type_t": "VisitTaskType",  # Used in unmarshalling/processing
+    "add_bottom": "AddBottom",  # Domain helper/wrapper
+
+    # Graph and Data Structures
+    "graph_t": "Graph",  # Generic graph type
+    "vert_id": "VertId",  # Vertex ID
+    "vert_map_t": "VertMap",  # Mapping variable to vertex ID
+    "vert_set_t": "VertSet",  # Set of vertex IDs
+    "edge_ref": "EdgeRef",  # Reference to a graph edge
+    "edge_vector": "EdgeVector",  # Vector of edges
+    "vert_const_iterator": "VertConstIterator",  # Iterator for vertices
+    "adj_const_range_t": "AdjConstRange",  # Range of adjacent vertices
+    "adj_range_t": "AdjRange",
+    "e_neighbour_const_range": "ENeighbourConstRange",  # Range of adjacent edges
+    "g_e_neighbour_const_range": "GENeighbourConstRange",
+    "g_neighbour_const_range": "GNeighbourConstRange",
+    "neighbour_const_range": "NeighbourConstRange",
+    "neighbour_range": "NeighbourRange",
+    "fwd_edge_const_iter": "FwdEdgeConstIter",  # Iterator for forward edges
+    "fwd_edge_range": "FwdEdgeRange",
+    "rev_edge_const_iter": "RevEdgeConstIter",  # Iterator for reverse edges
+    "rev_edge_range": "RevEdgeRange",
+    "rev_map_t": "RevMap",  # Mapping vertex ID to variable
+    "elt_iter_t": "EltIter",  # Iterator for elements in sparse map
+    "elt_range_t": "EltRange",
+    "patricia_tree_t": "PatriciaTree",  # Underlying structure for OffsetMap
+    "adj_const_iterator": "AdjConstIterator",
+    "adj_iterator": "AdjIterator",
+    "adj_list": "AdjList",
+    "const_adj_list": "ConstAdjList",
+    "e_adj_const_iterator": "EAdjConstIterator",
+    "e_adj_iterator": "EAdjIterator",
+    "elt_const_range_t": "EltConstRange",
+    "key_const_range_t": "KeyConstRange",
+    "key_iter_t": "KeyIter",
+    "vert_const_range": "VertConstRange",
+    "vert_set_wrap_t": "VertSetWrap",  # Wrapper for VertSet
+
+    # Utilities and Others
+    "ebpf_checker": "EbpfChecker",  # Verification checker
+    "ebpf_transformer": "EbpfTransformer",  # Applies instruction effects
+    "overloaded": "Overloaded",  # C++ utility for variant visitors
+    "at_scope_exit": "AtScopeExit",  # C++ utility for scope-based cleanup
+    "lazy_allocator": "LazyAllocator",  # Utility for lazy initialization
+    "expand_variadic_pack": "ExpandVariadicPack",  # C++ template utility
+    "swap_signedness": "SwapSignedness",  # C++ type trait
+    "compare_binding_t": "CompareBinding",  # Used in OffsetMap
+    "program_reader_t": "ProgramReader",  # Used in ELF parsing
+}
+
+
+def build_regex_patterns() -> Dict[str, re.Pattern]:
+    """
+    Build regex patterns for each class name to match different contexts where they might appear.
+    Avoids matching in file paths by excluding patterns followed by a period.
+    """
+    patterns = {}
+    for old_name in CLASS_MAPPING:
+        # This pattern will match class definitions and usages but not when followed by a period,
+        # which would indicate a file extension or namespace access
+        patterns[old_name] = re.compile(r'\b' + re.escape(old_name) + r'\b(?!\.)')
+    return patterns
+
+
+def should_skip_file(file_path: str, extensions: List[str]) -> bool:
+    """
+    Check if a file should be skipped based on its extension or path.
+    """
+    _, ext = os.path.splitext(file_path)
+    if ext and ext[1:] not in extensions:  # Remove the dot from extension
+        return True
+    return False
+
+
+def process_file(file_path: str, patterns: Dict[str, re.Pattern], dry_run: bool = False) -> Tuple[int, List[str]]:
+    """
+    Process a single file, applying the renaming patterns.
+    Returns the number of replacements made and a list of changes.
+    """
+    with open(file_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    original_content = content
+    change_count = 0
+    changes = []
+
+    # Apply each pattern
+    for old_name, pattern in patterns.items():
+        new_name = CLASS_MAPPING[old_name]
+
+        # Count occurrences before replacement
+        occurrences = len(pattern.findall(content))
+        if occurrences > 0:
+            # Replace all occurrences
+            content = pattern.sub(new_name, content)
+            change_count += occurrences
+            changes.append(f"  {old_name} → {new_name} ({occurrences} occurrences)")
+
+    # Write changes back to the file if not a dry run and changes were made
+    if not dry_run and content != original_content:
+        with open(file_path, 'w', encoding='utf-8') as f:
+            f.write(content)
+
+    return change_count, changes
+
+
+def process_directory(directory: str, patterns: Dict[str, re.Pattern],
+                      extensions: List[str], dry_run: bool = False) -> int:
+    """
+    Recursively process files in a directory.
+    Returns the total number of replacements made.
+    """
+    total_changes = 0
+    file_count = 0
+    modified_file_count = 0
+
+    for root, _, files in os.walk(directory):
+        for file in files:
+            file_path = os.path.join(root, file)
+
+            if should_skip_file(file_path, extensions):
+                continue
+
+            file_count += 1
+            changes, change_list = process_file(file_path, patterns, dry_run)
+
+            if changes > 0:
+                modified_file_count += 1
+                total_changes += changes
+                relative_path = os.path.relpath(file_path, directory)
+                print(f"Modified {relative_path} ({changes} changes):")
+                for change in change_list:
+                    print(change)
+                print()
+
+    print(f"Summary: {total_changes} changes across {modified_file_count} files (scanned {file_count} files)")
+    if dry_run:
+        print("Note: This was a dry run. No files were actually modified.")
+
+    return total_changes
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Rename class names in codebase according to a predefined mapping")
+    parser.add_argument("--dry-run", "-d", action="store_true",
+                        help="Perform a dry run without actually modifying files")
+    args = parser.parse_args()
+
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    directory = os.path.normpath(os.path.join(script_dir, "../src"))
+    extensions = ["cpp", "hpp"]
+
+    patterns = build_regex_patterns()
+
+    print(f"Starting class name renaming in {directory}")
+    print(f"Processing files with extensions: {', '.join(extensions)}")
+    print(
+        f"{'Dry run mode - ' if args.dry_run else ''}Changes will be applied based on {len(CLASS_MAPPING)} class mappings\n")
+
+    try:
+        changes = process_directory(directory, patterns, extensions, args.dry_run)
+        print(f"Completed with {changes} total changes")
+        return 0
+    except Exception as e:
+        print(f"Error occurred: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/asm_files.hpp
+++ b/src/asm_files.hpp
@@ -13,12 +13,12 @@ class UnmarshalError final : public std::runtime_error {
     explicit UnmarshalError(const std::string& what) : std::runtime_error(what) {}
 };
 
-std::vector<raw_program> read_raw(std::string path, program_info info);
-std::vector<raw_program> read_elf(const std::string& path, const std::string& desired_section,
-                                  const ebpf_verifier_options_t& options, const ebpf_platform_t* platform);
-std::vector<raw_program> read_elf(std::istream& input_stream, const std::string& path,
-                                  const std::string& desired_section, const ebpf_verifier_options_t& options,
-                                  const ebpf_platform_t* platform);
+std::vector<RawProgram> read_raw(std::string path, ProgramInfo info);
+std::vector<RawProgram> read_elf(const std::string& path, const std::string& desired_section,
+                                 const ebpf_verifier_options_t& options, const ebpf_platform_t* platform);
+std::vector<RawProgram> read_elf(std::istream& input_stream, const std::string& path,
+                                 const std::string& desired_section, const ebpf_verifier_options_t& options,
+                                 const ebpf_platform_t* platform);
 
 void write_binary_file(std::string path, const char* data, size_t size);
 

--- a/src/asm_marshal.cpp
+++ b/src/asm_marshal.cpp
@@ -89,31 +89,31 @@ static uint8_t imm_endian(const Un::Op op) {
 
 struct MarshalVisitor {
   private:
-    static vector<ebpf_inst> makeLddw(const Reg dst, const uint8_t type, const int32_t imm, const int32_t next_imm) {
-        return {ebpf_inst{.opcode = gsl::narrow<uint8_t>(INST_CLS_LD | width_to_opcode(8)),
-                          .dst = dst.v,
-                          .src = type,
-                          .offset = 0,
-                          .imm = imm},
-                ebpf_inst{.opcode = 0, .dst = 0, .src = 0, .offset = 0, .imm = next_imm}};
+    static vector<EbpfInst> makeLddw(const Reg dst, const uint8_t type, const int32_t imm, const int32_t next_imm) {
+        return {EbpfInst{.opcode = gsl::narrow<uint8_t>(INST_CLS_LD | width_to_opcode(8)),
+                         .dst = dst.v,
+                         .src = type,
+                         .offset = 0,
+                         .imm = imm},
+                EbpfInst{.opcode = 0, .dst = 0, .src = 0, .offset = 0, .imm = next_imm}};
     }
 
   public:
-    std::function<auto(label_t)->int16_t> label_to_offset16;
-    std::function<auto(label_t)->int32_t> label_to_offset32;
+    std::function<auto(Label)->int16_t> label_to_offset16;
+    std::function<auto(Label)->int32_t> label_to_offset32;
 
-    vector<ebpf_inst> operator()(Undefined const& a) const {
+    vector<EbpfInst> operator()(Undefined const& a) const {
         assert(false);
         return {};
     }
 
-    vector<ebpf_inst> operator()(LoadMapFd const& b) const { return makeLddw(b.dst, INST_LD_MODE_MAP_FD, b.mapfd, 0); }
+    vector<EbpfInst> operator()(LoadMapFd const& b) const { return makeLddw(b.dst, INST_LD_MODE_MAP_FD, b.mapfd, 0); }
 
-    vector<ebpf_inst> operator()(LoadMapAddress const& b) const {
+    vector<EbpfInst> operator()(LoadMapAddress const& b) const {
         return makeLddw(b.dst, INST_LD_MODE_MAP_VALUE, b.mapfd, b.offset);
     }
 
-    vector<ebpf_inst> operator()(Bin const& b) const {
+    vector<EbpfInst> operator()(Bin const& b) const {
         if (b.lddw) {
             const auto pimm = std::get_if<Imm>(&b.v);
             assert(pimm != nullptr);
@@ -121,12 +121,12 @@ struct MarshalVisitor {
             return makeLddw(b.dst, INST_LD_MODE_IMM, imm, next_imm);
         }
 
-        ebpf_inst res{.opcode = gsl::narrow<uint8_t>((b.is64 ? INST_CLS_ALU64 : INST_CLS_ALU) | (op(b.op) << 4)),
-                      .dst = b.dst.v,
-                      .src = 0,
-                      .offset = offset(b.op),
-                      .imm = 0};
-        std::visit(overloaded{[&](const Reg right) {
+        EbpfInst res{.opcode = gsl::narrow<uint8_t>((b.is64 ? INST_CLS_ALU64 : INST_CLS_ALU) | (op(b.op) << 4)),
+                     .dst = b.dst.v,
+                     .src = 0,
+                     .offset = offset(b.op),
+                     .imm = 0};
+        std::visit(Overloaded{[&](const Reg right) {
                                   res.opcode |= INST_SRC_REG;
                                   res.src = right.v;
                               },
@@ -135,10 +135,10 @@ struct MarshalVisitor {
         return {res};
     }
 
-    vector<ebpf_inst> operator()(Un const& b) const {
+    vector<EbpfInst> operator()(Un const& b) const {
         switch (b.op) {
         case Un::Op::NEG:
-            return {ebpf_inst{
+            return {EbpfInst{
                 .opcode = gsl::narrow<uint8_t>((b.is64 ? INST_CLS_ALU64 : INST_CLS_ALU) | INST_ALU_OP_NEG),
                 .dst = b.dst.v,
                 .src = 0,
@@ -148,7 +148,7 @@ struct MarshalVisitor {
         case Un::Op::LE16:
         case Un::Op::LE32:
         case Un::Op::LE64:
-            return {ebpf_inst{
+            return {EbpfInst{
                 .opcode = gsl::narrow<uint8_t>(INST_CLS_ALU | INST_END_LE | INST_ALU_OP_END),
                 .dst = b.dst.v,
                 .src = 0,
@@ -158,7 +158,7 @@ struct MarshalVisitor {
         case Un::Op::BE16:
         case Un::Op::BE32:
         case Un::Op::BE64:
-            return {ebpf_inst{
+            return {EbpfInst{
                 .opcode = gsl::narrow<uint8_t>(INST_CLS_ALU | INST_END_BE | INST_ALU_OP_END),
                 .dst = b.dst.v,
                 .src = 0,
@@ -168,7 +168,7 @@ struct MarshalVisitor {
         case Un::Op::SWAP16:
         case Un::Op::SWAP32:
         case Un::Op::SWAP64:
-            return {ebpf_inst{
+            return {EbpfInst{
                 .opcode = gsl::narrow<uint8_t>(INST_CLS_ALU64 | INST_ALU_OP_END),
                 .dst = b.dst.v,
                 .src = 0,
@@ -180,45 +180,45 @@ struct MarshalVisitor {
         return {};
     }
 
-    vector<ebpf_inst> operator()(Call const& b) const {
-        return {ebpf_inst{.opcode = gsl::narrow<uint8_t>(INST_OP_CALL),
-                          .dst = 0,
-                          .src = INST_CALL_STATIC_HELPER,
-                          .offset = 0,
-                          .imm = b.func}};
+    vector<EbpfInst> operator()(Call const& b) const {
+        return {EbpfInst{.opcode = gsl::narrow<uint8_t>(INST_OP_CALL),
+                         .dst = 0,
+                         .src = INST_CALL_STATIC_HELPER,
+                         .offset = 0,
+                         .imm = b.func}};
     }
 
-    vector<ebpf_inst> operator()(CallLocal const& b) const {
-        return {ebpf_inst{.opcode = gsl::narrow<uint8_t>(INST_OP_CALL),
-                          .dst = 0,
-                          .src = INST_CALL_LOCAL,
-                          .offset = 0,
-                          .imm = label_to_offset32(b.target)}};
+    vector<EbpfInst> operator()(CallLocal const& b) const {
+        return {EbpfInst{.opcode = gsl::narrow<uint8_t>(INST_OP_CALL),
+                         .dst = 0,
+                         .src = INST_CALL_LOCAL,
+                         .offset = 0,
+                         .imm = label_to_offset32(b.target)}};
     }
 
-    vector<ebpf_inst> operator()(Callx const& b) const {
+    vector<EbpfInst> operator()(Callx const& b) const {
         // callx is defined to have the register in 'dst' not in 'src'.
-        return {ebpf_inst{.opcode = gsl::narrow<uint8_t>(INST_OP_CALLX),
-                          .dst = b.func.v,
-                          .src = INST_CALL_STATIC_HELPER,
-                          .offset = 0}};
+        return {EbpfInst{.opcode = gsl::narrow<uint8_t>(INST_OP_CALLX),
+                         .dst = b.func.v,
+                         .src = INST_CALL_STATIC_HELPER,
+                         .offset = 0}};
     }
 
-    vector<ebpf_inst> operator()(Exit const& b) const {
-        return {ebpf_inst{.opcode = INST_OP_EXIT, .dst = 0, .src = 0, .offset = 0, .imm = 0}};
+    vector<EbpfInst> operator()(Exit const& b) const {
+        return {EbpfInst{.opcode = INST_OP_EXIT, .dst = 0, .src = 0, .offset = 0, .imm = 0}};
     }
 
-    vector<ebpf_inst> operator()(Assume const&) const { throw std::invalid_argument("Cannot marshal assumptions"); }
+    vector<EbpfInst> operator()(Assume const&) const { throw std::invalid_argument("Cannot marshal assumptions"); }
 
-    vector<ebpf_inst> operator()(Jmp const& b) const {
+    vector<EbpfInst> operator()(Jmp const& b) const {
         if (b.cond) {
-            ebpf_inst res{
+            EbpfInst res{
                 .opcode = gsl::narrow<uint8_t>(INST_CLS_JMP | (op(b.cond->op) << 4)),
                 .dst = b.cond->left.v,
                 .src = 0,
                 .offset = label_to_offset16(b.target),
             };
-            visit(overloaded{[&](const Reg right) {
+            visit(Overloaded{[&](const Reg right) {
                                  res.opcode |= INST_SRC_REG;
                                  res.src = right.v;
                              },
@@ -228,16 +228,16 @@ struct MarshalVisitor {
         } else {
             const int32_t imm = label_to_offset32(b.target);
             if (imm != 0) {
-                return {ebpf_inst{.opcode = INST_OP_JA32, .imm = imm}};
+                return {EbpfInst{.opcode = INST_OP_JA32, .imm = imm}};
             } else {
-                return {ebpf_inst{.opcode = INST_OP_JA16, .offset = label_to_offset16(b.target)}};
+                return {EbpfInst{.opcode = INST_OP_JA16, .offset = label_to_offset16(b.target)}};
             }
         }
     }
 
-    vector<ebpf_inst> operator()(Mem const& b) const {
+    vector<EbpfInst> operator()(Mem const& b) const {
         const Deref access = b.access;
-        ebpf_inst res{
+        EbpfInst res{
             .opcode = gsl::narrow<uint8_t>(INST_MODE_MEM | width_to_opcode(access.width)),
             .dst = 0,
             .src = 0,
@@ -264,8 +264,8 @@ struct MarshalVisitor {
         return {res};
     }
 
-    vector<ebpf_inst> operator()(Packet const& b) const {
-        ebpf_inst res{
+    vector<EbpfInst> operator()(Packet const& b) const {
+        EbpfInst res{
             .opcode = gsl::narrow<uint8_t>(INST_CLS_LD | width_to_opcode(b.width)),
             .dst = 0,
             .src = 0,
@@ -281,23 +281,23 @@ struct MarshalVisitor {
         return {res};
     }
 
-    vector<ebpf_inst> operator()(Atomic const& b) const {
+    vector<EbpfInst> operator()(Atomic const& b) const {
         auto imm = gsl::narrow<int32_t>(b.op);
         if (b.fetch) {
             imm |= INST_FETCH;
         }
         return {
-            ebpf_inst{.opcode = gsl::narrow<uint8_t>(INST_CLS_STX | INST_MODE_ATOMIC | width_to_opcode(b.access.width)),
-                      .dst = b.access.basereg.v,
-                      .src = b.valreg.v,
-                      .offset = gsl::narrow<int16_t>(b.access.offset),
-                      .imm = imm}};
+            EbpfInst{.opcode = gsl::narrow<uint8_t>(INST_CLS_STX | INST_MODE_ATOMIC | width_to_opcode(b.access.width)),
+                     .dst = b.access.basereg.v,
+                     .src = b.valreg.v,
+                     .offset = gsl::narrow<int16_t>(b.access.offset),
+                     .imm = imm}};
     }
 
-    vector<ebpf_inst> operator()(IncrementLoopCounter const&) const { return {}; }
+    vector<EbpfInst> operator()(IncrementLoopCounter const&) const { return {}; }
 };
 
-vector<ebpf_inst> marshal(const Instruction& ins, const pc_t pc) {
+vector<EbpfInst> marshal(const Instruction& ins, const Pc pc) {
     return std::visit(MarshalVisitor{label_to_offset16(pc), label_to_offset32(pc)}, ins);
 }
 
@@ -317,8 +317,8 @@ int size(const Instruction& inst) {
 }
 
 static auto get_labels(const InstructionSeq& insts) {
-    pc_t pc = 0;
-    std::map<label_t, pc_t> pc_of_label;
+    Pc pc = 0;
+    std::map<Label, Pc> pc_of_label;
     for (const auto& [label, inst, _] : insts) {
         pc_of_label[label] = pc;
         pc += size(inst);
@@ -326,14 +326,14 @@ static auto get_labels(const InstructionSeq& insts) {
     return pc_of_label;
 }
 
-vector<ebpf_inst> marshal(const InstructionSeq& insts) {
-    vector<ebpf_inst> res;
+vector<EbpfInst> marshal(const InstructionSeq& insts) {
+    vector<EbpfInst> res;
     const auto pc_of_label = get_labels(insts);
-    pc_t pc = 0;
+    Pc pc = 0;
     for (auto [label, ins, _] : insts) {
         (void)label; // unused
         if (const auto pins = std::get_if<Jmp>(&ins)) {
-            pins->target = label_t{gsl::narrow<int>(pc_of_label.at(pins->target))};
+            pins->target = Label{gsl::narrow<int>(pc_of_label.at(pins->target))};
         }
         for (const auto e : marshal(ins, pc)) {
             pc++;

--- a/src/asm_marshal.hpp
+++ b/src/asm_marshal.hpp
@@ -9,7 +9,7 @@
 
 namespace prevail {
 
-std::vector<ebpf_inst> marshal(const Instruction& ins, pc_t pc);
+std::vector<EbpfInst> marshal(const Instruction& ins, Pc pc);
 // TODO marshal to ostream?
 
 } // namespace prevail

--- a/src/asm_parse.hpp
+++ b/src/asm_parse.hpp
@@ -8,6 +8,6 @@
 
 namespace prevail {
 
-Instruction parse_instruction(const std::string& line, const std::map<std::string, label_t>& label_name_to_label);
+Instruction parse_instruction(const std::string& line, const std::map<std::string, Label>& label_name_to_label);
 
 }

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -125,7 +125,7 @@ struct Condition {
 
 struct Jmp {
     std::optional<Condition> cond;
-    label_t target;
+    Label target;
     bool operator==(const Jmp&) const = default;
 };
 
@@ -171,7 +171,7 @@ struct Call {
 
 /// Call a "function" (macro) within the same program.
 struct CallLocal {
-    label_t target;
+    Label target;
     std::string stack_frame_prefix; ///< Variable prefix to be used within the call.
     bool operator==(const CallLocal& other) const noexcept = default;
 };
@@ -251,14 +251,14 @@ struct Assume {
 };
 
 struct IncrementLoopCounter {
-    label_t name;
+    Label name;
     bool operator==(const IncrementLoopCounter&) const = default;
 };
 
 using Instruction = std::variant<Undefined, Bin, Un, LoadMapFd, Call, CallLocal, Callx, Exit, Jmp, Mem, Packet, Atomic,
                                  Assume, IncrementLoopCounter, LoadMapAddress>;
 
-using LabeledInstruction = std::tuple<label_t, Instruction, std::optional<btf_line_info_t>>;
+using LabeledInstruction = std::tuple<Label, Instruction, std::optional<btf_line_info_t>>;
 using InstructionSeq = std::vector<LabeledInstruction>;
 
 /// Condition check whether something is a valid size.
@@ -348,7 +348,7 @@ struct ZeroCtxOffset {
 };
 
 struct BoundedLoopCount {
-    label_t name;
+    Label name;
     bool operator==(const BoundedLoopCount&) const = default;
     // Maximum number of loop iterations allowed during verification.
     // This prevents infinite loops while allowing reasonable bounded loops.
@@ -377,13 +377,13 @@ inline std::ostream& operator<<(std::ostream& os, Value const& a) {
 std::ostream& operator<<(std::ostream& os, const Assertion& a);
 std::string to_string(const Assertion& constraint);
 
-void print(const InstructionSeq& insts, std::ostream& out, const std::optional<const label_t>& label_to_print,
+void print(const InstructionSeq& insts, std::ostream& out, const std::optional<const Label>& label_to_print,
            bool print_line_info = false);
 
 int size(const Instruction& inst);
 
 template <class... Ts>
-struct overloaded : Ts... {
+struct Overloaded : Ts... {
     using Ts::operator()...;
 };
 

--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -86,16 +86,16 @@ static Instruction shift32(const Reg dst, const Bin::Op op) {
 
 struct Unmarshaller {
     vector<vector<string>>& notes;
-    const program_info& info;
+    const ProgramInfo& info;
     // ReSharper disable once CppMemberFunctionMayBeConst
     void note(const string& what) { notes.back().emplace_back(what); }
     // ReSharper disable once CppMemberFunctionMayBeConst
     void note_next_pc() { notes.emplace_back(); }
-    explicit Unmarshaller(vector<vector<string>>& notes, const program_info& info) : notes{notes}, info{info} {
+    explicit Unmarshaller(vector<vector<string>>& notes, const ProgramInfo& info) : notes{notes}, info{info} {
         note_next_pc();
     }
 
-    auto getAluOp(const size_t pc, const ebpf_inst inst) -> std::variant<Bin::Op, Un::Op> {
+    auto getAluOp(const size_t pc, const EbpfInst inst) -> std::variant<Bin::Op, Un::Op> {
         // First handle instructions that support a non-zero offset.
         const bool is64 = (inst.opcode & INST_CLS_MASK) == INST_CLS_ALU64;
         switch (inst.opcode & INST_ALU_OP_MASK) {
@@ -220,7 +220,7 @@ struct Unmarshaller {
         }
     }
 
-    static auto getAtomicOp(const size_t pc, const ebpf_inst inst) -> Atomic::Op {
+    static auto getAtomicOp(const size_t pc, const EbpfInst inst) -> Atomic::Op {
         switch (const auto op = gsl::narrow<Atomic::Op>(inst.imm & ~INST_FETCH)) {
         case Atomic::Op::XCHG:
         case Atomic::Op::CMPXCHG:
@@ -239,7 +239,7 @@ struct Unmarshaller {
 
     static uint64_t zero_extend(const int32_t imm) { return uint64_t{to_unsigned(imm)}; }
 
-    static auto getBinValue(const pc_t pc, const ebpf_inst inst) -> Value {
+    static auto getBinValue(const Pc pc, const EbpfInst inst) -> Value {
         if (inst.opcode & INST_SRC_REG) {
             if (inst.imm != 0) {
                 throw InvalidInstruction(pc, make_opcode_message("nonzero imm for", inst.opcode));
@@ -276,7 +276,7 @@ struct Unmarshaller {
         }
     }
 
-    auto makeMemOp(const pc_t pc, const ebpf_inst inst) -> Instruction {
+    auto makeMemOp(const Pc pc, const EbpfInst inst) -> Instruction {
         if (inst.dst > R10_STACK_POINTER || inst.src > R10_STACK_POINTER) {
             throw InvalidInstruction(pc, "bad register");
         }
@@ -383,7 +383,7 @@ struct Unmarshaller {
         }
     }
 
-    auto makeAluOp(const size_t pc, const ebpf_inst inst) -> Instruction {
+    auto makeAluOp(const size_t pc, const EbpfInst inst) -> Instruction {
         const bool is64 = (inst.opcode & INST_CLS_MASK) == INST_CLS_ALU64;
         if (!info.platform->supports_group(is64 ? bpf_conformance_groups_t::base64
                                                 : bpf_conformance_groups_t::base32)) {
@@ -396,7 +396,7 @@ struct Unmarshaller {
             throw InvalidInstruction(pc, "bad register");
         }
         return std::visit(
-            overloaded{[&](const Un::Op op) -> Instruction { return Un{.op = op, .dst = Reg{inst.dst}, .is64 = is64}; },
+            Overloaded{[&](const Un::Op op) -> Instruction { return Un{.op = op, .dst = Reg{inst.dst}, .is64 = is64}; },
                        [&](const Bin::Op op) -> Instruction {
                            Bin res{
                                .op = op,
@@ -418,7 +418,7 @@ struct Unmarshaller {
     }
 
     [[nodiscard]]
-    auto makeLddw(const ebpf_inst inst, const int32_t next_imm, const vector<ebpf_inst>& insts, const pc_t pc) const
+    auto makeLddw(const EbpfInst inst, const int32_t next_imm, const vector<EbpfInst>& insts, const Pc pc) const
         -> Instruction {
         if (!info.platform->supports_group(bpf_conformance_groups_t::base64)) {
             throw InvalidInstruction{pc, inst.opcode};
@@ -426,7 +426,7 @@ struct Unmarshaller {
         if (pc >= insts.size() - 1) {
             throw InvalidInstruction(pc, "incomplete lddw");
         }
-        const ebpf_inst next = insts[pc + 1];
+        const EbpfInst next = insts[pc + 1];
         if (next.opcode != 0 || next.dst != 0 || next.src != 0 || next.offset != 0) {
             throw InvalidInstruction(pc, "invalid lddw");
         }
@@ -554,18 +554,18 @@ struct Unmarshaller {
     }
 
     /// Given a program counter and an offset, get the label of the target instruction.
-    static label_t getJumpTarget(const int32_t offset, const vector<ebpf_inst>& insts, const pc_t pc) {
-        const pc_t new_pc = pc + 1 + offset;
+    static Label getJumpTarget(const int32_t offset, const vector<EbpfInst>& insts, const Pc pc) {
+        const Pc new_pc = pc + 1 + offset;
         if (new_pc >= insts.size()) {
             throw InvalidInstruction(pc, "jump out of bounds");
         }
         if (insts[new_pc].opcode == 0) {
             throw InvalidInstruction(pc, "jump to middle of lddw");
         }
-        return label_t{gsl::narrow<int>(new_pc)};
+        return Label{gsl::narrow<int>(new_pc)};
     }
 
-    static auto makeCallLocal(const ebpf_inst inst, const vector<ebpf_inst>& insts, const pc_t pc) -> CallLocal {
+    static auto makeCallLocal(const EbpfInst inst, const vector<EbpfInst>& insts, const Pc pc) -> CallLocal {
         if (inst.opcode & INST_SRC_REG) {
             throw InvalidInstruction(pc, inst.opcode);
         }
@@ -575,7 +575,7 @@ struct Unmarshaller {
         return CallLocal{.target = getJumpTarget(inst.imm, insts, pc)};
     }
 
-    static auto makeCallx(const ebpf_inst inst, const pc_t pc) -> Callx {
+    static auto makeCallx(const EbpfInst inst, const Pc pc) -> Callx {
         // callx puts the register number in the 'dst' field rather than the 'src' field.
         if (inst.dst > R10_STACK_POINTER) {
             throw InvalidInstruction(pc, "bad register");
@@ -594,7 +594,7 @@ struct Unmarshaller {
     }
 
     [[nodiscard]]
-    auto makeJmp(const ebpf_inst inst, const vector<ebpf_inst>& insts, const pc_t pc) const -> Instruction {
+    auto makeJmp(const EbpfInst inst, const vector<EbpfInst>& insts, const Pc pc) const -> Instruction {
         switch ((inst.opcode >> 4) & 0xF) {
         case INST_CALL:
             if ((inst.opcode & INST_CLS_MASK) != INST_CLS_JMP) {
@@ -680,7 +680,7 @@ struct Unmarshaller {
             }
 
             const int32_t offset = (inst.opcode == INST_OP_JA32) ? inst.imm : inst.offset;
-            const label_t target = getJumpTarget(offset, insts, pc);
+            const Label target = getJumpTarget(offset, insts, pc);
             if (inst.opcode != INST_OP_JA16 && inst.opcode != INST_OP_JA32) {
                 if (inst.dst > R10_STACK_POINTER) {
                     throw InvalidInstruction(pc, "bad register");
@@ -702,14 +702,14 @@ struct Unmarshaller {
         }
     }
 
-    vector<LabeledInstruction> unmarshal(vector<ebpf_inst> const& insts) {
+    vector<LabeledInstruction> unmarshal(vector<EbpfInst> const& insts) {
         vector<LabeledInstruction> prog;
         int exit_count = 0;
         if (insts.empty()) {
             throw std::invalid_argument("Zero length programs are not allowed");
         }
         for (size_t pc = 0; pc < insts.size();) {
-            const ebpf_inst inst = insts[pc];
+            const EbpfInst inst = insts[pc];
             Instruction new_ins;
             bool skip_instruction = false;
             bool fallthrough = true;
@@ -735,7 +735,7 @@ struct Unmarshaller {
                 if (pc >= insts.size() - 1) {
                     break;
                 }
-                const ebpf_inst next = insts[pc + 1];
+                const EbpfInst next = insts[pc + 1];
                 auto dst = Reg{inst.dst};
 
                 if (new_ins != shift32(dst, Bin::Op::LSH)) {
@@ -783,7 +783,7 @@ struct Unmarshaller {
                 current_line_info = info.line_info.at(pc);
             }
 
-            prog.emplace_back(label_t(gsl::narrow<int>(pc)), new_ins, current_line_info);
+            prog.emplace_back(Label(gsl::narrow<int>(pc)), new_ins, current_line_info);
 
             pc++;
             note_next_pc();
@@ -799,7 +799,7 @@ struct Unmarshaller {
     }
 };
 
-std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog, vector<vector<string>>& notes) {
+std::variant<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog, vector<vector<string>>& notes) {
     thread_local_program_info = raw_prog.info;
     try {
         return Unmarshaller{notes, raw_prog.info}.unmarshal(raw_prog.prog);
@@ -810,14 +810,14 @@ std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog,
     }
 }
 
-std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog) {
+std::variant<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog) {
     vector<vector<string>> notes;
     return unmarshal(raw_prog, notes);
 }
 
 Call make_call(const int imm, const ebpf_platform_t& platform) {
     vector<vector<string>> notes;
-    const program_info info{.platform = &platform};
+    const ProgramInfo info{.platform = &platform};
     return Unmarshaller{notes, info}.makeCall(imm);
 }
 } // namespace prevail

--- a/src/asm_unmarshal.hpp
+++ b/src/asm_unmarshal.hpp
@@ -19,9 +19,9 @@ namespace prevail {
  *  \param[out] notes is a vector for storing errors and warnings.
  *  \return a sequence of instructions if successful, an error string otherwise.
  */
-std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog,
+std::variant<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog,
                                                     std::vector<std::vector<std::string>>& notes);
-std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog);
+std::variant<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog);
 
 Call make_call(int func, const ebpf_platform_t& platform);
 } // namespace prevail

--- a/src/assertions.cpp
+++ b/src/assertions.cpp
@@ -15,8 +15,8 @@ using std::vector;
 
 namespace prevail {
 class AssertExtractor {
-    program_info info;
-    std::optional<label_t> current_label; ///< Pre-simplification label this assert is part of.
+    ProgramInfo info;
+    std::optional<Label> current_label; ///< Pre-simplification label this assert is part of.
 
     static Imm imm(const Value& v) { return std::get<Imm>(v); }
 
@@ -34,7 +34,7 @@ class AssertExtractor {
     }
 
   public:
-    explicit AssertExtractor(program_info info, std::optional<label_t> label)
+    explicit AssertExtractor(ProgramInfo info, std::optional<Label> label)
         : info{std::move(info)}, current_label(label) {}
 
     vector<Assertion> operator()(const Undefined&) const {
@@ -303,7 +303,7 @@ class AssertExtractor {
 /// compare numbers and pointers, or pointers to potentially distinct memory
 /// regions. The verifier will use these assertions to treat the program as
 /// unsafe unless it can prove that the assertions can never fail.
-vector<Assertion> get_assertions(Instruction ins, const program_info& info, const std::optional<label_t>& label) {
+vector<Assertion> get_assertions(Instruction ins, const ProgramInfo& info, const std::optional<Label>& label) {
     return std::visit(AssertExtractor{info, label}, ins);
 }
 } // namespace prevail

--- a/src/cfg/cfg.hpp
+++ b/src/cfg/cfg.hpp
@@ -16,15 +16,15 @@
 namespace prevail {
 
 /// Control-Flow Graph
-class cfg_t final {
-    friend struct cfg_builder_t;
+class Cfg final {
+    friend struct CfgBuilder;
 
     // the choice to use set means that unmarshaling a conditional jump to the same target may be different
-    using label_vec_t = std::set<label_t>;
+    using LabelVec = std::set<Label>;
 
-    struct adjacent_t final {
-        label_vec_t parents;
-        label_vec_t children;
+    struct Adjacent final {
+        LabelVec parents;
+        LabelVec children;
 
         [[nodiscard]]
         size_t in_degree() const {
@@ -37,21 +37,21 @@ class cfg_t final {
         }
     };
 
-    std::map<label_t, adjacent_t> neighbours{{label_t::entry, adjacent_t{}}, {label_t::exit, adjacent_t{}}};
+    std::map<Label, Adjacent> neighbours{{Label::entry, Adjacent{}}, {Label::exit, Adjacent{}}};
 
     // Helpers
     [[nodiscard]]
-    bool has_one_child(const label_t& label) const {
+    bool has_one_child(const Label& label) const {
         return out_degree(label) == 1;
     }
 
     [[nodiscard]]
-    bool has_one_parent(const label_t& label) const {
+    bool has_one_parent(const Label& label) const {
         return in_degree(label) == 1;
     }
 
     [[nodiscard]]
-    adjacent_t& get_node(const label_t& _label) {
+    Adjacent& get_node(const Label& _label) {
         const auto it = neighbours.find(_label);
         if (it == neighbours.end()) {
             CRAB_ERROR("Label ", to_string(_label), " not found in the CFG: ");
@@ -60,7 +60,7 @@ class cfg_t final {
     }
 
     [[nodiscard]]
-    const adjacent_t& get_node(const label_t& _label) const {
+    const Adjacent& get_node(const Label& _label) const {
         const auto it = neighbours.find(_label);
         if (it == neighbours.end()) {
             CRAB_ERROR("Label ", to_string(_label), " not found in the CFG: ");
@@ -70,22 +70,22 @@ class cfg_t final {
 
   public:
     [[nodiscard]]
-    label_t exit_label() const {
-        return label_t::exit;
+    Label exit_label() const {
+        return Label::exit;
     }
 
     [[nodiscard]]
-    label_t entry_label() const {
-        return label_t::entry;
+    Label entry_label() const {
+        return Label::entry;
     }
 
     [[nodiscard]]
-    const label_vec_t& children_of(const label_t& _label) const {
+    const LabelVec& children_of(const Label& _label) const {
         return get_node(_label).children;
     }
 
     [[nodiscard]]
-    const label_vec_t& parents_of(const label_t& _label) const {
+    const LabelVec& parents_of(const Label& _label) const {
         return get_node(_label).parents;
     }
 
@@ -101,7 +101,7 @@ class cfg_t final {
     }
 
     [[nodiscard]]
-    label_t get_child(const label_t& label) const {
+    Label get_child(const Label& label) const {
         if (!has_one_child(label)) {
             CRAB_ERROR("Label ", to_string(label), " does not have a single child");
         }
@@ -109,7 +109,7 @@ class cfg_t final {
     }
 
     [[nodiscard]]
-    label_t get_parent(const label_t& label) const {
+    Label get_parent(const Label& label) const {
         if (!has_one_parent(label)) {
             CRAB_ERROR("Label ", to_string(label), " does not have a single parent");
         }
@@ -117,48 +117,48 @@ class cfg_t final {
     }
 
     [[nodiscard]]
-    bool contains(const label_t& label) const {
+    bool contains(const Label& label) const {
         return neighbours.contains(label);
     }
 
     [[nodiscard]]
-    int num_siblings(const label_t& label) const {
+    int num_siblings(const Label& label) const {
         return get_node(get_parent(label)).out_degree();
     }
 
     [[nodiscard]]
-    int in_degree(const label_t& label) const {
+    int in_degree(const Label& label) const {
         return get_node(label).in_degree();
     }
 
     [[nodiscard]]
-    int out_degree(const label_t& label) const {
+    int out_degree(const Label& label) const {
         return get_node(label).out_degree();
     }
 };
 
-class basic_block_t final {
-    using stmt_list_t = std::vector<label_t>;
-    using const_iterator = stmt_list_t::const_iterator;
+class BasicBlock final {
+    using StmtList = std::vector<Label>;
+    using const_iterator = StmtList::const_iterator;
 
-    stmt_list_t m_ts;
+    StmtList m_ts;
 
   public:
-    std::strong_ordering operator<=>(const basic_block_t& other) const { return first_label() <=> other.first_label(); }
+    std::strong_ordering operator<=>(const BasicBlock& other) const { return first_label() <=> other.first_label(); }
 
-    static std::set<basic_block_t> collect_basic_blocks(const cfg_t& cfg, bool simplify);
+    static std::set<BasicBlock> collect_basic_blocks(const Cfg& cfg, bool simplify);
 
-    explicit basic_block_t(const label_t& first_label) : m_ts{first_label} {}
-    basic_block_t(basic_block_t&&) noexcept = default;
-    basic_block_t(const basic_block_t&) = default;
+    explicit BasicBlock(const Label& first_label) : m_ts{first_label} {}
+    BasicBlock(BasicBlock&&) noexcept = default;
+    BasicBlock(const BasicBlock&) = default;
 
     [[nodiscard]]
-    label_t first_label() const {
+    Label first_label() const {
         return m_ts.front();
     }
 
     [[nodiscard]]
-    label_t last_label() const {
+    Label last_label() const {
         return m_ts.back();
     }
 
@@ -177,6 +177,6 @@ class basic_block_t final {
     }
 };
 
-cfg_t cfg_from_adjacency_list(const std::map<label_t, std::vector<label_t>>& adj_list);
+Cfg cfg_from_adjacency_list(const std::map<Label, std::vector<Label>>& AdjList);
 
 } // end namespace prevail

--- a/src/cfg/label.hpp
+++ b/src/cfg/label.hpp
@@ -16,27 +16,27 @@ namespace prevail {
 
 constexpr char STACK_FRAME_DELIMITER = '/';
 
-struct label_t {
+struct Label {
     std::string stack_frame_prefix; ///< Variable prefix when calling this label.
     int from{};                     ///< Jump source, or simply index of instruction
     int to{};                       ///< Jump target or -1
     std::string special_label;      ///< Special label for special instructions.
 
-    explicit label_t(const int index, const int to = -1, std::string stack_frame_prefix = {}) noexcept
+    explicit Label(const int index, const int to = -1, std::string stack_frame_prefix = {}) noexcept
         : stack_frame_prefix(std::move(stack_frame_prefix)), from(index), to(to) {}
 
-    static label_t make_jump(const label_t& src_label, const label_t& target_label) {
-        return label_t{src_label.from, target_label.from, target_label.stack_frame_prefix};
+    static Label make_jump(const Label& src_label, const Label& target_label) {
+        return Label{src_label.from, target_label.from, target_label.stack_frame_prefix};
     }
 
-    static label_t make_increment_counter(const label_t& label) {
+    static Label make_increment_counter(const Label& label) {
         // XXX: This is a hack to increment the loop counter.
-        label_t res{label.from, label.to, label.stack_frame_prefix};
+        Label res{label.from, label.to, label.stack_frame_prefix};
         res.special_label = "counter";
         return res;
     }
 
-    std::strong_ordering operator<=>(const label_t& other) const = default;
+    std::strong_ordering operator<=>(const Label& other) const = default;
 
     // no hash; intended for use in ordered containers.
 
@@ -56,22 +56,22 @@ struct label_t {
         return gsl::narrow<int>(2 + std::ranges::count(stack_frame_prefix, STACK_FRAME_DELIMITER));
     }
 
-    static const label_t entry;
-    static const label_t exit;
+    static const Label entry;
+    static const Label exit;
 };
 
-inline const label_t label_t::entry{-1};
-inline const label_t label_t::exit{INT_MAX};
+inline const Label Label::entry{-1};
+inline const Label Label::exit{INT_MAX};
 
-std::ostream& operator<<(std::ostream& os, const label_t& label);
-std::string to_string(label_t const& label);
+std::ostream& operator<<(std::ostream& os, const Label& label);
+std::string to_string(Label const& label);
 
 // cpu=v4 supports 32-bit PC offsets so we need a large enough type.
-using pc_t = uint32_t;
+using Pc = uint32_t;
 
 // We use a 16-bit offset whenever it fits in 16 bits.
-inline std::function<int16_t(label_t)> label_to_offset16(const pc_t pc) {
-    return [=](const label_t& label) {
+inline std::function<int16_t(Label)> label_to_offset16(const Pc pc) {
+    return [=](const Label& label) {
         const int64_t offset = label.from - gsl::narrow<int64_t>(pc) - 1;
         const bool is16 =
             std::numeric_limits<int16_t>::min() <= offset && offset <= std::numeric_limits<int16_t>::max();
@@ -81,8 +81,8 @@ inline std::function<int16_t(label_t)> label_to_offset16(const pc_t pc) {
 
 // We use the JA32 opcode with the offset in 'imm' when the offset
 // of an unconditional jump doesn't fit in an int16_t.
-inline std::function<int32_t(label_t)> label_to_offset32(const pc_t pc) {
-    return [=](const label_t& label) {
+inline std::function<int32_t(Label)> label_to_offset32(const Pc pc) {
+    return [=](const Label& label) {
         const int64_t offset = label.from - gsl::narrow<int64_t>(pc) - 1;
         const bool is16 =
             std::numeric_limits<int16_t>::min() <= offset && offset <= std::numeric_limits<int16_t>::max();

--- a/src/cfg/wto.hpp
+++ b/src/cfg/wto.hpp
@@ -17,9 +17,9 @@
 //   1 --> 2 --------> 8
 //
 // results in the WTO: 1 2 (3 4 (5 6) 7) 8
-// where a single vertex is represented via label_t, and a
+// where a single vertex is represented via Label, and a
 // cycle such as (5 6) is represented via a wto_cycle_t.
-// Each arrow points to a cycle_or_label, which can be either a
+// Each arrow points to a CycleOrLabel, which can be either a
 // single vertex such as 8, or a cycle such as (5 6).
 
 #include <memory>
@@ -38,101 +38,101 @@ namespace prevail {
 // uses the notation w(c) to refer to the set of heads of the nested components
 // containing a vertex c.  This class holds such a set of heads.  The table
 // mapping c to w(c) is stored outside the class, in wto_collector_t._nesting.
-class wto_nesting_t final {
+class WtoNesting final {
     // To optimize insertion performance, the list of heads is stored in reverse
     // order, i.e., from innermost to outermost cycle.
-    std::vector<label_t> _heads;
+    std::vector<Label> _heads;
 
-    friend class print_visitor;
+    friend class PrintVisitor;
 
   public:
-    explicit wto_nesting_t(std::vector<label_t>&& heads) : _heads(std::move(heads)) {}
+    explicit WtoNesting(std::vector<Label>&& heads) : _heads(std::move(heads)) {}
 
     // Test whether this nesting is a longer subset of another nesting.
-    bool operator>(const wto_nesting_t& nesting) const;
+    bool operator>(const WtoNesting& nesting) const;
 };
 
 // Define types used by both this header file and wto_cycle.hpp
-using cycle_or_label = std::variant<std::shared_ptr<class wto_cycle_t>, label_t>;
-using wto_partition_t = std::vector<cycle_or_label>;
+using CycleOrLabel = std::variant<std::shared_ptr<class WtoCycle>, Label>;
+using WtoPartition = std::vector<CycleOrLabel>;
 
 // Bourdoncle, "Efficient chaotic iteration strategies with widenings", 1993
-// section 3 uses the term "nested component" to refer to what wto_cycle_t implements.
-class wto_cycle_t final {
+// section 3 uses the term "nested component" to refer to what WtoCycle implements.
+class WtoCycle final {
     // List of subcomponents (i.e., vertices or other cycles) contained in this cycle.
-    wto_partition_t _components;
+    WtoPartition _components;
 
     // The cycle containing this cycle, or null if there is no parent cycle.
-    std::weak_ptr<wto_cycle_t> _containing_cycle;
+    std::weak_ptr<WtoCycle> _containing_cycle;
 
-    friend class wto_t;
-    friend class wto_builder_t;
+    friend class Wto;
+    friend class WtoBuilder;
 
   public:
-    explicit wto_cycle_t(const std::weak_ptr<wto_cycle_t>& containing_cycle) : _containing_cycle(containing_cycle) {}
+    explicit WtoCycle(const std::weak_ptr<WtoCycle>& containing_cycle) : _containing_cycle(containing_cycle) {}
 
     // Get a vertex of an entry point of the cycle.
     [[nodiscard]]
-    const label_t& head() const {
+    const Label& head() const {
         // Any cycle must start with a vertex, not another cycle,
         // per Definition 1 in the paper.  Since the vector is in reverse
         // order, the head is the last element.
         if (_components.empty()) {
             CRAB_ERROR("Empty cycle");
         }
-        if (const auto label = std::get_if<label_t>(&_components.back())) {
+        if (const auto label = std::get_if<Label>(&_components.back())) {
             return *label;
         }
-        CRAB_ERROR("Expected label_t at the back of _components");
+        CRAB_ERROR("Expected Label at the back of _components");
     }
 
     [[nodiscard]]
-    wto_partition_t::const_reverse_iterator begin() const {
+    WtoPartition::const_reverse_iterator begin() const {
         return _components.crbegin();
     }
 
     [[nodiscard]]
-    wto_partition_t::const_reverse_iterator end() const {
+    WtoPartition::const_reverse_iterator end() const {
         return _components.crend();
     }
 };
 
 // Check if node is a member of the wto component.
-bool is_component_member(const label_t& label, const cycle_or_label& component);
+bool is_component_member(const Label& label, const CycleOrLabel& component);
 
-class wto_t final {
+class Wto final {
     // Top level components, in reverse order.
-    wto_partition_t _components;
+    WtoPartition _components;
 
     // Table mapping label to the cycle containing the label.
-    std::map<label_t, std::weak_ptr<wto_cycle_t>> _containing_cycle;
+    std::map<Label, std::weak_ptr<WtoCycle>> _containing_cycle;
 
     // Table mapping label to the list of heads of cycles containing the label.
     // This is an on-demand cache, since for most vertices the nesting is never
-    // looked at so we only create a wto_nesting_t for cases we actually need it.
-    mutable std::map<label_t, wto_nesting_t> _nesting;
+    // looked at so we only create a WtoNesting for cases we actually need it.
+    mutable std::map<Label, WtoNesting> _nesting;
 
-    std::vector<label_t> collect_heads(const label_t& label) const;
-    std::optional<label_t> head(const label_t& label) const;
+    std::vector<Label> collect_heads(const Label& label) const;
+    std::optional<Label> head(const Label& label) const;
 
-    wto_t() = default;
-    friend class wto_builder_t;
+    Wto() = default;
+    friend class WtoBuilder;
 
   public:
-    explicit wto_t(const cfg_t& cfg);
+    explicit Wto(const Cfg& cfg);
 
     [[nodiscard]]
-    wto_partition_t::const_reverse_iterator begin() const {
+    WtoPartition::const_reverse_iterator begin() const {
         return _components.crbegin();
     }
 
     [[nodiscard]]
-    wto_partition_t::const_reverse_iterator end() const {
+    WtoPartition::const_reverse_iterator end() const {
         return _components.crend();
     }
 
-    friend std::ostream& operator<<(std::ostream& o, const wto_t& wto);
-    const wto_nesting_t& nesting(const label_t& label) const;
+    friend std::ostream& operator<<(std::ostream& o, const Wto& wto);
+    const WtoNesting& nesting(const Label& label) const;
 
     /**
      * Visit the heads of all loops in the WTO.
@@ -143,7 +143,7 @@ class wto_t final {
      */
     void for_each_loop_head(auto&& f) const {
         for (const auto& component : *this) {
-            if (const auto pc = std::get_if<std::shared_ptr<wto_cycle_t>>(&component)) {
+            if (const auto pc = std::get_if<std::shared_ptr<WtoCycle>>(&component)) {
                 f((*pc)->head());
             }
         }

--- a/src/crab/add_bottom.hpp
+++ b/src/crab/add_bottom.hpp
@@ -127,7 +127,7 @@ class AddBottom final {
     }
 
     [[nodiscard]]
-    AddBottom when(const linear_constraint_t& cst) const {
+    AddBottom when(const LinearConstraint& cst) const {
         if (dom) {
             AddBottom result(*dom);
             if (!result.dom->add_constraint(cst)) {
@@ -138,13 +138,13 @@ class AddBottom final {
         return bottom();
     }
 
-    void havoc(variable_t v) {
+    void havoc(Variable v) {
         if (dom) {
             dom->havoc(v);
         }
     }
 
-    void add_constraint(const linear_constraint_t& cst) {
+    void add_constraint(const LinearConstraint& cst) {
         if (dom) {
             if (!dom->add_constraint(cst)) {
                 dom = {};
@@ -153,14 +153,14 @@ class AddBottom final {
     }
 
     [[nodiscard]]
-    interval_t eval_interval(const linear_expression_t& e) const {
+    Interval eval_interval(const LinearExpression& e) const {
         if (dom) {
             return dom->eval_interval(e);
         }
-        return interval_t::bottom();
+        return Interval::bottom();
     }
 
-    void set(variable_t x, const interval_t& intv) {
+    void set(Variable x, const Interval& intv) {
         if (intv.is_bottom()) {
             dom = {};
         } else if (dom) {
@@ -168,14 +168,14 @@ class AddBottom final {
         }
     }
 
-    void assign(const std::optional<variable_t> x, const linear_expression_t& e) {
+    void assign(const std::optional<Variable> x, const LinearExpression& e) {
         if (x) {
             assign(*x, e);
         }
     }
 
     template <typename V>
-    void assign(variable_t x, const V& value) {
+    void assign(Variable x, const V& value) {
         if (dom) {
             // XXX: maybe needs to return false when becomes bottom
             // is this possible?
@@ -184,7 +184,7 @@ class AddBottom final {
     }
 
     template <typename Op, typename Left, typename Right>
-    void apply(Op op, variable_t x, const Left& left, const Right& right, int finite_width) {
+    void apply(Op op, Variable x, const Left& left, const Right& right, int finite_width) {
         if (dom) {
             dom->apply(op, x, left, right, finite_width);
         }
@@ -192,7 +192,7 @@ class AddBottom final {
 
     // Return true if inv intersects with cst.
     [[nodiscard]]
-    bool intersect(const linear_constraint_t& cst) const {
+    bool intersect(const LinearConstraint& cst) const {
         if (dom) {
             return dom->intersect(cst);
         }
@@ -201,7 +201,7 @@ class AddBottom final {
 
     // Return true if entails rhs.
     [[nodiscard]]
-    bool entail(const linear_constraint_t& cst) const {
+    bool entail(const LinearConstraint& cst) const {
         if (dom) {
             return dom->entail(cst);
         }
@@ -216,11 +216,11 @@ class AddBottom final {
     }
 
     [[nodiscard]]
-    string_invariant to_set() const {
+    StringInvariant to_set() const {
         if (dom) {
             return dom->to_set();
         }
-        return string_invariant::bottom();
+        return StringInvariant::bottom();
     }
 }; // class AddBottom
 

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -20,13 +20,13 @@
 
 namespace prevail {
 
-using index_t = uint64_t;
+using Index = uint64_t;
 
-static bool maybe_between(const NumAbsDomain& dom, const extended_number& x, const linear_expression_t& symb_lb,
-                          const linear_expression_t& symb_ub) {
+static bool maybe_between(const NumAbsDomain& dom, const ExtendedNumber& x, const LinearExpression& symb_lb,
+                          const LinearExpression& symb_ub) {
     using namespace dsl_syntax;
     assert(x.is_finite());
-    const linear_expression_t num(*x.number());
+    const LinearExpression num(*x.number());
     NumAbsDomain tmp(dom);
     tmp.add_constraint(num >= symb_lb);
     tmp.add_constraint(num <= symb_ub);
@@ -34,22 +34,22 @@ static bool maybe_between(const NumAbsDomain& dom, const extended_number& x, con
 }
 
 class offset_t final {
-    index_t _index{};
+    Index _index{};
     int _prefix_length;
 
   public:
-    static constexpr int bitsize = 8 * sizeof(index_t);
+    static constexpr int bitsize = 8 * sizeof(Index);
     offset_t() : _prefix_length(bitsize) {}
-    explicit offset_t(const index_t index) : _index(index), _prefix_length(bitsize) {}
-    offset_t(const index_t index, const int prefix_length) : _index(index), _prefix_length(prefix_length) {}
+    explicit offset_t(const Index index) : _index(index), _prefix_length(bitsize) {}
+    offset_t(const Index index, const int prefix_length) : _index(index), _prefix_length(prefix_length) {}
     explicit operator int() const { return gsl::narrow<int>(_index); }
-    operator index_t() const { return _index; }
+    operator Index() const { return _index; }
     [[nodiscard]]
     int prefix_length() const {
         return _prefix_length;
     }
 
-    index_t operator[](const int n) const { return (_index >> (bitsize - 1 - n)) & 1; }
+    Index operator[](const int n) const { return (_index >> (bitsize - 1 - n)) & 1; }
 };
 
 // NOTE: required by radix_tree
@@ -63,18 +63,18 @@ int radix_length(const offset_t& offset) {
 // Get a range of bits out of the middle of a key, starting at [begin] for a given length.
 [[maybe_unused]]
 offset_t radix_substr(const offset_t& key, const int begin, const int length) {
-    index_t mask;
+    Index mask;
 
     if (length == offset_t::bitsize) {
         mask = 0;
     } else {
-        mask = index_t{1} << length;
+        mask = Index{1} << length;
     }
 
     mask -= 1;
     mask <<= offset_t::bitsize - length - begin;
 
-    const index_t value = (gsl::narrow_cast<index_t>(key) & mask) << begin;
+    const Index value = (gsl::narrow_cast<Index>(key) & mask) << begin;
     return offset_t{value, length};
 }
 
@@ -82,7 +82,7 @@ offset_t radix_substr(const offset_t& key, const int begin, const int length) {
 // Concatenate two bit patterns.
 [[maybe_unused]]
 offset_t radix_join(const offset_t& entry1, const offset_t& entry2) {
-    const index_t value = entry1 | (entry2 >> entry1.prefix_length());
+    const Index value = entry1 | (entry2 >> entry1.prefix_length());
     const int prefix_length = entry1.prefix_length() + entry2.prefix_length();
     return offset_t{value, prefix_length};
 }
@@ -97,7 +97,7 @@ _scalar = array[_offset, _offset + 1, ..., _offset + _size - 1]
     Only, offset_map objects can create cells. They will consider the
             array when generating the scalar variable.
 */
-class cell_t final {
+class Cell final {
   private:
     friend class offset_map_t;
 
@@ -105,18 +105,18 @@ class cell_t final {
     unsigned _size{};
 
     // Only offset_map_t can create cells
-    cell_t() = default;
+    Cell() = default;
 
-    cell_t(const offset_t offset, const unsigned size) : _offset(offset), _size(size) {}
+    Cell(const offset_t offset, const unsigned size) : _offset(offset), _size(size) {}
 
-    static interval_t to_interval(const offset_t o, const unsigned size) {
-        const number_t lb{gsl::narrow<int>(o)};
+    static Interval to_interval(const offset_t o, const unsigned size) {
+        const Number lb{gsl::narrow<int>(o)};
         return {lb, lb + size - 1};
     }
 
   public:
     [[nodiscard]]
-    interval_t to_interval() const {
+    Interval to_interval() const {
         return to_interval(_offset, _size);
     }
 
@@ -131,15 +131,15 @@ class cell_t final {
     }
 
     [[nodiscard]]
-    variable_t get_scalar(const data_kind_t kind) const {
-        return variable_t::cell_var(kind, gsl::narrow<index_t>(_offset), _size);
+    Variable get_scalar(const DataKind kind) const {
+        return Variable::cell_var(kind, gsl::narrow<Index>(_offset), _size);
     }
 
     // ignore the scalar variable
-    bool operator==(const cell_t& o) const { return to_interval() == o.to_interval(); }
+    bool operator==(const Cell& o) const { return to_interval() == o.to_interval(); }
 
     // ignore the scalar variable
-    bool operator<(const cell_t& o) const {
+    bool operator<(const Cell& o) const {
         if (_offset == o._offset) {
             return _size < o._size;
         }
@@ -150,8 +150,8 @@ class cell_t final {
     // where o is a constant expression.
     [[nodiscard]]
     bool overlap(const offset_t& o, const unsigned size) const {
-        const interval_t x = to_interval();
-        const interval_t y = to_interval(o, size);
+        const Interval x = to_interval();
+        const Interval y = to_interval(o, size);
         const bool res = (!(x & y).is_bottom());
         CRAB_LOG("array-expansion-overlap",
                  std::cout << "**Checking if " << x << " overlaps with " << y << "=" << res << "\n";);
@@ -161,26 +161,26 @@ class cell_t final {
     // Return true if [symb_lb, symb_ub] may overlap with the cell,
     // where symb_lb and symb_ub are not constant expressions.
     [[nodiscard]]
-    bool symbolic_overlap(const linear_expression_t& symb_lb, const linear_expression_t& symb_ub,
+    bool symbolic_overlap(const LinearExpression& symb_lb, const LinearExpression& symb_ub,
                           const NumAbsDomain& dom) const;
 
-    friend std::ostream& operator<<(std::ostream& o, const cell_t& c) { return o << "cell(" << c.to_interval() << ")"; }
+    friend std::ostream& operator<<(std::ostream& o, const Cell& c) { return o << "cell(" << c.to_interval() << ")"; }
 };
 
 // Return true if [symb_lb, symb_ub] may overlap with the cell,
 // where symb_lb and symb_ub are not constant expressions.
-bool cell_t::symbolic_overlap(const linear_expression_t& symb_lb, const linear_expression_t& symb_ub,
-                              const NumAbsDomain& dom) const {
-    const interval_t x = to_interval();
+bool Cell::symbolic_overlap(const LinearExpression& symb_lb, const LinearExpression& symb_ub,
+                            const NumAbsDomain& dom) const {
+    const Interval x = to_interval();
     return maybe_between(dom, x.lb(), symb_lb, symb_ub) || maybe_between(dom, x.ub(), symb_lb, symb_ub);
 }
 
 // Map offsets to cells
 class offset_map_t final {
   private:
-    friend class array_domain_t;
+    friend class ArrayDomain;
 
-    using cell_set_t = std::set<cell_t>;
+    using cell_set_t = std::set<Cell>;
 
     /*
       The keys in the patricia tree are processing in big-endian order. This means that the keys are sorted.
@@ -188,27 +188,27 @@ class offset_map_t final {
       Since keys are treated as bit patterns, negative offsets can be used, but they are treated as large unsigned
       numbers.
     */
-    using patricia_tree_t = radix_tree<offset_t, cell_set_t>;
+    using PatriciaTree = radix_tree<offset_t, cell_set_t>;
 
-    patricia_tree_t _map;
+    PatriciaTree _map;
 
     // for algorithm::lower_bound and algorithm::upper_bound
-    struct compare_binding_t {
-        bool operator()(const patricia_tree_t::value_type& kv, const offset_t& o) const { return kv.first < o; }
-        bool operator()(const offset_t& o, const patricia_tree_t::value_type& kv) const { return o < kv.first; }
-        bool operator()(const patricia_tree_t::value_type& kv1, const patricia_tree_t::value_type& kv2) const {
+    struct CompareBinding {
+        bool operator()(const PatriciaTree::value_type& kv, const offset_t& o) const { return kv.first < o; }
+        bool operator()(const offset_t& o, const PatriciaTree::value_type& kv) const { return o < kv.first; }
+        bool operator()(const PatriciaTree::value_type& kv1, const PatriciaTree::value_type& kv2) const {
             return kv1.first < kv2.first;
         }
     };
 
-    void remove_cell(const cell_t& c);
+    void remove_cell(const Cell& c);
 
-    void insert_cell(const cell_t& c);
+    void insert_cell(const Cell& c);
 
     [[nodiscard]]
-    std::optional<cell_t> get_cell(offset_t o, unsigned size);
+    std::optional<Cell> get_cell(offset_t o, unsigned size);
 
-    cell_t mk_cell(offset_t o, unsigned size);
+    Cell mk_cell(offset_t o, unsigned size);
 
   public:
     offset_map_t() = default;
@@ -223,20 +223,20 @@ class offset_map_t final {
         return _map.size();
     }
 
-    void operator-=(const cell_t& c) { remove_cell(c); }
+    void operator-=(const Cell& c) { remove_cell(c); }
 
-    void operator-=(const std::vector<cell_t>& cells) {
+    void operator-=(const std::vector<Cell>& cells) {
         for (const auto& c : cells) {
             this->operator-=(c);
         }
     }
 
     // Return in out all cells that might overlap with (o, size).
-    std::vector<cell_t> get_overlap_cells(offset_t o, unsigned size);
+    std::vector<Cell> get_overlap_cells(offset_t o, unsigned size);
 
     [[nodiscard]]
-    std::vector<cell_t> get_overlap_cells_symbolic_offset(const NumAbsDomain& dom, const linear_expression_t& symb_lb,
-                                                          const linear_expression_t& symb_ub);
+    std::vector<Cell> get_overlap_cells_symbolic_offset(const NumAbsDomain& dom, const LinearExpression& symb_lb,
+                                                        const LinearExpression& symb_ub);
 
     friend std::ostream& operator<<(std::ostream& o, offset_map_t& m);
 
@@ -260,16 +260,16 @@ class offset_map_t final {
     static offset_map_t top() { return offset_map_t(); }
 };
 
-void offset_map_t::remove_cell(const cell_t& c) {
+void offset_map_t::remove_cell(const Cell& c) {
     const offset_t key = c.get_offset();
     _map[key].erase(c);
 }
 
 [[nodiscard]]
-std::vector<cell_t> offset_map_t::get_overlap_cells_symbolic_offset(const NumAbsDomain& dom,
-                                                                    const linear_expression_t& symb_lb,
-                                                                    const linear_expression_t& symb_ub) {
-    std::vector<cell_t> out;
+std::vector<Cell> offset_map_t::get_overlap_cells_symbolic_offset(const NumAbsDomain& dom,
+                                                                  const LinearExpression& symb_lb,
+                                                                  const LinearExpression& symb_ub) {
+    std::vector<Cell> out;
     for (const auto& [_offset, o_cells] : _map) {
         // All cells in o_cells have the same offset. They only differ in the size.
         // If the largest cell overlaps with [offset, offset + size)
@@ -277,8 +277,8 @@ std::vector<cell_t> offset_map_t::get_overlap_cells_symbolic_offset(const NumAbs
         // This is an over-approximation because [offset, offset+size) can overlap
         // with the largest cell, but it doesn't necessarily overlap with smaller cells.
         // For efficiency, we assume it overlaps with all.
-        cell_t largest_cell;
-        for (const cell_t& c : o_cells) {
+        Cell largest_cell;
+        for (const Cell& c : o_cells) {
             if (largest_cell.is_null()) {
                 largest_cell = c;
             } else {
@@ -299,18 +299,18 @@ std::vector<cell_t> offset_map_t::get_overlap_cells_symbolic_offset(const NumAbs
     return out;
 }
 
-void offset_map_t::insert_cell(const cell_t& c) { _map[c.get_offset()].insert(c); }
+void offset_map_t::insert_cell(const Cell& c) { _map[c.get_offset()].insert(c); }
 
-std::optional<cell_t> offset_map_t::get_cell(const offset_t o, const unsigned size) {
+std::optional<Cell> offset_map_t::get_cell(const offset_t o, const unsigned size) {
     cell_set_t& cells = _map[o];
-    const auto it = cells.find(cell_t(o, size));
+    const auto it = cells.find(Cell(o, size));
     if (it != cells.end()) {
         return *it;
     }
     return {};
 }
 
-cell_t offset_map_t::mk_cell(const offset_t o, const unsigned size) {
+Cell offset_map_t::mk_cell(const offset_t o, const unsigned size) {
     // TODO: check array is the array associated to this offset map
 
     if (const auto maybe_c = get_cell(o, size)) {
@@ -318,20 +318,20 @@ cell_t offset_map_t::mk_cell(const offset_t o, const unsigned size) {
     }
     // create a new scalar variable for representing the contents
     // of bytes array[o,o+1,..., o+size-1]
-    const cell_t c(o, size);
+    const Cell c(o, size);
     insert_cell(c);
     return c;
 }
 
 // Return all cells that might overlap with (o, size).
-std::vector<cell_t> offset_map_t::get_overlap_cells(const offset_t o, const unsigned size) {
-    std::vector<cell_t> out;
-    constexpr compare_binding_t comp;
+std::vector<Cell> offset_map_t::get_overlap_cells(const offset_t o, const unsigned size) {
+    std::vector<Cell> out;
+    constexpr CompareBinding comp;
 
     bool added = false;
     auto maybe_c = get_cell(o, size);
     if (!maybe_c) {
-        maybe_c = cell_t(o, size);
+        maybe_c = Cell(o, size);
         insert_cell(*maybe_c);
         added = true;
     }
@@ -358,7 +358,7 @@ std::vector<cell_t> offset_map_t::get_overlap_cells(const offset_t o, const unsi
             // we can stop.
             ////////
             bool continue_outer_loop = false;
-            for (const cell_t& x : upto_lb[i]) {
+            for (const Cell& x : upto_lb[i]) {
                 if (x.overlap(o, size)) {
                     if (x != *maybe_c) {
                         // FIXME: we might have some duplicates. this is a very drastic solution.
@@ -379,7 +379,7 @@ std::vector<cell_t> offset_map_t::get_overlap_cells(const offset_t o, const unsi
     auto ub_it = std::upper_bound(_map.begin(), _map.end(), o, comp);
     for (; ub_it != _map.end(); ++ub_it) {
         bool continue_outer_loop = false;
-        for (const cell_t& x : ub_it->second) {
+        for (const Cell& x : ub_it->second) {
             if (x.overlap(o, size)) {
                 // FIXME: we might have some duplicates. this is a very drastic solution.
                 if (std::ranges::find(out, x) == out.end()) {
@@ -396,7 +396,7 @@ std::vector<cell_t> offset_map_t::get_overlap_cells(const offset_t o, const unsi
     // do not forget the rest of overlapping cells == o
     for (auto it = ++lb_it, et = ub_it; it != et; ++it) {
         bool continue_outer_loop = false;
-        for (const cell_t& x : it->second) {
+        for (const Cell& x : it->second) {
             if (x == *maybe_c) { // we don't put it in out
                 continue;
             }
@@ -419,17 +419,17 @@ std::vector<cell_t> offset_map_t::get_overlap_cells(const offset_t o, const unsi
 }
 
 // We use a global array map
-using array_map_t = std::unordered_map<data_kind_t, offset_map_t>;
+using array_map_t = std::unordered_map<DataKind, offset_map_t>;
 
-static thread_local lazy_allocator<array_map_t> thread_local_array_map;
+static thread_local LazyAllocator<array_map_t> thread_local_array_map;
 
 void clear_thread_local_state() { thread_local_array_map.clear(); }
 
-static offset_map_t& lookup_array_map(const data_kind_t kind) { return (*thread_local_array_map)[kind]; }
+static offset_map_t& lookup_array_map(const DataKind kind) { return (*thread_local_array_map)[kind]; }
 
-void array_domain_t::initialize_numbers(const int lb, const int width) {
+void ArrayDomain::initialize_numbers(const int lb, const int width) {
     num_bytes.reset(lb, width);
-    lookup_array_map(data_kind_t::svalues).mk_cell(offset_t{gsl::narrow_cast<index_t>(lb)}, width);
+    lookup_array_map(DataKind::svalues).mk_cell(offset_t{gsl::narrow_cast<Index>(lb)}, width);
 }
 
 std::ostream& operator<<(std::ostream& o, offset_map_t& m) {
@@ -452,45 +452,45 @@ std::ostream& operator<<(std::ostream& o, offset_map_t& m) {
 }
 
 // Create a new cell that is a subset of an existing cell.
-void array_domain_t::split_cell(NumAbsDomain& inv, const data_kind_t kind, const int cell_start_index,
-                                const unsigned int len) const {
-    assert(kind == data_kind_t::svalues || kind == data_kind_t::uvalues);
+void ArrayDomain::split_cell(NumAbsDomain& inv, const DataKind kind, const int cell_start_index,
+                             const unsigned int len) const {
+    assert(kind == DataKind::svalues || kind == DataKind::uvalues);
 
     // Get the values from the indicated stack range.
-    const std::optional<linear_expression_t> svalue = load(inv, data_kind_t::svalues, number_t(cell_start_index), len);
-    const std::optional<linear_expression_t> uvalue = load(inv, data_kind_t::uvalues, number_t(cell_start_index), len);
+    const std::optional<LinearExpression> svalue = load(inv, DataKind::svalues, Number(cell_start_index), len);
+    const std::optional<LinearExpression> uvalue = load(inv, DataKind::uvalues, Number(cell_start_index), len);
 
     // Create a new cell for that range.
     offset_map_t& offset_map = lookup_array_map(kind);
-    const cell_t new_cell = offset_map.mk_cell(offset_t{gsl::narrow_cast<index_t>(cell_start_index)}, len);
-    inv.assign(new_cell.get_scalar(data_kind_t::svalues), svalue);
-    inv.assign(new_cell.get_scalar(data_kind_t::uvalues), uvalue);
+    const Cell new_cell = offset_map.mk_cell(offset_t{gsl::narrow_cast<Index>(cell_start_index)}, len);
+    inv.assign(new_cell.get_scalar(DataKind::svalues), svalue);
+    inv.assign(new_cell.get_scalar(DataKind::uvalues), uvalue);
 }
 
 // Prepare to havoc bytes in the middle of a cell by potentially splitting the cell if it is numeric,
 // into the part to the left of the havoced portion, and the part to the right of the havoced portion.
-void array_domain_t::split_number_var(NumAbsDomain& inv, data_kind_t kind, const linear_expression_t& i,
-                                      const linear_expression_t& elem_size) const {
-    assert(kind == data_kind_t::svalues || kind == data_kind_t::uvalues);
+void ArrayDomain::split_number_var(NumAbsDomain& inv, DataKind kind, const LinearExpression& i,
+                                   const LinearExpression& elem_size) const {
+    assert(kind == DataKind::svalues || kind == DataKind::uvalues);
     offset_map_t& offset_map = lookup_array_map(kind);
-    interval_t ii = inv.eval_interval(i);
-    std::optional<number_t> n = ii.singleton();
+    Interval ii = inv.eval_interval(i);
+    std::optional<Number> n = ii.singleton();
     if (!n) {
         // We can only split a singleton offset.
         return;
     }
-    interval_t i_elem_size = inv.eval_interval(elem_size);
-    std::optional<number_t> n_bytes = i_elem_size.singleton();
+    Interval i_elem_size = inv.eval_interval(elem_size);
+    std::optional<Number> n_bytes = i_elem_size.singleton();
     if (!n_bytes) {
         // We can only split a singleton size.
         return;
     }
     auto size = n_bytes->narrow<unsigned int>();
-    offset_t o(n->narrow<index_t>());
+    offset_t o(n->narrow<Index>());
 
-    std::vector<cell_t> cells = offset_map.get_overlap_cells(o, size);
-    for (cell_t const& c : cells) {
-        interval_t intv = c.to_interval();
+    std::vector<Cell> cells = offset_map.get_overlap_cells(o, size);
+    for (Cell const& c : cells) {
+        Interval intv = c.to_interval();
         int cell_start_index = intv.lb().narrow<int>();
         int cell_end_index = intv.ub().narrow<int>();
 
@@ -504,7 +504,7 @@ void array_domain_t::split_number_var(NumAbsDomain& inv, data_kind_t kind, const
             // We can only split cells with a singleton value.
             continue;
         }
-        if (gsl::narrow_cast<index_t>(cell_start_index) < o) {
+        if (gsl::narrow_cast<Index>(cell_start_index) < o) {
             // Use the bytes to the left of the specified range.
             split_cell(inv, kind, cell_start_index, gsl::narrow<unsigned int>(o - cell_start_index));
         }
@@ -517,20 +517,19 @@ void array_domain_t::split_number_var(NumAbsDomain& inv, data_kind_t kind, const
 }
 
 // we can only treat this as non-member because we use global state
-static std::optional<std::pair<offset_t, unsigned>> kill_and_find_var(NumAbsDomain& inv, data_kind_t kind,
-                                                                      const linear_expression_t& i,
-                                                                      const linear_expression_t& elem_size) {
+static std::optional<std::pair<offset_t, unsigned>>
+kill_and_find_var(NumAbsDomain& inv, DataKind kind, const LinearExpression& i, const LinearExpression& elem_size) {
     std::optional<std::pair<offset_t, unsigned>> res;
 
     offset_map_t& offset_map = lookup_array_map(kind);
-    interval_t ii = inv.eval_interval(i);
-    std::vector<cell_t> cells;
-    if (std::optional<number_t> n = ii.singleton()) {
-        interval_t i_elem_size = inv.eval_interval(elem_size);
+    Interval ii = inv.eval_interval(i);
+    std::vector<Cell> cells;
+    if (std::optional<Number> n = ii.singleton()) {
+        Interval i_elem_size = inv.eval_interval(elem_size);
         if (auto n_bytes = i_elem_size.singleton()) {
             auto size = n_bytes->narrow<unsigned int>();
             // -- Constant index: kill overlapping cells
-            offset_t o(n->narrow<index_t>());
+            offset_t o(n->narrow<Index>());
             cells = offset_map.get_overlap_cells(o, size);
             res = std::make_pair(o, size);
         }
@@ -545,10 +544,10 @@ static std::optional<std::pair<offset_t, unsigned>> kill_and_find_var(NumAbsDoma
             inv.havoc(c.get_scalar(kind));
 
             // Forget signed and unsigned values together.
-            if (kind == data_kind_t::svalues) {
-                inv.havoc(c.get_scalar(data_kind_t::uvalues));
-            } else if (kind == data_kind_t::uvalues) {
-                inv.havoc(c.get_scalar(data_kind_t::svalues));
+            if (kind == DataKind::svalues) {
+                inv.havoc(c.get_scalar(DataKind::uvalues));
+            } else if (kind == DataKind::uvalues) {
+                inv.havoc(c.get_scalar(DataKind::svalues));
             }
         }
         // Remove the cells. If needed again they will be re-created.
@@ -557,8 +556,7 @@ static std::optional<std::pair<offset_t, unsigned>> kill_and_find_var(NumAbsDoma
     return res;
 }
 
-bool array_domain_t::all_num(const NumAbsDomain& inv, const linear_expression_t& lb,
-                             const linear_expression_t& ub) const {
+bool ArrayDomain::all_num(const NumAbsDomain& inv, const LinearExpression& lb, const LinearExpression& ub) const {
     const auto min_lb = inv.eval_interval(lb).lb().number();
     const auto max_ub = inv.eval_interval(ub).ub().number();
     if (!min_lb || !max_ub || !min_lb->fits<int32_t>() || !max_ub->fits<int32_t>()) {
@@ -576,7 +574,7 @@ bool array_domain_t::all_num(const NumAbsDomain& inv, const linear_expression_t&
 }
 
 // Get the number of bytes, starting at offset, that are known to be numbers.
-int array_domain_t::min_all_num_size(const NumAbsDomain& inv, const variable_t offset) const {
+int ArrayDomain::min_all_num_size(const NumAbsDomain& inv, const Variable offset) const {
     const auto min_lb = inv.eval_interval(offset).lb().number();
     const auto max_ub = inv.eval_interval(offset).ub().number();
     if (!min_lb || !max_ub || !min_lb->fits<int32_t>() || !max_ub->fits<int32_t>()) {
@@ -589,12 +587,12 @@ int array_domain_t::min_all_num_size(const NumAbsDomain& inv, const variable_t o
 
 // Get one byte of a value.
 std::optional<uint8_t> get_value_byte(const NumAbsDomain& inv, const offset_t o, const int width) {
-    const variable_t v = variable_t::cell_var(data_kind_t::svalues, (o / width) * width, width);
-    const std::optional<number_t> t = inv.eval_interval(v).singleton();
+    const Variable v = Variable::cell_var(DataKind::svalues, (o / width) * width, width);
+    const std::optional<Number> t = inv.eval_interval(v).singleton();
     if (!t) {
         return {};
     }
-    index_t n = t->cast_to<index_t>();
+    Index n = t->cast_to<Index>();
 
     // Convert value to bytes of the appropriate endian-ness.
     switch (width) {
@@ -613,11 +611,11 @@ std::optional<uint8_t> get_value_byte(const NumAbsDomain& inv, const offset_t o,
             n = boost::endian::native_to_little<uint32_t>(n);
         }
         break;
-    case sizeof(index_t):
+    case sizeof(Index):
         if (thread_local_options.big_endian) {
-            n = boost::endian::native_to_big<index_t>(n);
+            n = boost::endian::native_to_big<Index>(n);
         } else {
-            n = boost::endian::native_to_little<index_t>(n);
+            n = boost::endian::native_to_little<Index>(n);
         }
         break;
     default: CRAB_ERROR("Unexpected width ", width);
@@ -626,13 +624,13 @@ std::optional<uint8_t> get_value_byte(const NumAbsDomain& inv, const offset_t o,
     return bytes[o % width];
 }
 
-std::optional<linear_expression_t> array_domain_t::load(const NumAbsDomain& inv, data_kind_t kind,
-                                                        const linear_expression_t& i, int width) const {
-    interval_t ii = inv.eval_interval(i);
-    if (std::optional<number_t> n = ii.singleton()) {
+std::optional<LinearExpression> ArrayDomain::load(const NumAbsDomain& inv, DataKind kind, const LinearExpression& i,
+                                                  int width) const {
+    Interval ii = inv.eval_interval(i);
+    if (std::optional<Number> n = ii.singleton()) {
         offset_map_t& offset_map = lookup_array_map(kind);
         int64_t k = n->narrow<int64_t>();
-        if (kind == data_kind_t::types) {
+        if (kind == DataKind::types) {
             auto [only_num, only_non_num] = num_bytes.uniformity(k, width);
             if (only_num) {
                 return T_NUM;
@@ -646,7 +644,7 @@ std::optional<linear_expression_t> array_domain_t::load(const NumAbsDomain& inv,
         if (auto cell = lookup_array_map(kind).get_cell(o, size)) {
             return cell->get_scalar(kind);
         }
-        if (kind == data_kind_t::svalues || kind == data_kind_t::uvalues) {
+        if (kind == DataKind::svalues || kind == DataKind::uvalues) {
             // Copy bytes into result_buffer, taking into account that the
             // bytes might be in different stack variables and might be unaligned.
             uint8_t result_buffer[8];
@@ -695,20 +693,20 @@ std::optional<linear_expression_t> array_domain_t::load(const NumAbsDomain& inv,
                     return b;
                 }
                 if (size == 8) {
-                    index_t b = *reinterpret_cast<index_t*>(result_buffer);
+                    Index b = *reinterpret_cast<Index*>(result_buffer);
                     if (thread_local_options.big_endian) {
-                        b = boost::endian::native_to_big<index_t>(b);
+                        b = boost::endian::native_to_big<Index>(b);
                     } else {
-                        b = boost::endian::native_to_little<index_t>(b);
+                        b = boost::endian::native_to_little<Index>(b);
                     }
-                    return kind == data_kind_t::uvalues ? number_t(b) : number_t(to_signed(b));
+                    return kind == DataKind::uvalues ? Number(b) : Number(to_signed(b));
                 }
             }
         }
 
-        std::vector<cell_t> cells = offset_map.get_overlap_cells(o, size);
+        std::vector<Cell> cells = offset_map.get_overlap_cells(o, size);
         if (cells.empty()) {
-            cell_t c = offset_map.mk_cell(o, size);
+            Cell c = offset_map.mk_cell(o, size);
             // Here it's ok to do assignment (instead of expand) because c is not a summarized variable.
             // Otherwise, it would be unsound.
             return c.get_scalar(kind);
@@ -720,12 +718,12 @@ std::optional<linear_expression_t> array_domain_t::load(const NumAbsDomain& inv,
                 to construct values of some type from a sequence of bytes.
                 It can be endian-independent but it would more precise if we choose between little- and big-endian.
         */
-    } else if (kind == data_kind_t::types) {
+    } else if (kind == DataKind::types) {
         // Check whether the kind is uniform across the entire interval.
         auto lb = ii.lb().number();
         auto ub = ii.ub().number();
         if (lb.has_value() && ub.has_value()) {
-            number_t fullwidth = ub.value() - lb.value() + width;
+            Number fullwidth = ub.value() - lb.value() + width;
             if (lb->fits<uint32_t>() && fullwidth.fits<uint32_t>()) {
                 auto [only_num, only_non_num] =
                     num_bytes.uniformity(lb->narrow<uint32_t>(), fullwidth.narrow<uint32_t>());
@@ -744,80 +742,78 @@ std::optional<linear_expression_t> array_domain_t::load(const NumAbsDomain& inv,
 // We are about to write to a given range of bytes on the stack.
 // Any cells covering that range need to be removed, and any cells that only
 // partially cover that range can be split such that any non-covered portions become new cells.
-static std::optional<std::pair<offset_t, unsigned>> split_and_find_var(const array_domain_t& array_domain,
-                                                                       NumAbsDomain& inv, const data_kind_t kind,
-                                                                       const linear_expression_t& idx,
-                                                                       const linear_expression_t& elem_size) {
-    if (kind == data_kind_t::svalues || kind == data_kind_t::uvalues) {
+static std::optional<std::pair<offset_t, unsigned>> split_and_find_var(const ArrayDomain& array_domain,
+                                                                       NumAbsDomain& inv, const DataKind kind,
+                                                                       const LinearExpression& idx,
+                                                                       const LinearExpression& elem_size) {
+    if (kind == DataKind::svalues || kind == DataKind::uvalues) {
         array_domain.split_number_var(inv, kind, idx, elem_size);
     }
     return kill_and_find_var(inv, kind, idx, elem_size);
 }
 
-std::optional<variable_t> array_domain_t::store(NumAbsDomain& inv, const data_kind_t kind,
-                                                const linear_expression_t& idx, const linear_expression_t& elem_size,
-                                                const linear_expression_t& val) {
+std::optional<Variable> ArrayDomain::store(NumAbsDomain& inv, const DataKind kind, const LinearExpression& idx,
+                                           const LinearExpression& elem_size, const LinearExpression& val) {
     if (auto maybe_cell = split_and_find_var(*this, inv, kind, idx, elem_size)) {
         // perform strong update
         auto [offset, size] = *maybe_cell;
-        if (kind == data_kind_t::types) {
-            const std::optional<number_t> t = inv.eval_interval(val).singleton();
-            if (t == number_t{T_NUM}) {
+        if (kind == DataKind::types) {
+            const std::optional<Number> t = inv.eval_interval(val).singleton();
+            if (t == Number{T_NUM}) {
                 num_bytes.reset(offset, size);
             } else {
                 num_bytes.havoc(offset, size);
             }
         }
-        variable_t v = lookup_array_map(kind).mk_cell(offset, size).get_scalar(kind);
+        Variable v = lookup_array_map(kind).mk_cell(offset, size).get_scalar(kind);
         return v;
     }
     return {};
 }
 
-std::optional<variable_t> array_domain_t::store_type(NumAbsDomain& inv, const linear_expression_t& idx,
-                                                     const linear_expression_t& elem_size,
-                                                     const linear_expression_t& val) {
-    constexpr auto kind = data_kind_t::types;
+std::optional<Variable> ArrayDomain::store_type(NumAbsDomain& inv, const LinearExpression& idx,
+                                                const LinearExpression& elem_size, const LinearExpression& val) {
+    constexpr auto kind = DataKind::types;
     if (auto maybe_cell = split_and_find_var(*this, inv, kind, idx, elem_size)) {
         // perform strong update
         auto [offset, size] = *maybe_cell;
-        const std::optional<number_t> t = inv.eval_interval(val).singleton();
-        if (t == number_t{T_NUM}) {
+        const std::optional<Number> t = inv.eval_interval(val).singleton();
+        if (t == Number{T_NUM}) {
             num_bytes.reset(offset, size);
         } else {
             num_bytes.havoc(offset, size);
         }
-        variable_t v = lookup_array_map(kind).mk_cell(offset, size).get_scalar(kind);
+        Variable v = lookup_array_map(kind).mk_cell(offset, size).get_scalar(kind);
         return v;
     }
     return {};
 }
 
-void array_domain_t::havoc(NumAbsDomain& inv, const data_kind_t kind, const linear_expression_t& idx,
-                           const linear_expression_t& elem_size) {
+void ArrayDomain::havoc(NumAbsDomain& inv, const DataKind kind, const LinearExpression& idx,
+                        const LinearExpression& elem_size) {
     auto maybe_cell = split_and_find_var(*this, inv, kind, idx, elem_size);
-    if (maybe_cell && kind == data_kind_t::types) {
+    if (maybe_cell && kind == DataKind::types) {
         auto [offset, size] = *maybe_cell;
         num_bytes.havoc(offset, size);
     }
 }
 
-void array_domain_t::store_numbers(const NumAbsDomain& inv, const variable_t _idx, const variable_t _width) {
+void ArrayDomain::store_numbers(const NumAbsDomain& inv, const Variable _idx, const Variable _width) {
 
     // TODO: this should be an user parameter.
-    const number_t max_num_elems = EBPF_TOTAL_STACK_SIZE;
+    const Number max_num_elems = EBPF_TOTAL_STACK_SIZE;
 
     if (is_bottom()) {
         return;
     }
 
-    const std::optional<number_t> idx_n = inv.eval_interval(_idx).singleton();
+    const std::optional<Number> idx_n = inv.eval_interval(_idx).singleton();
     if (!idx_n) {
         CRAB_WARN("array expansion store range ignored because ", "lower bound is not constant");
         return;
     }
 
-    const std::optional<number_t> width = inv.eval_interval(_width).singleton();
+    const std::optional<Number> width = inv.eval_interval(_width).singleton();
     if (!width) {
         CRAB_WARN("array expansion store range ignored because ", "upper bound is not constant");
         return;
@@ -831,21 +827,21 @@ void array_domain_t::store_numbers(const NumAbsDomain& inv, const variable_t _id
     num_bytes.reset(idx_n->narrow<size_t>(), width->narrow<int>());
 }
 
-void array_domain_t::set_to_top() { num_bytes.set_to_top(); }
+void ArrayDomain::set_to_top() { num_bytes.set_to_top(); }
 
-void array_domain_t::set_to_bottom() { num_bytes.set_to_bottom(); }
+void ArrayDomain::set_to_bottom() { num_bytes.set_to_bottom(); }
 
-bool array_domain_t::is_bottom() const { return num_bytes.is_bottom(); }
+bool ArrayDomain::is_bottom() const { return num_bytes.is_bottom(); }
 
-bool array_domain_t::is_top() const { return num_bytes.is_top(); }
+bool ArrayDomain::is_top() const { return num_bytes.is_top(); }
 
-string_invariant array_domain_t::to_set() const { return num_bytes.to_set(); }
+StringInvariant ArrayDomain::to_set() const { return num_bytes.to_set(); }
 
-bool array_domain_t::operator<=(const array_domain_t& other) const { return num_bytes <= other.num_bytes; }
+bool ArrayDomain::operator<=(const ArrayDomain& other) const { return num_bytes <= other.num_bytes; }
 
-bool array_domain_t::operator==(const array_domain_t& other) const { return num_bytes == other.num_bytes; }
+bool ArrayDomain::operator==(const ArrayDomain& other) const { return num_bytes == other.num_bytes; }
 
-void array_domain_t::operator|=(const array_domain_t& other) {
+void ArrayDomain::operator|=(const ArrayDomain& other) {
     if (is_bottom()) {
         *this = other;
         return;
@@ -853,25 +849,17 @@ void array_domain_t::operator|=(const array_domain_t& other) {
     num_bytes |= other.num_bytes;
 }
 
-array_domain_t array_domain_t::operator|(const array_domain_t& other) const {
-    return array_domain_t(num_bytes | other.num_bytes);
+ArrayDomain ArrayDomain::operator|(const ArrayDomain& other) const { return ArrayDomain(num_bytes | other.num_bytes); }
+
+ArrayDomain ArrayDomain::operator&(const ArrayDomain& other) const { return ArrayDomain(num_bytes & other.num_bytes); }
+
+ArrayDomain ArrayDomain::widen(const ArrayDomain& other) const { return ArrayDomain(num_bytes | other.num_bytes); }
+
+ArrayDomain ArrayDomain::widening_thresholds(const ArrayDomain& other, const Thresholds& ts) const {
+    return ArrayDomain(num_bytes | other.num_bytes);
 }
 
-array_domain_t array_domain_t::operator&(const array_domain_t& other) const {
-    return array_domain_t(num_bytes & other.num_bytes);
-}
+ArrayDomain ArrayDomain::narrow(const ArrayDomain& other) const { return ArrayDomain(num_bytes & other.num_bytes); }
 
-array_domain_t array_domain_t::widen(const array_domain_t& other) const {
-    return array_domain_t(num_bytes | other.num_bytes);
-}
-
-array_domain_t array_domain_t::widening_thresholds(const array_domain_t& other, const thresholds_t& ts) const {
-    return array_domain_t(num_bytes | other.num_bytes);
-}
-
-array_domain_t array_domain_t::narrow(const array_domain_t& other) const {
-    return array_domain_t(num_bytes & other.num_bytes);
-}
-
-std::ostream& operator<<(std::ostream& o, const array_domain_t& dom) { return o << dom.num_bytes; }
+std::ostream& operator<<(std::ostream& o, const ArrayDomain& dom) { return o << dom.num_bytes; }
 } // namespace prevail

--- a/src/crab/array_domain.hpp
+++ b/src/crab/array_domain.hpp
@@ -36,13 +36,13 @@ using NumAbsDomain = AddBottom;
 
 void clear_thread_local_state();
 
-class array_domain_t final {
-    bitset_domain_t num_bytes;
+class ArrayDomain final {
+    BitsetDomain num_bytes;
 
   public:
-    array_domain_t() = default;
+    ArrayDomain() = default;
 
-    explicit array_domain_t(const bitset_domain_t& num_bytes) : num_bytes(num_bytes) {}
+    explicit ArrayDomain(const BitsetDomain& num_bytes) : num_bytes(num_bytes) {}
 
     void set_to_top();
     void set_to_bottom();
@@ -51,40 +51,39 @@ class array_domain_t final {
     [[nodiscard]]
     bool is_top() const;
 
-    bool operator<=(const array_domain_t& other) const;
-    bool operator==(const array_domain_t& other) const;
+    bool operator<=(const ArrayDomain& other) const;
+    bool operator==(const ArrayDomain& other) const;
 
-    void operator|=(const array_domain_t& other);
+    void operator|=(const ArrayDomain& other);
 
-    array_domain_t operator|(const array_domain_t& other) const;
-    array_domain_t operator&(const array_domain_t& other) const;
-    array_domain_t widen(const array_domain_t& other) const;
-    array_domain_t widening_thresholds(const array_domain_t& other, const thresholds_t& ts) const;
-    array_domain_t narrow(const array_domain_t& other) const;
+    ArrayDomain operator|(const ArrayDomain& other) const;
+    ArrayDomain operator&(const ArrayDomain& other) const;
+    ArrayDomain widen(const ArrayDomain& other) const;
+    ArrayDomain widening_thresholds(const ArrayDomain& other, const Thresholds& ts) const;
+    ArrayDomain narrow(const ArrayDomain& other) const;
 
-    friend std::ostream& operator<<(std::ostream& o, const array_domain_t& dom);
+    friend std::ostream& operator<<(std::ostream& o, const ArrayDomain& dom);
     [[nodiscard]]
-    string_invariant to_set() const;
+    StringInvariant to_set() const;
 
-    bool all_num(const NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub) const;
+    bool all_num(const NumAbsDomain& inv, const LinearExpression& lb, const LinearExpression& ub) const;
     [[nodiscard]]
-    int min_all_num_size(const NumAbsDomain& inv, variable_t offset) const;
+    int min_all_num_size(const NumAbsDomain& inv, Variable offset) const;
 
-    std::optional<linear_expression_t> load(const NumAbsDomain& inv, data_kind_t kind, const linear_expression_t& i,
-                                            int width) const;
-    std::optional<variable_t> store(NumAbsDomain& inv, data_kind_t kind, const linear_expression_t& idx,
-                                    const linear_expression_t& elem_size, const linear_expression_t& val);
-    std::optional<variable_t> store_type(NumAbsDomain& inv, const linear_expression_t& idx,
-                                         const linear_expression_t& elem_size, const linear_expression_t& val);
-    void havoc(NumAbsDomain& inv, data_kind_t kind, const linear_expression_t& idx,
-               const linear_expression_t& elem_size);
+    std::optional<LinearExpression> load(const NumAbsDomain& inv, DataKind kind, const LinearExpression& i,
+                                         int width) const;
+    std::optional<Variable> store(NumAbsDomain& inv, DataKind kind, const LinearExpression& idx,
+                                  const LinearExpression& elem_size, const LinearExpression& val);
+    std::optional<Variable> store_type(NumAbsDomain& inv, const LinearExpression& idx,
+                                       const LinearExpression& elem_size, const LinearExpression& val);
+    void havoc(NumAbsDomain& inv, DataKind kind, const LinearExpression& idx, const LinearExpression& elem_size);
 
     // Perform array stores over an array segment
-    void store_numbers(const NumAbsDomain& inv, variable_t _idx, variable_t _width);
+    void store_numbers(const NumAbsDomain& inv, Variable _idx, Variable _width);
 
-    void split_number_var(NumAbsDomain& inv, data_kind_t kind, const linear_expression_t& i,
-                          const linear_expression_t& elem_size) const;
-    void split_cell(NumAbsDomain& inv, data_kind_t kind, int cell_start_index, unsigned int len) const;
+    void split_number_var(NumAbsDomain& inv, DataKind kind, const LinearExpression& i,
+                          const LinearExpression& elem_size) const;
+    void split_cell(NumAbsDomain& inv, DataKind kind, int cell_start_index, unsigned int len) const;
 
     void initialize_numbers(int lb, int width);
 };

--- a/src/crab/bitset_domain.cpp
+++ b/src/crab/bitset_domain.cpp
@@ -5,7 +5,7 @@
 #include "bitset_domain.hpp"
 
 namespace prevail {
-std::ostream& operator<<(std::ostream& o, const bitset_domain_t& b) {
+std::ostream& operator<<(std::ostream& o, const BitsetDomain& b) {
     o << "Numbers -> {";
     bool first = true;
     for (int i = -EBPF_TOTAL_STACK_SIZE; i < 0; i++) {
@@ -33,12 +33,12 @@ std::ostream& operator<<(std::ostream& o, const bitset_domain_t& b) {
     return o;
 }
 
-string_invariant bitset_domain_t::to_set() const {
+StringInvariant BitsetDomain::to_set() const {
     if (this->is_bottom()) {
-        return string_invariant::bottom();
+        return StringInvariant::bottom();
     }
     if (this->is_top()) {
-        return string_invariant::top();
+        return StringInvariant::top();
     }
 
     std::set<std::string> result;
@@ -60,6 +60,6 @@ string_invariant bitset_domain_t::to_set() const {
         result.insert(value);
         i = j;
     }
-    return string_invariant{result};
+    return StringInvariant{result};
 }
 } // namespace prevail

--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -8,15 +8,15 @@
 #include "string_constraints.hpp"
 
 namespace prevail {
-class bitset_domain_t final {
+class BitsetDomain final {
   private:
     using bits_t = std::bitset<EBPF_TOTAL_STACK_SIZE>;
     bits_t non_numerical_bytes;
 
   public:
-    bitset_domain_t() { non_numerical_bytes.set(); }
+    BitsetDomain() { non_numerical_bytes.set(); }
 
-    bitset_domain_t(bits_t non_numerical_bytes) : non_numerical_bytes{non_numerical_bytes} {}
+    BitsetDomain(bits_t non_numerical_bytes) : non_numerical_bytes{non_numerical_bytes} {}
 
     void set_to_top() { non_numerical_bytes.set(); }
 
@@ -33,33 +33,29 @@ class bitset_domain_t final {
     }
 
     [[nodiscard]]
-    string_invariant to_set() const;
+    StringInvariant to_set() const;
 
-    bool operator<=(const bitset_domain_t& other) const {
+    bool operator<=(const BitsetDomain& other) const {
         return (non_numerical_bytes | other.non_numerical_bytes) == other.non_numerical_bytes;
     }
 
-    bool operator==(const bitset_domain_t& other) const { return non_numerical_bytes == other.non_numerical_bytes; }
+    bool operator==(const BitsetDomain& other) const { return non_numerical_bytes == other.non_numerical_bytes; }
 
-    void operator|=(const bitset_domain_t& other) { non_numerical_bytes |= other.non_numerical_bytes; }
+    void operator|=(const BitsetDomain& other) { non_numerical_bytes |= other.non_numerical_bytes; }
 
-    bitset_domain_t operator|(bitset_domain_t&& other) const { return non_numerical_bytes | other.non_numerical_bytes; }
+    BitsetDomain operator|(BitsetDomain&& other) const { return non_numerical_bytes | other.non_numerical_bytes; }
 
-    bitset_domain_t operator|(const bitset_domain_t& other) const {
-        return non_numerical_bytes | other.non_numerical_bytes;
-    }
+    BitsetDomain operator|(const BitsetDomain& other) const { return non_numerical_bytes | other.non_numerical_bytes; }
 
-    bitset_domain_t operator&(const bitset_domain_t& other) const {
-        return non_numerical_bytes & other.non_numerical_bytes;
-    }
+    BitsetDomain operator&(const BitsetDomain& other) const { return non_numerical_bytes & other.non_numerical_bytes; }
 
     [[nodiscard]]
-    bitset_domain_t widen(const bitset_domain_t& other) const {
+    BitsetDomain widen(const BitsetDomain& other) const {
         return non_numerical_bytes | other.non_numerical_bytes;
     }
 
     [[nodiscard]]
-    bitset_domain_t narrow(const bitset_domain_t& other) const {
+    BitsetDomain narrow(const BitsetDomain& other) const {
         return non_numerical_bytes & other.non_numerical_bytes;
     }
 
@@ -103,7 +99,7 @@ class bitset_domain_t final {
         }
     }
 
-    friend std::ostream& operator<<(std::ostream& o, const bitset_domain_t& array);
+    friend std::ostream& operator<<(std::ostream& o, const BitsetDomain& array);
 
     // Test whether all values in the range [lb,ub) are numerical.
     [[nodiscard]]

--- a/src/crab/dsl_syntax.hpp
+++ b/src/crab/dsl_syntax.hpp
@@ -6,48 +6,44 @@
 
 namespace prevail::dsl_syntax {
 
-inline linear_expression_t operator-(const linear_expression_t& e) { return e.negate(); }
+inline LinearExpression operator-(const LinearExpression& e) { return e.negate(); }
 
-inline linear_expression_t operator*(variable_t x, const number_t& n) { return linear_expression_t(n, x); }
+inline LinearExpression operator*(Variable x, const Number& n) { return LinearExpression(n, x); }
 
-inline linear_expression_t operator*(const number_t& n, const linear_expression_t& e) { return e.multiply(n); }
+inline LinearExpression operator*(const Number& n, const LinearExpression& e) { return e.multiply(n); }
 
-inline linear_expression_t operator+(const linear_expression_t& e1, const linear_expression_t& e2) {
-    return e1.plus(e2);
+inline LinearExpression operator+(const LinearExpression& e1, const LinearExpression& e2) { return e1.plus(e2); }
+
+inline LinearExpression operator-(const LinearExpression& e1, const LinearExpression& e2) { return e1.subtract(e2); }
+
+inline LinearConstraint operator<=(const LinearExpression& e1, const LinearExpression& e2) {
+    return LinearConstraint(e1 - e2, ConstraintKind::LESS_THAN_OR_EQUALS_ZERO);
 }
 
-inline linear_expression_t operator-(const linear_expression_t& e1, const linear_expression_t& e2) {
-    return e1.subtract(e2);
+inline LinearConstraint operator<(const LinearExpression& e1, const LinearExpression& e2) {
+    return LinearConstraint(e1 - e2, ConstraintKind::LESS_THAN_ZERO);
 }
 
-inline linear_constraint_t operator<=(const linear_expression_t& e1, const linear_expression_t& e2) {
-    return linear_constraint_t(e1 - e2, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
+inline LinearConstraint operator>=(const LinearExpression& e1, const LinearExpression& e2) { return e2 <= e1; }
 
-inline linear_constraint_t operator<(const linear_expression_t& e1, const linear_expression_t& e2) {
-    return linear_constraint_t(e1 - e2, constraint_kind_t::LESS_THAN_ZERO);
-}
+inline LinearConstraint operator>(const LinearExpression& e1, const LinearExpression& e2) { return e2 < e1; }
 
-inline linear_constraint_t operator>=(const linear_expression_t& e1, const linear_expression_t& e2) { return e2 <= e1; }
-
-inline linear_constraint_t operator>(const linear_expression_t& e1, const linear_expression_t& e2) { return e2 < e1; }
-
-inline linear_constraint_t eq(const variable_t a, const variable_t b) {
+inline LinearConstraint eq(const Variable a, const Variable b) {
     using namespace dsl_syntax;
-    return {a - b, constraint_kind_t::EQUALS_ZERO};
+    return {a - b, ConstraintKind::EQUALS_ZERO};
 }
 
-inline linear_constraint_t neq(const variable_t a, const variable_t b) {
+inline LinearConstraint neq(const Variable a, const Variable b) {
     using namespace dsl_syntax;
-    return {a - b, constraint_kind_t::NOT_ZERO};
+    return {a - b, ConstraintKind::NOT_ZERO};
 }
 
-inline linear_constraint_t operator==(const linear_expression_t& e1, const linear_expression_t& e2) {
-    return linear_constraint_t(e1 - e2, constraint_kind_t::EQUALS_ZERO);
+inline LinearConstraint operator==(const LinearExpression& e1, const LinearExpression& e2) {
+    return LinearConstraint(e1 - e2, ConstraintKind::EQUALS_ZERO);
 }
 
-inline linear_constraint_t operator!=(const linear_expression_t& e1, const linear_expression_t& e2) {
-    return linear_constraint_t(e1 - e2, constraint_kind_t::NOT_ZERO);
+inline LinearConstraint operator!=(const LinearExpression& e1, const LinearExpression& e2) {
+    return LinearConstraint(e1 - e2, ConstraintKind::NOT_ZERO);
 }
 
 } // end namespace prevail::dsl_syntax

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -22,77 +22,77 @@ namespace prevail {
 constexpr int MAX_PACKET_SIZE = 0xffff;
 constexpr int64_t PTR_MAX = std::numeric_limits<int32_t>::max() - MAX_PACKET_SIZE;
 
-class ebpf_domain_t;
+class EbpfDomain;
 
-void ebpf_domain_transform(ebpf_domain_t& inv, const Instruction& ins);
-void ebpf_domain_assume(ebpf_domain_t& dom, const Assertion& assertion);
-std::vector<std::string> ebpf_domain_check(const ebpf_domain_t& dom, const Assertion& assertion);
+void ebpf_domain_transform(EbpfDomain& inv, const Instruction& ins);
+void ebpf_domain_assume(EbpfDomain& dom, const Assertion& assertion);
+std::vector<std::string> ebpf_domain_check(const EbpfDomain& dom, const Assertion& assertion);
 
 // TODO: make this an explicit instruction
-void ebpf_domain_initialize_loop_counter(ebpf_domain_t& dom, const label_t& label);
+void ebpf_domain_initialize_loop_counter(EbpfDomain& dom, const Label& label);
 
-class ebpf_domain_t final {
-    friend class ebpf_checker;
-    friend class ebpf_transformer;
+class EbpfDomain final {
+    friend class EbpfChecker;
+    friend class EbpfTransformer;
 
-    friend std::ostream& operator<<(std::ostream& o, const ebpf_domain_t& dom);
+    friend std::ostream& operator<<(std::ostream& o, const EbpfDomain& dom);
 
   public:
-    ebpf_domain_t();
-    ebpf_domain_t(NumAbsDomain inv, array_domain_t stack);
+    EbpfDomain();
+    EbpfDomain(NumAbsDomain inv, ArrayDomain stack);
 
     // Generic abstract domain operations
-    static ebpf_domain_t top();
-    static ebpf_domain_t bottom();
+    static EbpfDomain top();
+    static EbpfDomain bottom();
     void set_to_top();
     void set_to_bottom();
     [[nodiscard]]
     bool is_bottom() const;
     [[nodiscard]]
     bool is_top() const;
-    bool operator<=(const ebpf_domain_t& other) const;
-    bool operator==(const ebpf_domain_t& other) const;
-    void operator|=(ebpf_domain_t&& other);
-    void operator|=(const ebpf_domain_t& other);
-    ebpf_domain_t operator|(ebpf_domain_t&& other) const;
-    ebpf_domain_t operator|(const ebpf_domain_t& other) const&;
-    ebpf_domain_t operator|(const ebpf_domain_t& other) &&;
-    ebpf_domain_t operator&(const ebpf_domain_t& other) const;
-    ebpf_domain_t widen(const ebpf_domain_t& other, bool to_constants) const;
-    ebpf_domain_t widening_thresholds(const ebpf_domain_t& other, const thresholds_t& ts);
-    ebpf_domain_t narrow(const ebpf_domain_t& other) const;
+    bool operator<=(const EbpfDomain& other) const;
+    bool operator==(const EbpfDomain& other) const;
+    void operator|=(EbpfDomain&& other);
+    void operator|=(const EbpfDomain& other);
+    EbpfDomain operator|(EbpfDomain&& other) const;
+    EbpfDomain operator|(const EbpfDomain& other) const&;
+    EbpfDomain operator|(const EbpfDomain& other) &&;
+    EbpfDomain operator&(const EbpfDomain& other) const;
+    EbpfDomain widen(const EbpfDomain& other, bool to_constants) const;
+    EbpfDomain widening_thresholds(const EbpfDomain& other, const Thresholds& ts);
+    EbpfDomain narrow(const EbpfDomain& other) const;
 
-    static ebpf_domain_t calculate_constant_limits();
-    extended_number get_loop_count_upper_bound() const;
-    interval_t get_r0() const;
+    static EbpfDomain calculate_constant_limits();
+    ExtendedNumber get_loop_count_upper_bound() const;
+    Interval get_r0() const;
 
-    static ebpf_domain_t setup_entry(bool init_r1);
-    static ebpf_domain_t from_constraints(const std::set<std::string>& constraints, bool setup_constraints);
+    static EbpfDomain setup_entry(bool init_r1);
+    static EbpfDomain from_constraints(const std::set<std::string>& constraints, bool setup_constraints);
     void initialize_packet();
 
-    string_invariant to_set() const;
+    StringInvariant to_set() const;
 
   private:
     // private generic domain functions
-    void add_constraint(const linear_constraint_t& cst);
-    void havoc(variable_t var);
+    void add_constraint(const LinearConstraint& cst);
+    void havoc(Variable var);
 
     [[nodiscard]]
     std::optional<uint32_t> get_map_type(const Reg& map_fd_reg) const;
     [[nodiscard]]
     std::optional<uint32_t> get_map_inner_map_fd(const Reg& map_fd_reg) const;
     [[nodiscard]]
-    interval_t get_map_key_size(const Reg& map_fd_reg) const;
+    Interval get_map_key_size(const Reg& map_fd_reg) const;
     [[nodiscard]]
-    interval_t get_map_value_size(const Reg& map_fd_reg) const;
+    Interval get_map_value_size(const Reg& map_fd_reg) const;
     [[nodiscard]]
-    interval_t get_map_max_entries(const Reg& map_fd_reg) const;
+    Interval get_map_max_entries(const Reg& map_fd_reg) const;
 
-    static std::optional<variable_t> get_type_offset_variable(const Reg& reg, int type);
+    static std::optional<Variable> get_type_offset_variable(const Reg& reg, int type);
     [[nodiscard]]
-    std::optional<variable_t> get_type_offset_variable(const Reg& reg, const NumAbsDomain& inv) const;
+    std::optional<Variable> get_type_offset_variable(const Reg& reg, const NumAbsDomain& inv) const;
     [[nodiscard]]
-    std::optional<variable_t> get_type_offset_variable(const Reg& reg) const;
+    std::optional<Variable> get_type_offset_variable(const Reg& reg) const;
 
     bool get_map_fd_range(const Reg& map_fd_reg, int32_t* start_fd, int32_t* end_fd) const;
 
@@ -104,7 +104,7 @@ class ebpf_domain_t final {
     /// Represents the stack as a memory region, i.e., an array of bytes,
     /// allowing mapping to variable in the m_inv numeric domains
     /// while dealing with overlapping byte ranges.
-    array_domain_t stack;
+    ArrayDomain stack;
 
     TypeDomain type_inv;
 };

--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -21,16 +21,15 @@
 
 namespace prevail {
 
-class ebpf_transformer final {
-    ebpf_domain_t& dom;
+class EbpfTransformer final {
+    EbpfDomain& dom;
     // shorthands:
     NumAbsDomain& m_inv;
-    array_domain_t& stack;
+    ArrayDomain& stack;
     TypeDomain& type_inv;
 
   public:
-    explicit ebpf_transformer(ebpf_domain_t& dom)
-        : dom(dom), m_inv(dom.m_inv), stack(dom.stack), type_inv(dom.type_inv) {}
+    explicit EbpfTransformer(EbpfDomain& dom) : dom(dom), m_inv(dom.m_inv), stack(dom.stack), type_inv(dom.type_inv) {}
 
     // abstract transformers
     void operator()(const Assume&);
@@ -49,7 +48,7 @@ class ebpf_transformer final {
     void operator()(const Un&);
     void operator()(const Undefined&);
 
-    void initialize_loop_counter(const label_t& label);
+    void initialize_loop_counter(const Label& label);
 
   private:
     /// Forget everything about all offset variables for a given register.
@@ -66,33 +65,33 @@ class ebpf_transformer final {
     void assign_valid_ptr(const Reg& dst_reg, bool maybe_null);
 
     void recompute_stack_numeric_size(NumAbsDomain& inv, const Reg& reg) const;
-    void recompute_stack_numeric_size(NumAbsDomain& inv, variable_t type_variable) const;
-    void do_load_stack(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr, int width,
+    void recompute_stack_numeric_size(NumAbsDomain& inv, Variable type_variable) const;
+    void do_load_stack(NumAbsDomain& inv, const Reg& target_reg, const LinearExpression& addr, int width,
                        const Reg& src_reg);
-    void do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr_vague, int width);
-    void do_load_packet_or_shared(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr, int width);
+    void do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, const LinearExpression& addr_vague, int width);
+    void do_load_packet_or_shared(NumAbsDomain& inv, const Reg& target_reg, const LinearExpression& addr, int width);
     void do_load(const Mem& b, const Reg& target_reg);
 
-    void do_store_stack(NumAbsDomain& inv, const linear_expression_t& addr, int width,
-                        const linear_expression_t& val_type, const linear_expression_t& val_svalue,
-                        const linear_expression_t& val_uvalue, const std::optional<reg_pack_t>& opt_val_reg);
+    void do_store_stack(NumAbsDomain& inv, const LinearExpression& addr, int width, const LinearExpression& val_type,
+                        const LinearExpression& val_svalue, const LinearExpression& val_uvalue,
+                        const std::optional<RegPack>& opt_val_reg);
 
-    void do_mem_store(const Mem& b, const linear_expression_t& val_type, const linear_expression_t& val_svalue,
-                      const linear_expression_t& val_uvalue, const std::optional<reg_pack_t>& opt_val_reg);
+    void do_mem_store(const Mem& b, const LinearExpression& val_type, const LinearExpression& val_svalue,
+                      const LinearExpression& val_uvalue, const std::optional<RegPack>& opt_val_reg);
 
     void add(const Reg& dst_reg, int imm, int finite_width);
     void shl(const Reg& dst_reg, int imm, int finite_width);
     void lshr(const Reg& dst_reg, int imm, int finite_width);
-    void ashr(const Reg& dst_reg, const linear_expression_t& right_svalue, int finite_width);
-    void sign_extend(const Reg& dst_reg, const linear_expression_t& right_svalue, int target_width, int source_width);
-}; // end ebpf_domain_t
+    void ashr(const Reg& dst_reg, const LinearExpression& right_svalue, int finite_width);
+    void sign_extend(const Reg& dst_reg, const LinearExpression& right_svalue, int target_width, int source_width);
+}; // end EbpfDomain
 
-void ebpf_domain_transform(ebpf_domain_t& inv, const Instruction& ins) {
+void ebpf_domain_transform(EbpfDomain& inv, const Instruction& ins) {
     if (inv.is_bottom()) {
         return;
     }
     const auto pre = inv;
-    std::visit(ebpf_transformer{inv}, ins);
+    std::visit(EbpfTransformer{inv}, ins);
     if (inv.is_bottom() && !std::holds_alternative<Assume>(ins)) {
         // Fail. raise an exception to stop the analysis.
         std::stringstream msg;
@@ -104,7 +103,7 @@ void ebpf_domain_transform(ebpf_domain_t& inv, const Instruction& ins) {
 }
 
 static void havoc_offsets(NumAbsDomain& inv, const Reg& reg) {
-    const reg_pack_t r = reg_pack(reg);
+    const RegPack r = reg_pack(reg);
     inv.havoc(r.ctx_offset);
     inv.havoc(r.map_fd);
     inv.havoc(r.packet_offset);
@@ -115,13 +114,13 @@ static void havoc_offsets(NumAbsDomain& inv, const Reg& reg) {
 }
 
 static void havoc_register(NumAbsDomain& inv, const Reg& reg) {
-    const reg_pack_t r = reg_pack(reg);
+    const RegPack r = reg_pack(reg);
     havoc_offsets(inv, reg);
     inv.havoc(r.svalue);
     inv.havoc(r.uvalue);
 }
 
-void ebpf_transformer::scratch_caller_saved_registers() {
+void EbpfTransformer::scratch_caller_saved_registers() {
     for (int i = R1_ARG; i <= R5_ARG; i++) {
         Reg r{gsl::narrow<uint8_t>(i)};
         havoc_register(m_inv, r);
@@ -129,83 +128,83 @@ void ebpf_transformer::scratch_caller_saved_registers() {
     }
 }
 
-void ebpf_transformer::save_callee_saved_registers(const std::string& prefix) {
+void EbpfTransformer::save_callee_saved_registers(const std::string& prefix) {
     // Create variables specific to the new call stack frame that store
     // copies of the states of r6 through r9.
     for (int r = R6; r <= R9; r++) {
-        for (const data_kind_t kind : iterate_kinds()) {
-            const variable_t src_var = variable_t::reg(kind, r);
+        for (const DataKind kind : iterate_kinds()) {
+            const Variable src_var = Variable::reg(kind, r);
             if (!m_inv.eval_interval(src_var).is_top()) {
-                m_inv.assign(variable_t::stack_frame_var(kind, r, prefix), src_var);
+                m_inv.assign(Variable::stack_frame_var(kind, r, prefix), src_var);
             }
         }
     }
 }
 
-void ebpf_transformer::restore_callee_saved_registers(const std::string& prefix) {
+void EbpfTransformer::restore_callee_saved_registers(const std::string& prefix) {
     for (int r = R6; r <= R9; r++) {
-        for (const data_kind_t kind : iterate_kinds()) {
-            const variable_t src_var = variable_t::stack_frame_var(kind, r, prefix);
+        for (const DataKind kind : iterate_kinds()) {
+            const Variable src_var = Variable::stack_frame_var(kind, r, prefix);
             if (!m_inv.eval_interval(src_var).is_top()) {
-                m_inv.assign(variable_t::reg(kind, r), src_var);
+                m_inv.assign(Variable::reg(kind, r), src_var);
             } else {
-                m_inv.havoc(variable_t::reg(kind, r));
+                m_inv.havoc(Variable::reg(kind, r));
             }
             m_inv.havoc(src_var);
         }
     }
 }
 
-void ebpf_transformer::havoc_subprogram_stack(const std::string& prefix) {
-    const variable_t r10_stack_offset = reg_pack(R10_STACK_POINTER).stack_offset;
+void EbpfTransformer::havoc_subprogram_stack(const std::string& prefix) {
+    const Variable r10_stack_offset = reg_pack(R10_STACK_POINTER).stack_offset;
     const auto intv = m_inv.eval_interval(r10_stack_offset);
     if (!intv.is_singleton()) {
         return;
     }
     const int64_t stack_start = intv.singleton()->cast_to<int64_t>() - EBPF_SUBPROGRAM_STACK_SIZE;
-    for (const data_kind_t kind : iterate_kinds()) {
+    for (const DataKind kind : iterate_kinds()) {
         stack.havoc(m_inv, kind, stack_start, EBPF_SUBPROGRAM_STACK_SIZE);
     }
 }
 
-void ebpf_transformer::forget_packet_pointers() {
+void EbpfTransformer::forget_packet_pointers() {
     using namespace dsl_syntax;
 
-    for (const variable_t type_variable : variable_t::get_type_variables()) {
+    for (const Variable type_variable : Variable::get_type_variables()) {
         if (type_inv.has_type(m_inv, type_variable, T_PACKET)) {
-            m_inv.havoc(variable_t::kind_var(data_kind_t::types, type_variable));
-            m_inv.havoc(variable_t::kind_var(data_kind_t::packet_offsets, type_variable));
-            m_inv.havoc(variable_t::kind_var(data_kind_t::svalues, type_variable));
-            m_inv.havoc(variable_t::kind_var(data_kind_t::uvalues, type_variable));
+            m_inv.havoc(Variable::kind_var(DataKind::types, type_variable));
+            m_inv.havoc(Variable::kind_var(DataKind::packet_offsets, type_variable));
+            m_inv.havoc(Variable::kind_var(DataKind::svalues, type_variable));
+            m_inv.havoc(Variable::kind_var(DataKind::uvalues, type_variable));
         }
     }
 
     dom.initialize_packet();
 }
 
-void ebpf_transformer::havoc_offsets(const Reg& reg) { prevail::havoc_offsets(m_inv, reg); }
+void EbpfTransformer::havoc_offsets(const Reg& reg) { prevail::havoc_offsets(m_inv, reg); }
 
-static linear_constraint_t type_is_pointer(const reg_pack_t& r) {
+static LinearConstraint type_is_pointer(const RegPack& r) {
     using namespace dsl_syntax;
     return r.type >= T_CTX;
 }
 
-static linear_constraint_t type_is_number(const reg_pack_t& r) {
+static LinearConstraint type_is_number(const RegPack& r) {
     using namespace dsl_syntax;
     return r.type == T_NUM;
 }
 
-static linear_constraint_t type_is_number(const Reg& r) { return type_is_number(reg_pack(r)); }
+static LinearConstraint type_is_number(const Reg& r) { return type_is_number(reg_pack(r)); }
 
-static linear_constraint_t type_is_not_stack(const reg_pack_t& r) {
+static LinearConstraint type_is_not_stack(const RegPack& r) {
     using namespace dsl_syntax;
     return r.type != T_STACK;
 }
 
 /** Linear constraint for a pointer comparison.
  */
-static linear_constraint_t assume_cst_offsets_reg(const Condition::Op op, const variable_t dst_offset,
-                                                  const variable_t src_offset) {
+static LinearConstraint assume_cst_offsets_reg(const Condition::Op op, const Variable dst_offset,
+                                               const Variable src_offset) {
     using namespace dsl_syntax;
     using Op = Condition::Op;
     switch (op) {
@@ -225,7 +224,7 @@ static linear_constraint_t assume_cst_offsets_reg(const Condition::Op op, const 
     }
 }
 
-void ebpf_transformer::operator()(const Assume& s) {
+void EbpfTransformer::operator()(const Assume& s) {
     if (m_inv.is_bottom()) {
         return;
     }
@@ -235,9 +234,9 @@ void ebpf_transformer::operator()(const Assume& s) {
         const auto src_reg = *psrc_reg;
         const auto src = reg_pack(src_reg);
         if (type_inv.same_type(m_inv, cond.left, std::get<Reg>(cond.right))) {
-            m_inv = type_inv.join_over_types(m_inv, cond.left, [&](NumAbsDomain& inv, const type_encoding_t type) {
+            m_inv = type_inv.join_over_types(m_inv, cond.left, [&](NumAbsDomain& inv, const TypeEncoding type) {
                 if (type == T_NUM) {
-                    for (const linear_constraint_t& cst :
+                    for (const LinearConstraint& cst :
                          inv->assume_cst_reg(cond.op, cond.is64, dst.svalue, dst.uvalue, src.svalue, src.uvalue)) {
                         inv.add_constraint(cst);
                     }
@@ -259,13 +258,13 @@ void ebpf_transformer::operator()(const Assume& s) {
         }
     } else {
         const int64_t imm = gsl::narrow_cast<int64_t>(std::get<Imm>(cond.right).v);
-        for (const linear_constraint_t& cst : m_inv->assume_cst_imm(cond.op, cond.is64, dst.svalue, dst.uvalue, imm)) {
+        for (const LinearConstraint& cst : m_inv->assume_cst_imm(cond.op, cond.is64, dst.svalue, dst.uvalue, imm)) {
             m_inv.add_constraint(cst);
         }
     }
 }
 
-void ebpf_transformer::operator()(const Undefined& a) {}
+void EbpfTransformer::operator()(const Undefined& a) {}
 
 // Simple truncation function usable with swap_endianness().
 template <class T>
@@ -273,16 +272,16 @@ constexpr T truncate(T x) noexcept {
     return x;
 }
 
-void ebpf_transformer::operator()(const Un& stmt) {
+void EbpfTransformer::operator()(const Un& stmt) {
     if (m_inv.is_bottom()) {
         return;
     }
     const auto dst = reg_pack(stmt.dst);
-    auto swap_endianness = [&](const variable_t v, auto be_or_le) {
+    auto swap_endianness = [&](const Variable v, auto be_or_le) {
         if (m_inv.entail(type_is_number(stmt.dst))) {
             if (const auto n = m_inv.eval_interval(v).singleton()) {
                 if (n->fits_cast_to<int64_t>()) {
-                    m_inv.set(v, interval_t{be_or_le(n->cast_to<int64_t>())});
+                    m_inv.set(v, Interval{be_or_le(n->cast_to<int64_t>())});
                     return;
                 }
             }
@@ -361,7 +360,7 @@ void ebpf_transformer::operator()(const Un& stmt) {
     }
 }
 
-void ebpf_transformer::operator()(const Exit& a) {
+void EbpfTransformer::operator()(const Exit& a) {
     if (m_inv.is_bottom()) {
         return;
     }
@@ -378,11 +377,11 @@ void ebpf_transformer::operator()(const Exit& a) {
     add(r10_reg, EBPF_SUBPROGRAM_STACK_SIZE, 64);
 }
 
-void ebpf_transformer::operator()(const Jmp&) const {
+void EbpfTransformer::operator()(const Jmp&) const {
     // This is a NOP. It only exists to hold the jump preconditions.
 }
 
-void ebpf_transformer::operator()(const Packet& a) {
+void EbpfTransformer::operator()(const Packet& a) {
     if (m_inv.is_bottom()) {
         return;
     }
@@ -395,48 +394,48 @@ void ebpf_transformer::operator()(const Packet& a) {
     scratch_caller_saved_registers();
 }
 
-void ebpf_transformer::do_load_stack(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr,
-                                     const int width, const Reg& src_reg) {
-    type_inv.assign_type(inv, target_reg, stack.load(inv, data_kind_t::types, addr, width));
+void EbpfTransformer::do_load_stack(NumAbsDomain& inv, const Reg& target_reg, const LinearExpression& addr,
+                                    const int width, const Reg& src_reg) {
+    type_inv.assign_type(inv, target_reg, stack.load(inv, DataKind::types, addr, width));
     using namespace dsl_syntax;
     if (inv.entail(width <= reg_pack(src_reg).stack_numeric_size)) {
         type_inv.assign_type(inv, target_reg, T_NUM);
     }
 
-    const reg_pack_t& target = reg_pack(target_reg);
+    const RegPack& target = reg_pack(target_reg);
     if (width == 1 || width == 2 || width == 4 || width == 8) {
         // Use the addr before we havoc the destination register since we might be getting the
         // addr from that same register.
-        const std::optional<linear_expression_t> sresult = stack.load(inv, data_kind_t::svalues, addr, width);
-        const std::optional<linear_expression_t> uresult = stack.load(inv, data_kind_t::uvalues, addr, width);
+        const std::optional<LinearExpression> sresult = stack.load(inv, DataKind::svalues, addr, width);
+        const std::optional<LinearExpression> uresult = stack.load(inv, DataKind::uvalues, addr, width);
         havoc_register(inv, target_reg);
         inv.assign(target.svalue, sresult);
         inv.assign(target.uvalue, uresult);
 
         if (type_inv.has_type(inv, target.type, T_CTX)) {
-            inv.assign(target.ctx_offset, stack.load(inv, data_kind_t::ctx_offsets, addr, width));
+            inv.assign(target.ctx_offset, stack.load(inv, DataKind::ctx_offsets, addr, width));
         }
         if (type_inv.has_type(inv, target.type, T_MAP) || type_inv.has_type(inv, target.type, T_MAP_PROGRAMS)) {
-            inv.assign(target.map_fd, stack.load(inv, data_kind_t::map_fds, addr, width));
+            inv.assign(target.map_fd, stack.load(inv, DataKind::map_fds, addr, width));
         }
         if (type_inv.has_type(inv, target.type, T_PACKET)) {
-            inv.assign(target.packet_offset, stack.load(inv, data_kind_t::packet_offsets, addr, width));
+            inv.assign(target.packet_offset, stack.load(inv, DataKind::packet_offsets, addr, width));
         }
         if (type_inv.has_type(inv, target.type, T_SHARED)) {
-            inv.assign(target.shared_offset, stack.load(inv, data_kind_t::shared_offsets, addr, width));
-            inv.assign(target.shared_region_size, stack.load(inv, data_kind_t::shared_region_sizes, addr, width));
+            inv.assign(target.shared_offset, stack.load(inv, DataKind::shared_offsets, addr, width));
+            inv.assign(target.shared_region_size, stack.load(inv, DataKind::shared_region_sizes, addr, width));
         }
         if (type_inv.has_type(inv, target.type, T_STACK)) {
-            inv.assign(target.stack_offset, stack.load(inv, data_kind_t::stack_offsets, addr, width));
-            inv.assign(target.stack_numeric_size, stack.load(inv, data_kind_t::stack_numeric_sizes, addr, width));
+            inv.assign(target.stack_offset, stack.load(inv, DataKind::stack_offsets, addr, width));
+            inv.assign(target.stack_numeric_size, stack.load(inv, DataKind::stack_numeric_sizes, addr, width));
         }
     } else {
         havoc_register(inv, target_reg);
     }
 }
 
-void ebpf_transformer::do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr_vague,
-                                   const int width) {
+void EbpfTransformer::do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, const LinearExpression& addr_vague,
+                                  const int width) {
     using namespace dsl_syntax;
     if (inv.is_bottom()) {
         return;
@@ -444,7 +443,7 @@ void ebpf_transformer::do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, con
 
     const ebpf_context_descriptor_t* desc = thread_local_program_info->type.context_descriptor;
 
-    const reg_pack_t& target = reg_pack(target_reg);
+    const RegPack& target = reg_pack(target_reg);
 
     if (desc->end < 0) {
         havoc_register(inv, target_reg);
@@ -452,8 +451,8 @@ void ebpf_transformer::do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, con
         return;
     }
 
-    const interval_t interval = inv.eval_interval(addr_vague);
-    const std::optional<number_t> maybe_addr = interval.singleton();
+    const Interval interval = inv.eval_interval(addr_vague);
+    const std::optional<Number> maybe_addr = interval.singleton();
     havoc_register(inv, target_reg);
 
     const bool may_touch_ptr =
@@ -468,7 +467,7 @@ void ebpf_transformer::do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, con
         return;
     }
 
-    const number_t addr = *maybe_addr;
+    const Number addr = *maybe_addr;
 
     // We use offsets for packet data, data_end, and meta during verification,
     // but at runtime they will be 64-bit pointers.  We can use the offset values
@@ -481,11 +480,11 @@ void ebpf_transformer::do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, con
         }
     } else if (addr == desc->end) {
         if (width == offset_width) {
-            inv.assign(target.packet_offset, variable_t::packet_size());
+            inv.assign(target.packet_offset, Variable::packet_size());
         }
     } else if (addr == desc->meta) {
         if (width == offset_width) {
-            inv.assign(target.packet_offset, variable_t::meta_offset());
+            inv.assign(target.packet_offset, Variable::meta_offset());
         }
     } else {
         if (may_touch_ptr) {
@@ -502,25 +501,25 @@ void ebpf_transformer::do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, con
     }
 }
 
-void ebpf_transformer::do_load_packet_or_shared(NumAbsDomain& inv, const Reg& target_reg,
-                                                const linear_expression_t& addr, const int width) {
+void EbpfTransformer::do_load_packet_or_shared(NumAbsDomain& inv, const Reg& target_reg, const LinearExpression& addr,
+                                               const int width) {
     if (inv.is_bottom()) {
         return;
     }
-    const reg_pack_t& target = reg_pack(target_reg);
+    const RegPack& target = reg_pack(target_reg);
 
     type_inv.assign_type(inv, target_reg, T_NUM);
     havoc_register(inv, target_reg);
 
     // A 1 or 2 byte copy results in a limited range of values that may be used as array indices.
     if (width == 1 || width == 2) {
-        const interval_t full = interval_t::unsigned_int(width * 8);
+        const Interval full = Interval::unsigned_int(width * 8);
         inv.set(target.svalue, full);
         inv.set(target.uvalue, full);
     }
 }
 
-void ebpf_transformer::do_load(const Mem& b, const Reg& target_reg) {
+void EbpfTransformer::do_load(const Mem& b, const Reg& target_reg) {
     using namespace dsl_syntax;
 
     const auto mem_reg = reg_pack(b.access.basereg);
@@ -528,34 +527,34 @@ void ebpf_transformer::do_load(const Mem& b, const Reg& target_reg) {
     const int offset = b.access.offset;
 
     if (b.access.basereg.v == R10_STACK_POINTER) {
-        const linear_expression_t addr = mem_reg.stack_offset + offset;
+        const LinearExpression addr = mem_reg.stack_offset + offset;
         do_load_stack(m_inv, target_reg, addr, width, b.access.basereg);
         return;
     }
 
-    m_inv = type_inv.join_over_types(m_inv, b.access.basereg, [&](NumAbsDomain& inv, type_encoding_t type) {
+    m_inv = type_inv.join_over_types(m_inv, b.access.basereg, [&](NumAbsDomain& inv, TypeEncoding type) {
         switch (type) {
         case T_UNINIT: return;
         case T_MAP: return;
         case T_MAP_PROGRAMS: return;
         case T_NUM: return;
         case T_CTX: {
-            linear_expression_t addr = mem_reg.ctx_offset + offset;
+            LinearExpression addr = mem_reg.ctx_offset + offset;
             do_load_ctx(inv, target_reg, addr, width);
             break;
         }
         case T_STACK: {
-            linear_expression_t addr = mem_reg.stack_offset + offset;
+            LinearExpression addr = mem_reg.stack_offset + offset;
             do_load_stack(inv, target_reg, addr, width, b.access.basereg);
             break;
         }
         case T_PACKET: {
-            linear_expression_t addr = mem_reg.packet_offset + offset;
+            LinearExpression addr = mem_reg.packet_offset + offset;
             do_load_packet_or_shared(inv, target_reg, addr, width);
             break;
         }
         default: {
-            linear_expression_t addr = mem_reg.shared_offset + offset;
+            LinearExpression addr = mem_reg.shared_offset + offset;
             do_load_packet_or_shared(inv, target_reg, addr, width);
             break;
         }
@@ -563,93 +562,91 @@ void ebpf_transformer::do_load(const Mem& b, const Reg& target_reg) {
     });
 }
 
-void ebpf_transformer::do_store_stack(NumAbsDomain& inv, const linear_expression_t& addr, const int width,
-                                      const linear_expression_t& val_type, const linear_expression_t& val_svalue,
-                                      const linear_expression_t& val_uvalue,
-                                      const std::optional<reg_pack_t>& opt_val_reg) {
+void EbpfTransformer::do_store_stack(NumAbsDomain& inv, const LinearExpression& addr, const int width,
+                                     const LinearExpression& val_type, const LinearExpression& val_svalue,
+                                     const LinearExpression& val_uvalue, const std::optional<RegPack>& opt_val_reg) {
     {
-        const std::optional<variable_t> var = stack.store_type(inv, addr, width, val_type);
+        const std::optional<Variable> var = stack.store_type(inv, addr, width, val_type);
         type_inv.assign_type(inv, var, val_type);
     }
     if (width == 8) {
-        inv.assign(stack.store(inv, data_kind_t::svalues, addr, width, val_svalue), val_svalue);
-        inv.assign(stack.store(inv, data_kind_t::uvalues, addr, width, val_uvalue), val_uvalue);
+        inv.assign(stack.store(inv, DataKind::svalues, addr, width, val_svalue), val_svalue);
+        inv.assign(stack.store(inv, DataKind::uvalues, addr, width, val_uvalue), val_uvalue);
 
         if (opt_val_reg && type_inv.has_type(m_inv, val_type, T_CTX)) {
-            inv.assign(stack.store(inv, data_kind_t::ctx_offsets, addr, width, opt_val_reg->ctx_offset),
+            inv.assign(stack.store(inv, DataKind::ctx_offsets, addr, width, opt_val_reg->ctx_offset),
                        opt_val_reg->ctx_offset);
         } else {
-            stack.havoc(inv, data_kind_t::ctx_offsets, addr, width);
+            stack.havoc(inv, DataKind::ctx_offsets, addr, width);
         }
 
         if (opt_val_reg &&
             (type_inv.has_type(m_inv, val_type, T_MAP) || type_inv.has_type(m_inv, val_type, T_MAP_PROGRAMS))) {
-            inv.assign(stack.store(inv, data_kind_t::map_fds, addr, width, opt_val_reg->map_fd), opt_val_reg->map_fd);
+            inv.assign(stack.store(inv, DataKind::map_fds, addr, width, opt_val_reg->map_fd), opt_val_reg->map_fd);
         } else {
-            stack.havoc(inv, data_kind_t::map_fds, addr, width);
+            stack.havoc(inv, DataKind::map_fds, addr, width);
         }
 
         if (opt_val_reg && type_inv.has_type(m_inv, val_type, T_PACKET)) {
-            inv.assign(stack.store(inv, data_kind_t::packet_offsets, addr, width, opt_val_reg->packet_offset),
+            inv.assign(stack.store(inv, DataKind::packet_offsets, addr, width, opt_val_reg->packet_offset),
                        opt_val_reg->packet_offset);
         } else {
-            stack.havoc(inv, data_kind_t::packet_offsets, addr, width);
+            stack.havoc(inv, DataKind::packet_offsets, addr, width);
         }
 
         if (opt_val_reg && type_inv.has_type(m_inv, val_type, T_SHARED)) {
-            inv.assign(stack.store(inv, data_kind_t::shared_offsets, addr, width, opt_val_reg->shared_offset),
+            inv.assign(stack.store(inv, DataKind::shared_offsets, addr, width, opt_val_reg->shared_offset),
                        opt_val_reg->shared_offset);
-            inv.assign(stack.store(inv, data_kind_t::shared_region_sizes, addr, width, opt_val_reg->shared_region_size),
+            inv.assign(stack.store(inv, DataKind::shared_region_sizes, addr, width, opt_val_reg->shared_region_size),
                        opt_val_reg->shared_region_size);
         } else {
-            stack.havoc(inv, data_kind_t::shared_region_sizes, addr, width);
-            stack.havoc(inv, data_kind_t::shared_offsets, addr, width);
+            stack.havoc(inv, DataKind::shared_region_sizes, addr, width);
+            stack.havoc(inv, DataKind::shared_offsets, addr, width);
         }
 
         if (opt_val_reg && type_inv.has_type(m_inv, val_type, T_STACK)) {
-            inv.assign(stack.store(inv, data_kind_t::stack_offsets, addr, width, opt_val_reg->stack_offset),
+            inv.assign(stack.store(inv, DataKind::stack_offsets, addr, width, opt_val_reg->stack_offset),
                        opt_val_reg->stack_offset);
-            inv.assign(stack.store(inv, data_kind_t::stack_numeric_sizes, addr, width, opt_val_reg->stack_numeric_size),
+            inv.assign(stack.store(inv, DataKind::stack_numeric_sizes, addr, width, opt_val_reg->stack_numeric_size),
                        opt_val_reg->stack_numeric_size);
         } else {
-            stack.havoc(inv, data_kind_t::stack_offsets, addr, width);
-            stack.havoc(inv, data_kind_t::stack_numeric_sizes, addr, width);
+            stack.havoc(inv, DataKind::stack_offsets, addr, width);
+            stack.havoc(inv, DataKind::stack_numeric_sizes, addr, width);
         }
     } else {
         if ((width == 1 || width == 2 || width == 4) && type_inv.get_type(m_inv, val_type) == T_NUM) {
             // Keep track of numbers on the stack that might be used as array indices.
-            if (const auto stack_svalue = stack.store(inv, data_kind_t::svalues, addr, width, val_svalue)) {
+            if (const auto stack_svalue = stack.store(inv, DataKind::svalues, addr, width, val_svalue)) {
                 inv.assign(stack_svalue, val_svalue);
                 inv->overflow_bounds(*stack_svalue, width * 8, true);
             }
-            if (const auto stack_uvalue = stack.store(inv, data_kind_t::uvalues, addr, width, val_uvalue)) {
+            if (const auto stack_uvalue = stack.store(inv, DataKind::uvalues, addr, width, val_uvalue)) {
                 inv.assign(stack_uvalue, val_uvalue);
                 inv->overflow_bounds(*stack_uvalue, width * 8, false);
             }
         } else {
-            stack.havoc(inv, data_kind_t::svalues, addr, width);
-            stack.havoc(inv, data_kind_t::uvalues, addr, width);
+            stack.havoc(inv, DataKind::svalues, addr, width);
+            stack.havoc(inv, DataKind::uvalues, addr, width);
         }
-        stack.havoc(inv, data_kind_t::ctx_offsets, addr, width);
-        stack.havoc(inv, data_kind_t::map_fds, addr, width);
-        stack.havoc(inv, data_kind_t::packet_offsets, addr, width);
-        stack.havoc(inv, data_kind_t::shared_offsets, addr, width);
-        stack.havoc(inv, data_kind_t::stack_offsets, addr, width);
-        stack.havoc(inv, data_kind_t::shared_region_sizes, addr, width);
-        stack.havoc(inv, data_kind_t::stack_numeric_sizes, addr, width);
+        stack.havoc(inv, DataKind::ctx_offsets, addr, width);
+        stack.havoc(inv, DataKind::map_fds, addr, width);
+        stack.havoc(inv, DataKind::packet_offsets, addr, width);
+        stack.havoc(inv, DataKind::shared_offsets, addr, width);
+        stack.havoc(inv, DataKind::stack_offsets, addr, width);
+        stack.havoc(inv, DataKind::shared_region_sizes, addr, width);
+        stack.havoc(inv, DataKind::stack_numeric_sizes, addr, width);
     }
 
     // Update stack_numeric_size for any stack type variables.
     // stack_numeric_size holds the number of continuous bytes starting from stack_offset that are known to be numeric.
     auto updated_lb = m_inv.eval_interval(addr).lb();
     auto updated_ub = m_inv.eval_interval(addr).ub() + width;
-    for (const variable_t type_variable : variable_t::get_type_variables()) {
+    for (const Variable type_variable : Variable::get_type_variables()) {
         if (!type_inv.has_type(inv, type_variable, T_STACK)) {
             continue;
         }
-        const variable_t stack_offset_variable = variable_t::kind_var(data_kind_t::stack_offsets, type_variable);
-        const variable_t stack_numeric_size_variable =
-            variable_t::kind_var(data_kind_t::stack_numeric_sizes, type_variable);
+        const Variable stack_offset_variable = Variable::kind_var(DataKind::stack_offsets, type_variable);
+        const Variable stack_numeric_size_variable = Variable::kind_var(DataKind::stack_numeric_sizes, type_variable);
 
         using namespace dsl_syntax;
         // See if the variable's numeric interval overlaps with changed bytes.
@@ -661,7 +658,7 @@ void ebpf_transformer::do_store_stack(NumAbsDomain& inv, const linear_expression
     }
 }
 
-void ebpf_transformer::operator()(const Mem& b) {
+void EbpfTransformer::operator()(const Mem& b) {
     if (m_inv.is_bottom()) {
         return;
     }
@@ -678,27 +675,26 @@ void ebpf_transformer::operator()(const Mem& b) {
     }
 }
 
-void ebpf_transformer::do_mem_store(const Mem& b, const linear_expression_t& val_type,
-                                    const linear_expression_t& val_svalue, const linear_expression_t& val_uvalue,
-                                    const std::optional<reg_pack_t>& opt_val_reg) {
+void EbpfTransformer::do_mem_store(const Mem& b, const LinearExpression& val_type, const LinearExpression& val_svalue,
+                                   const LinearExpression& val_uvalue, const std::optional<RegPack>& opt_val_reg) {
     if (m_inv.is_bottom()) {
         return;
     }
     const int width = b.access.width;
-    const number_t offset{b.access.offset};
+    const Number offset{b.access.offset};
     if (b.access.basereg.v == R10_STACK_POINTER) {
         const auto r10_stack_offset = reg_pack(b.access.basereg).stack_offset;
         const auto r10_interval = m_inv.eval_interval(r10_stack_offset);
         if (r10_interval.is_singleton()) {
             const int32_t stack_offset = r10_interval.singleton()->cast_to<int32_t>();
-            const number_t base_addr{stack_offset};
+            const Number base_addr{stack_offset};
             do_store_stack(m_inv, base_addr + offset, width, val_type, val_svalue, val_uvalue, opt_val_reg);
         }
         return;
     }
-    m_inv = type_inv.join_over_types(m_inv, b.access.basereg, [&](NumAbsDomain& inv, const type_encoding_t type) {
+    m_inv = type_inv.join_over_types(m_inv, b.access.basereg, [&](NumAbsDomain& inv, const TypeEncoding type) {
         if (type == T_STACK) {
-            const auto base_addr = linear_expression_t(dom.get_type_offset_variable(b.access.basereg, type).value());
+            const auto base_addr = LinearExpression(dom.get_type_offset_variable(b.access.basereg, type).value());
             do_store_stack(inv, dsl_syntax::operator+(base_addr, offset), width, val_type, val_svalue, val_uvalue,
                            opt_val_reg);
         }
@@ -721,7 +717,7 @@ static Bin atomic_to_bin(const Atomic& a) {
     return bin;
 }
 
-void ebpf_transformer::operator()(const Atomic& a) {
+void EbpfTransformer::operator()(const Atomic& a) {
     if (m_inv.is_bottom()) {
         return;
     }
@@ -772,7 +768,7 @@ void ebpf_transformer::operator()(const Atomic& a) {
     type_inv.havoc_type(m_inv, r11);
 }
 
-void ebpf_transformer::operator()(const Call& call) {
+void EbpfTransformer::operator()(const Call& call) {
     using namespace dsl_syntax;
     if (m_inv.is_bottom()) {
         return;
@@ -804,22 +800,22 @@ void ebpf_transformer::operator()(const Call& call) {
                 // checked by the checker
                 break;
             }
-            variable_t addr = variable.value();
-            variable_t width = reg_pack(param.size).svalue;
+            Variable addr = variable.value();
+            Variable width = reg_pack(param.size).svalue;
 
-            m_inv = type_inv.join_over_types(m_inv, param.mem, [&](NumAbsDomain& inv, const type_encoding_t type) {
+            m_inv = type_inv.join_over_types(m_inv, param.mem, [&](NumAbsDomain& inv, const TypeEncoding type) {
                 if (type == T_STACK) {
                     // Pointer to a memory region that the called function may change,
                     // so we must havoc.
-                    stack.havoc(inv, data_kind_t::types, addr, width);
-                    stack.havoc(inv, data_kind_t::svalues, addr, width);
-                    stack.havoc(inv, data_kind_t::uvalues, addr, width);
-                    stack.havoc(inv, data_kind_t::ctx_offsets, addr, width);
-                    stack.havoc(inv, data_kind_t::map_fds, addr, width);
-                    stack.havoc(inv, data_kind_t::packet_offsets, addr, width);
-                    stack.havoc(inv, data_kind_t::shared_offsets, addr, width);
-                    stack.havoc(inv, data_kind_t::stack_offsets, addr, width);
-                    stack.havoc(inv, data_kind_t::shared_region_sizes, addr, width);
+                    stack.havoc(inv, DataKind::types, addr, width);
+                    stack.havoc(inv, DataKind::svalues, addr, width);
+                    stack.havoc(inv, DataKind::uvalues, addr, width);
+                    stack.havoc(inv, DataKind::ctx_offsets, addr, width);
+                    stack.havoc(inv, DataKind::map_fds, addr, width);
+                    stack.havoc(inv, DataKind::packet_offsets, addr, width);
+                    stack.havoc(inv, DataKind::shared_offsets, addr, width);
+                    stack.havoc(inv, DataKind::stack_offsets, addr, width);
+                    stack.havoc(inv, DataKind::shared_region_sizes, addr, width);
                 } else {
                     store_numbers = false;
                 }
@@ -870,7 +866,7 @@ out:
     }
 }
 
-void ebpf_transformer::operator()(const CallLocal& call) {
+void EbpfTransformer::operator()(const CallLocal& call) {
     using namespace dsl_syntax;
     if (m_inv.is_bottom()) {
         return;
@@ -882,14 +878,14 @@ void ebpf_transformer::operator()(const CallLocal& call) {
     add(r10_reg, -EBPF_SUBPROGRAM_STACK_SIZE, 64);
 }
 
-void ebpf_transformer::operator()(const Callx& callx) {
+void EbpfTransformer::operator()(const Callx& callx) {
     using namespace dsl_syntax;
     if (m_inv.is_bottom()) {
         return;
     }
 
     // Look up the helper function id.
-    const reg_pack_t& reg = reg_pack(callx.func);
+    const RegPack& reg = reg_pack(callx.func);
     const auto src_interval = m_inv.eval_interval(reg.svalue);
     if (const auto sn = src_interval.singleton()) {
         if (sn->fits<int32_t>()) {
@@ -904,7 +900,7 @@ void ebpf_transformer::operator()(const Callx& callx) {
     }
 }
 
-void ebpf_transformer::do_load_mapfd(const Reg& dst_reg, const int mapfd, const bool maybe_null) {
+void EbpfTransformer::do_load_mapfd(const Reg& dst_reg, const int mapfd, const bool maybe_null) {
     const EbpfMapDescriptor& desc = thread_local_program_info->platform->get_map_descriptor(mapfd);
     const EbpfMapType& type = thread_local_program_info->platform->get_map_type(desc.type);
     if (type.value_type == EbpfMapValueType::PROGRAM) {
@@ -912,19 +908,19 @@ void ebpf_transformer::do_load_mapfd(const Reg& dst_reg, const int mapfd, const 
     } else {
         type_inv.assign_type(m_inv, dst_reg, T_MAP);
     }
-    const reg_pack_t& dst = reg_pack(dst_reg);
+    const RegPack& dst = reg_pack(dst_reg);
     m_inv.assign(dst.map_fd, mapfd);
     assign_valid_ptr(dst_reg, maybe_null);
 }
 
-void ebpf_transformer::operator()(const LoadMapFd& ins) {
+void EbpfTransformer::operator()(const LoadMapFd& ins) {
     if (m_inv.is_bottom()) {
         return;
     }
     do_load_mapfd(ins.dst, ins.mapfd, false);
 }
 
-void ebpf_transformer::do_load_map_address(const Reg& dst_reg, const int mapfd, const int32_t offset) {
+void EbpfTransformer::do_load_map_address(const Reg& dst_reg, const int mapfd, const int32_t offset) {
     const EbpfMapDescriptor& desc = thread_local_program_info->platform->get_map_descriptor(mapfd);
     const EbpfMapType& type = thread_local_program_info->platform->get_map_type(desc.type);
 
@@ -934,22 +930,22 @@ void ebpf_transformer::do_load_map_address(const Reg& dst_reg, const int mapfd, 
 
     // Set the shared region size and offset for the map.
     type_inv.assign_type(m_inv, dst_reg, T_SHARED);
-    const reg_pack_t& dst = reg_pack(dst_reg);
+    const RegPack& dst = reg_pack(dst_reg);
     m_inv.assign(dst.shared_offset, offset);
     m_inv.assign(dst.shared_region_size, desc.value_size);
     assign_valid_ptr(dst_reg, false);
 }
 
-void ebpf_transformer::operator()(const LoadMapAddress& ins) {
+void EbpfTransformer::operator()(const LoadMapAddress& ins) {
     if (m_inv.is_bottom()) {
         return;
     }
     do_load_map_address(ins.dst, ins.mapfd, ins.offset);
 }
 
-void ebpf_transformer::assign_valid_ptr(const Reg& dst_reg, const bool maybe_null) {
+void EbpfTransformer::assign_valid_ptr(const Reg& dst_reg, const bool maybe_null) {
     using namespace dsl_syntax;
-    const reg_pack_t& reg = reg_pack(dst_reg);
+    const RegPack& reg = reg_pack(dst_reg);
     m_inv.havoc(reg.svalue);
     m_inv.havoc(reg.uvalue);
     if (maybe_null) {
@@ -963,9 +959,8 @@ void ebpf_transformer::assign_valid_ptr(const Reg& dst_reg, const bool maybe_nul
 
 // If nothing is known of the stack_numeric_size,
 // try to recompute the stack_numeric_size.
-void ebpf_transformer::recompute_stack_numeric_size(NumAbsDomain& inv, const variable_t type_variable) const {
-    const variable_t stack_numeric_size_variable =
-        variable_t::kind_var(data_kind_t::stack_numeric_sizes, type_variable);
+void EbpfTransformer::recompute_stack_numeric_size(NumAbsDomain& inv, const Variable type_variable) const {
+    const Variable stack_numeric_size_variable = Variable::kind_var(DataKind::stack_numeric_sizes, type_variable);
 
     if (!inv.eval_interval(stack_numeric_size_variable).is_top()) {
         return;
@@ -973,18 +968,18 @@ void ebpf_transformer::recompute_stack_numeric_size(NumAbsDomain& inv, const var
 
     if (type_inv.has_type(inv, type_variable, T_STACK)) {
         const int numeric_size =
-            stack.min_all_num_size(inv, variable_t::kind_var(data_kind_t::stack_offsets, type_variable));
+            stack.min_all_num_size(inv, Variable::kind_var(DataKind::stack_offsets, type_variable));
         if (numeric_size > 0) {
             inv.assign(stack_numeric_size_variable, numeric_size);
         }
     }
 }
 
-void ebpf_transformer::recompute_stack_numeric_size(NumAbsDomain& inv, const Reg& reg) const {
+void EbpfTransformer::recompute_stack_numeric_size(NumAbsDomain& inv, const Reg& reg) const {
     recompute_stack_numeric_size(inv, reg_pack(reg).type);
 }
 
-void ebpf_transformer::add(const Reg& dst_reg, const int imm, const int finite_width) {
+void EbpfTransformer::add(const Reg& dst_reg, const int imm, const int finite_width) {
     const auto dst = reg_pack(dst_reg);
     m_inv->add_overflow(dst.svalue, dst.uvalue, imm, finite_width);
     if (const auto offset = dom.get_type_offset_variable(dst_reg)) {
@@ -1000,12 +995,12 @@ void ebpf_transformer::add(const Reg& dst_reg, const int imm, const int finite_w
     }
 }
 
-void ebpf_transformer::shl(const Reg& dst_reg, int imm, const int finite_width) {
+void EbpfTransformer::shl(const Reg& dst_reg, int imm, const int finite_width) {
     havoc_offsets(dst_reg);
 
     // The BPF ISA requires masking the imm.
     imm &= finite_width - 1;
-    const reg_pack_t dst = reg_pack(dst_reg);
+    const RegPack dst = reg_pack(dst_reg);
     if (m_inv.entail(type_is_number(dst))) {
         m_inv->shl(dst.svalue, dst.uvalue, imm, finite_width);
     } else {
@@ -1014,12 +1009,12 @@ void ebpf_transformer::shl(const Reg& dst_reg, int imm, const int finite_width) 
     }
 }
 
-void ebpf_transformer::lshr(const Reg& dst_reg, int imm, int finite_width) {
+void EbpfTransformer::lshr(const Reg& dst_reg, int imm, int finite_width) {
     havoc_offsets(dst_reg);
 
     // The BPF ISA requires masking the imm.
     imm &= finite_width - 1;
-    const reg_pack_t dst = reg_pack(dst_reg);
+    const RegPack dst = reg_pack(dst_reg);
     if (m_inv.entail(type_is_number(dst))) {
         m_inv->lshr(dst.svalue, dst.uvalue, imm, finite_width);
     } else {
@@ -1028,10 +1023,10 @@ void ebpf_transformer::lshr(const Reg& dst_reg, int imm, int finite_width) {
     }
 }
 
-void ebpf_transformer::ashr(const Reg& dst_reg, const linear_expression_t& right_svalue, const int finite_width) {
+void EbpfTransformer::ashr(const Reg& dst_reg, const LinearExpression& right_svalue, const int finite_width) {
     havoc_offsets(dst_reg);
 
-    const reg_pack_t dst = reg_pack(dst_reg);
+    const RegPack dst = reg_pack(dst_reg);
     if (m_inv.entail(type_is_number(dst))) {
         m_inv->ashr(dst.svalue, dst.uvalue, right_svalue, finite_width);
     } else {
@@ -1040,13 +1035,13 @@ void ebpf_transformer::ashr(const Reg& dst_reg, const linear_expression_t& right
     }
 }
 
-void ebpf_transformer::sign_extend(const Reg& dst_reg, const linear_expression_t& right_svalue, const int target_width,
-                                   const int source_width) {
+void EbpfTransformer::sign_extend(const Reg& dst_reg, const LinearExpression& right_svalue, const int target_width,
+                                  const int source_width) {
     havoc_offsets(dst_reg);
 
     type_inv.assign_type(dom.m_inv, dst_reg, T_NUM);
 
-    const reg_pack_t dst = reg_pack(dst_reg);
+    const RegPack dst = reg_pack(dst_reg);
     m_inv->sign_extend(dst.svalue, dst.uvalue, right_svalue, target_width, source_width);
 }
 
@@ -1059,7 +1054,7 @@ static int _movsx_bits(const Bin::Op op) {
     }
 }
 
-void ebpf_transformer::operator()(const Bin& bin) {
+void EbpfTransformer::operator()(const Bin& bin) {
     if (m_inv.is_bottom()) {
         return;
     }
@@ -1177,65 +1172,62 @@ void ebpf_transformer::operator()(const Bin& bin) {
             } else {
                 // Here we're not sure that lhs and rhs are the same type; they might be.
                 // But previous assertions should fail unless we know that exactly one of lhs or rhs is a pointer.
-                m_inv =
-                    type_inv.join_over_types(m_inv, bin.dst, [&](NumAbsDomain& inv, const type_encoding_t dst_type) {
-                        inv = type_inv.join_over_types(
-                            inv, src_reg, [&](NumAbsDomain& inv, const type_encoding_t src_type) {
-                                if (dst_type == T_NUM && src_type != T_NUM) {
-                                    // num += ptr
-                                    type_inv.assign_type(inv, bin.dst, src_type);
-                                    if (const auto dst_offset = dom.get_type_offset_variable(bin.dst, src_type)) {
-                                        inv->apply(arith_binop_t::ADD, dst_offset.value(), dst.svalue,
-                                                   dom.get_type_offset_variable(src_reg, src_type).value());
+                m_inv = type_inv.join_over_types(m_inv, bin.dst, [&](NumAbsDomain& inv, const TypeEncoding dst_type) {
+                    inv = type_inv.join_over_types(inv, src_reg, [&](NumAbsDomain& inv, const TypeEncoding src_type) {
+                        if (dst_type == T_NUM && src_type != T_NUM) {
+                            // num += ptr
+                            type_inv.assign_type(inv, bin.dst, src_type);
+                            if (const auto dst_offset = dom.get_type_offset_variable(bin.dst, src_type)) {
+                                inv->apply(ArithBinOp::ADD, dst_offset.value(), dst.svalue,
+                                           dom.get_type_offset_variable(src_reg, src_type).value());
+                            }
+                            if (src_type == T_SHARED) {
+                                inv.assign(dst.shared_region_size, src.shared_region_size);
+                            }
+                        } else if (dst_type != T_NUM && src_type == T_NUM) {
+                            // ptr += num
+                            type_inv.assign_type(inv, bin.dst, dst_type);
+                            if (const auto dst_offset = dom.get_type_offset_variable(bin.dst, dst_type)) {
+                                inv->apply(ArithBinOp::ADD, dst_offset.value(), dst_offset.value(), src.svalue);
+                                if (dst_type == T_STACK) {
+                                    // Reduce the numeric size.
+                                    using namespace dsl_syntax;
+                                    if (inv.intersect(src.svalue < 0)) {
+                                        inv.havoc(dst.stack_numeric_size);
+                                        recompute_stack_numeric_size(inv, dst.type);
+                                    } else {
+                                        inv->apply_signed(ArithBinOp::SUB, dst.stack_numeric_size,
+                                                          dst.stack_numeric_size, dst.stack_numeric_size, src.svalue,
+                                                          0);
                                     }
-                                    if (src_type == T_SHARED) {
-                                        inv.assign(dst.shared_region_size, src.shared_region_size);
-                                    }
-                                } else if (dst_type != T_NUM && src_type == T_NUM) {
-                                    // ptr += num
-                                    type_inv.assign_type(inv, bin.dst, dst_type);
-                                    if (const auto dst_offset = dom.get_type_offset_variable(bin.dst, dst_type)) {
-                                        inv->apply(arith_binop_t::ADD, dst_offset.value(), dst_offset.value(),
-                                                   src.svalue);
-                                        if (dst_type == T_STACK) {
-                                            // Reduce the numeric size.
-                                            using namespace dsl_syntax;
-                                            if (inv.intersect(src.svalue < 0)) {
-                                                inv.havoc(dst.stack_numeric_size);
-                                                recompute_stack_numeric_size(inv, dst.type);
-                                            } else {
-                                                inv->apply_signed(arith_binop_t::SUB, dst.stack_numeric_size,
-                                                                  dst.stack_numeric_size, dst.stack_numeric_size,
-                                                                  src.svalue, 0);
-                                            }
-                                        }
-                                    }
-                                } else if (dst_type == T_NUM && src_type == T_NUM) {
-                                    // dst and src don't necessarily have the same type, but among the possibilities
-                                    // enumerated is the case where they are both numbers.
-                                    inv->apply_signed(arith_binop_t::ADD, dst.svalue, dst.uvalue, dst.svalue,
-                                                      src.svalue, finite_width);
-                                } else {
-                                    // We ignore the cases here that do not match the assumption described
-                                    // above.  Joining bottom with another results will leave the other
-                                    // results unchanged.
-                                    inv.set_to_bottom();
                                 }
-                            });
+                            }
+                        } else if (dst_type == T_NUM && src_type == T_NUM) {
+                            // dst and src don't necessarily have the same type, but among the possibilities
+                            // enumerated is the case where they are both numbers.
+                            inv->apply_signed(ArithBinOp::ADD, dst.svalue, dst.uvalue, dst.svalue, src.svalue,
+                                              finite_width);
+                        } else {
+                            // We ignore the cases here that do not match the assumption described
+                            // above.  Joining bottom with another results will leave the other
+                            // results unchanged.
+                            inv.set_to_bottom();
+                        }
                     });
+                });
                 // careful: change dst.value only after dealing with offset
-                m_inv->apply_signed(arith_binop_t::ADD, dst.svalue, dst.uvalue, dst.svalue, src.svalue, finite_width);
+                m_inv->apply_signed(ArithBinOp::ADD, dst.svalue, dst.uvalue, dst.svalue, src.svalue, finite_width);
             }
             break;
         }
         case Bin::Op::SUB: {
             if (type_inv.same_type(m_inv, bin.dst, std::get<Reg>(bin.v))) {
                 // src and dest have the same type.
-                m_inv = type_inv.join_over_types(m_inv, bin.dst, [&](NumAbsDomain& inv, const type_encoding_t type) {
+                m_inv = type_inv.join_over_types(m_inv, bin.dst, [&](NumAbsDomain& inv, const TypeEncoding type) {
                     switch (type) {
                     case T_NUM:
                         // This is: sub_overflow(inv, dst.value, src.value, finite_width);
-                        inv->apply_signed(arith_binop_t::SUB, dst.svalue, dst.uvalue, dst.svalue, src.svalue,
+                        inv->apply_signed(ArithBinOp::SUB, dst.svalue, dst.uvalue, dst.svalue, src.svalue,
                                           finite_width);
                         type_inv.assign_type(inv, bin.dst, T_NUM);
                         prevail::havoc_offsets(inv, bin.dst);
@@ -1244,7 +1236,7 @@ void ebpf_transformer::operator()(const Bin& bin) {
                         // ptr -= ptr
                         // Assertions should make sure we only perform this on non-shared pointers.
                         if (const auto dst_offset = dom.get_type_offset_variable(bin.dst, type)) {
-                            inv->apply_signed(arith_binop_t::SUB, dst.svalue, dst.uvalue, dst_offset.value(),
+                            inv->apply_signed(ArithBinOp::SUB, dst.svalue, dst.uvalue, dst_offset.value(),
                                               dom.get_type_offset_variable(src_reg, type).value(), finite_width);
                             inv.havoc(dst_offset.value());
                         }
@@ -1272,7 +1264,7 @@ void ebpf_transformer::operator()(const Bin& bin) {
                                 m_inv.havoc(dst.stack_numeric_size);
                                 recompute_stack_numeric_size(m_inv, dst.type);
                             } else {
-                                m_inv->apply(arith_binop_t::ADD, dst.stack_numeric_size, dst.stack_numeric_size,
+                                m_inv->apply(ArithBinOp::ADD, dst.stack_numeric_size, dst.stack_numeric_size,
                                              src.svalue);
                             }
                         }
@@ -1312,7 +1304,7 @@ void ebpf_transformer::operator()(const Bin& bin) {
         case Bin::Op::LSH:
             if (m_inv.entail(type_is_number(src_reg))) {
                 auto src_interval = m_inv.eval_interval(src.uvalue);
-                if (std::optional<number_t> sn = src_interval.singleton()) {
+                if (std::optional<Number> sn = src_interval.singleton()) {
                     // truncate to uint64?
                     uint64_t imm = sn->cast_to<uint64_t>() & (bin.is64 ? 63 : 31);
                     if (imm <= std::numeric_limits<int32_t>::max()) {
@@ -1331,7 +1323,7 @@ void ebpf_transformer::operator()(const Bin& bin) {
         case Bin::Op::RSH:
             if (m_inv.entail(type_is_number(src_reg))) {
                 auto src_interval = m_inv.eval_interval(src.uvalue);
-                if (std::optional<number_t> sn = src_interval.singleton()) {
+                if (std::optional<Number> sn = src_interval.singleton()) {
                     uint64_t imm = sn->cast_to<uint64_t>() & (bin.is64 ? 63 : 31);
                     if (imm <= std::numeric_limits<int32_t>::max()) {
                         if (!bin.is64) {
@@ -1365,7 +1357,7 @@ void ebpf_transformer::operator()(const Bin& bin) {
         case Bin::Op::MOVSX32: {
             const int source_width = _movsx_bits(bin.op);
             // Keep relational information if operation is a no-op.
-            if (dst.svalue == src.svalue && m_inv.eval_interval(dst.svalue) <= interval_t::signed_int(source_width)) {
+            if (dst.svalue == src.svalue && m_inv.eval_interval(dst.svalue) <= Interval::signed_int(source_width)) {
                 return;
             }
             if (m_inv.entail(type_is_number(src_reg))) {
@@ -1380,13 +1372,13 @@ void ebpf_transformer::operator()(const Bin& bin) {
         case Bin::Op::MOV:
             // Keep relational information if operation is a no-op.
             if (dst.svalue == src.svalue &&
-                m_inv.eval_interval(dst.uvalue) <= interval_t::unsigned_int(bin.is64 ? 64 : 32)) {
+                m_inv.eval_interval(dst.uvalue) <= Interval::unsigned_int(bin.is64 ? 64 : 32)) {
                 return;
             }
             m_inv.assign(dst.svalue, src.svalue);
             m_inv.assign(dst.uvalue, src.uvalue);
             havoc_offsets(bin.dst);
-            m_inv = type_inv.join_over_types(m_inv, src_reg, [&](NumAbsDomain& inv, const type_encoding_t type) {
+            m_inv = type_inv.join_over_types(m_inv, src_reg, [&](NumAbsDomain& inv, const TypeEncoding type) {
                 switch (type) {
                 case T_CTX:
                     if (bin.is64) {
@@ -1441,20 +1433,20 @@ void ebpf_transformer::operator()(const Bin& bin) {
     }
 }
 
-void ebpf_transformer::initialize_loop_counter(const label_t& label) {
-    m_inv.assign(variable_t::loop_counter(to_string(label)), 0);
+void EbpfTransformer::initialize_loop_counter(const Label& label) {
+    m_inv.assign(Variable::loop_counter(to_string(label)), 0);
 }
 
-void ebpf_transformer::operator()(const IncrementLoopCounter& ins) {
+void EbpfTransformer::operator()(const IncrementLoopCounter& ins) {
     if (m_inv.is_bottom()) {
         return;
     }
-    const auto counter = variable_t::loop_counter(to_string(ins.name));
+    const auto counter = Variable::loop_counter(to_string(ins.name));
     m_inv->add(counter, 1);
 }
 
-void ebpf_domain_initialize_loop_counter(ebpf_domain_t& dom, const label_t& label) {
-    ebpf_transformer{dom}.initialize_loop_counter(label);
+void ebpf_domain_initialize_loop_counter(EbpfDomain& dom, const Label& label) {
+    EbpfTransformer{dom}.initialize_loop_counter(label);
 }
 
 } // namespace prevail

--- a/src/crab/finite_domain.hpp
+++ b/src/crab/finite_domain.hpp
@@ -59,7 +59,7 @@ class FiniteDomain {
     }
 
     [[nodiscard]]
-    FiniteDomain widening_thresholds(const FiniteDomain& o, const thresholds_t& ts) const {
+    FiniteDomain widening_thresholds(const FiniteDomain& o, const Thresholds& ts) const {
         // TODO: use thresholds
         return this->widen(o);
     }
@@ -77,72 +77,70 @@ class FiniteDomain {
         return FiniteDomain{dom.narrow(o.dom)};
     }
 
-    interval_t eval_interval(const variable_t& v) const { return dom.eval_interval(v); }
-    interval_t eval_interval(const linear_expression_t& exp) const { return dom.eval_interval(exp); }
+    Interval eval_interval(const Variable& v) const { return dom.eval_interval(v); }
+    Interval eval_interval(const LinearExpression& exp) const { return dom.eval_interval(exp); }
 
-    void assign(variable_t x, const std::optional<linear_expression_t>& e);
-    void assign(variable_t x, variable_t e);
-    void assign(variable_t x, const linear_expression_t& e);
-    void assign(variable_t x, int64_t e);
+    void assign(Variable x, const std::optional<LinearExpression>& e);
+    void assign(Variable x, Variable e);
+    void assign(Variable x, const LinearExpression& e);
+    void assign(Variable x, int64_t e);
 
-    void apply(arith_binop_t op, variable_t x, variable_t y, const number_t& z, int finite_width);
-    void apply(arith_binop_t op, variable_t x, variable_t y, variable_t z, int finite_width);
-    void apply(bitwise_binop_t op, variable_t x, variable_t y, variable_t z, int finite_width);
-    void apply(bitwise_binop_t op, variable_t x, variable_t y, const number_t& k, int finite_width);
-    void apply(binop_t op, variable_t x, variable_t y, const number_t& z, int finite_width);
-    void apply(binop_t op, variable_t x, variable_t y, variable_t z, int finite_width);
-    void apply(const binop_t& op, const variable_t x, const variable_t y, const variable_t z) { apply(op, x, y, z, 0); }
+    void apply(ArithBinOp op, Variable x, Variable y, const Number& z, int finite_width);
+    void apply(ArithBinOp op, Variable x, Variable y, Variable z, int finite_width);
+    void apply(BitwiseBinOp op, Variable x, Variable y, Variable z, int finite_width);
+    void apply(BitwiseBinOp op, Variable x, Variable y, const Number& k, int finite_width);
+    void apply(BinOp op, Variable x, Variable y, const Number& z, int finite_width);
+    void apply(BinOp op, Variable x, Variable y, Variable z, int finite_width);
+    void apply(const BinOp& op, const Variable x, const Variable y, const Variable z) { apply(op, x, y, z, 0); }
 
-    void overflow_bounds(variable_t lhs, int finite_width, bool issigned);
-    void overflow_bounds(variable_t svalue, variable_t uvalue, int finite_width);
+    void overflow_bounds(Variable lhs, int finite_width, bool issigned);
+    void overflow_bounds(Variable svalue, Variable uvalue, int finite_width);
 
-    void apply_signed(const binop_t& op, variable_t xs, variable_t xu, variable_t y, const number_t& z,
-                      int finite_width);
-    void apply_signed(const binop_t& op, variable_t xs, variable_t xu, variable_t y, variable_t z, int finite_width);
-    void apply_unsigned(const binop_t& op, variable_t xs, variable_t xu, variable_t y, const number_t& z,
-                        int finite_width);
-    void apply_unsigned(const binop_t& op, variable_t xs, variable_t xu, variable_t y, variable_t z, int finite_width);
+    void apply_signed(const BinOp& op, Variable xs, Variable xu, Variable y, const Number& z, int finite_width);
+    void apply_signed(const BinOp& op, Variable xs, Variable xu, Variable y, Variable z, int finite_width);
+    void apply_unsigned(const BinOp& op, Variable xs, Variable xu, Variable y, const Number& z, int finite_width);
+    void apply_unsigned(const BinOp& op, Variable xs, Variable xu, Variable y, Variable z, int finite_width);
 
-    void add(variable_t lhs, variable_t op2);
-    void add(variable_t lhs, const number_t& op2);
-    void sub(variable_t lhs, variable_t op2);
-    void sub(variable_t lhs, const number_t& op2);
-    void add_overflow(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width);
-    void add_overflow(variable_t lhss, variable_t lhsu, const number_t& op2, int finite_width);
-    void sub_overflow(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width);
-    void sub_overflow(variable_t lhss, variable_t lhsu, const number_t& op2, int finite_width);
-    void neg(variable_t lhss, variable_t lhsu, int finite_width);
-    void mul(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width);
-    void mul(variable_t lhss, variable_t lhsu, const number_t& op2, int finite_width);
-    void sdiv(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width);
-    void sdiv(variable_t lhss, variable_t lhsu, const number_t& op2, int finite_width);
-    void udiv(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width);
-    void udiv(variable_t lhss, variable_t lhsu, const number_t& op2, int finite_width);
-    void srem(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width);
-    void srem(variable_t lhss, variable_t lhsu, const number_t& op2, int finite_width);
-    void urem(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width);
-    void urem(variable_t lhss, variable_t lhsu, const number_t& op2, int finite_width);
+    void add(Variable lhs, Variable op2);
+    void add(Variable lhs, const Number& op2);
+    void sub(Variable lhs, Variable op2);
+    void sub(Variable lhs, const Number& op2);
+    void add_overflow(Variable lhss, Variable lhsu, Variable op2, int finite_width);
+    void add_overflow(Variable lhss, Variable lhsu, const Number& op2, int finite_width);
+    void sub_overflow(Variable lhss, Variable lhsu, Variable op2, int finite_width);
+    void sub_overflow(Variable lhss, Variable lhsu, const Number& op2, int finite_width);
+    void neg(Variable lhss, Variable lhsu, int finite_width);
+    void mul(Variable lhss, Variable lhsu, Variable op2, int finite_width);
+    void mul(Variable lhss, Variable lhsu, const Number& op2, int finite_width);
+    void sdiv(Variable lhss, Variable lhsu, Variable op2, int finite_width);
+    void sdiv(Variable lhss, Variable lhsu, const Number& op2, int finite_width);
+    void udiv(Variable lhss, Variable lhsu, Variable op2, int finite_width);
+    void udiv(Variable lhss, Variable lhsu, const Number& op2, int finite_width);
+    void srem(Variable lhss, Variable lhsu, Variable op2, int finite_width);
+    void srem(Variable lhss, Variable lhsu, const Number& op2, int finite_width);
+    void urem(Variable lhss, Variable lhsu, Variable op2, int finite_width);
+    void urem(Variable lhss, Variable lhsu, const Number& op2, int finite_width);
 
-    void bitwise_and(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width);
-    void bitwise_and(variable_t lhss, variable_t lhsu, const number_t& op2);
-    void bitwise_or(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width);
-    void bitwise_or(variable_t lhss, variable_t lhsu, const number_t& op2);
-    void bitwise_xor(variable_t lhsss, variable_t lhsu, variable_t op2, int finite_width);
-    void bitwise_xor(variable_t lhss, variable_t lhsu, const number_t& op2);
-    void shl_overflow(variable_t lhss, variable_t lhsu, variable_t op2);
-    void shl_overflow(variable_t lhss, variable_t lhsu, const number_t& op2);
-    void shl(variable_t svalue, variable_t uvalue, int imm, int finite_width);
-    void lshr(variable_t svalue, variable_t uvalue, int imm, int finite_width);
-    void ashr(variable_t svalue, variable_t uvalue, const linear_expression_t& right_svalue, int finite_width);
-    void sign_extend(variable_t svalue, variable_t uvalue, const linear_expression_t& right_svalue, int target_width,
+    void bitwise_and(Variable lhss, Variable lhsu, Variable op2, int finite_width);
+    void bitwise_and(Variable lhss, Variable lhsu, const Number& op2);
+    void bitwise_or(Variable lhss, Variable lhsu, Variable op2, int finite_width);
+    void bitwise_or(Variable lhss, Variable lhsu, const Number& op2);
+    void bitwise_xor(Variable lhsss, Variable lhsu, Variable op2, int finite_width);
+    void bitwise_xor(Variable lhss, Variable lhsu, const Number& op2);
+    void shl_overflow(Variable lhss, Variable lhsu, Variable op2);
+    void shl_overflow(Variable lhss, Variable lhsu, const Number& op2);
+    void shl(Variable svalue, Variable uvalue, int imm, int finite_width);
+    void lshr(Variable svalue, Variable uvalue, int imm, int finite_width);
+    void ashr(Variable svalue, Variable uvalue, const LinearExpression& right_svalue, int finite_width);
+    void sign_extend(Variable svalue, Variable uvalue, const LinearExpression& right_svalue, int target_width,
                      int source_width);
 
-    bool add_constraint(const linear_constraint_t& cst) { return dom.add_constraint(cst); }
+    bool add_constraint(const LinearConstraint& cst) { return dom.add_constraint(cst); }
 
-    void set(const variable_t x, const interval_t& intv) { dom.set(x, intv); }
+    void set(const Variable x, const Interval& intv) { dom.set(x, intv); }
 
     /// Forget everything we know about the value of a variable.
-    void havoc(variable_t v) { dom.havoc(v); }
+    void havoc(Variable v) { dom.havoc(v); }
 
     [[nodiscard]]
     std::pair<std::size_t, std::size_t> size() const {
@@ -151,102 +149,94 @@ class FiniteDomain {
 
     // Return true if inv intersects with cst.
     [[nodiscard]]
-    bool intersect(const linear_constraint_t& cst) const {
+    bool intersect(const LinearConstraint& cst) const {
         return dom.intersect(cst);
     }
 
     // Return true if entails rhs.
     [[nodiscard]]
-    bool entail(const linear_constraint_t& rhs) const {
+    bool entail(const LinearConstraint& rhs) const {
         return dom.entail(rhs);
     }
 
     friend std::ostream& operator<<(std::ostream& o, const FiniteDomain& dom) { return o << dom.dom; }
 
     [[nodiscard]]
-    string_invariant to_set() const {
+    StringInvariant to_set() const {
         return dom.to_set();
     }
 
     static void clear_thread_local_state() { SplitDBM::clear_thread_local_state(); }
 
   private:
-    std::vector<linear_constraint_t> assume_signed_64bit_eq(variable_t left_svalue, variable_t left_uvalue,
-                                                            const interval_t& right_interval,
-                                                            const linear_expression_t& right_svalue,
-                                                            const linear_expression_t& right_uvalue) const;
-    std::vector<linear_constraint_t> assume_signed_32bit_eq(variable_t left_svalue, variable_t left_uvalue,
-                                                            const interval_t& right_interval) const;
+    std::vector<LinearConstraint> assume_signed_64bit_eq(Variable left_svalue, Variable left_uvalue,
+                                                         const Interval& right_interval,
+                                                         const LinearExpression& right_svalue,
+                                                         const LinearExpression& right_uvalue) const;
+    std::vector<LinearConstraint> assume_signed_32bit_eq(Variable left_svalue, Variable left_uvalue,
+                                                         const Interval& right_interval) const;
 
-    std::vector<linear_constraint_t> assume_bit_cst_interval(Condition::Op op, bool is64, interval_t dst_interval,
-                                                             interval_t src_interval) const;
+    std::vector<LinearConstraint> assume_bit_cst_interval(Condition::Op op, bool is64, Interval dst_interval,
+                                                          Interval src_interval) const;
 
-    void get_unsigned_intervals(bool is64, variable_t left_svalue, variable_t left_uvalue,
-                                const linear_expression_t& right_uvalue, interval_t& left_interval,
-                                interval_t& right_interval, interval_t& left_interval_low,
-                                interval_t& left_interval_high) const;
-    std::vector<linear_constraint_t> assume_signed_64bit_lt(bool strict, variable_t left_svalue, variable_t left_uvalue,
-                                                            const interval_t& left_interval_positive,
-                                                            const interval_t& left_interval_negative,
-                                                            const linear_expression_t& right_svalue,
-                                                            const linear_expression_t& right_uvalue,
-                                                            const interval_t& right_interval) const;
-    std::vector<linear_constraint_t> assume_signed_32bit_lt(bool strict, variable_t left_svalue, variable_t left_uvalue,
-                                                            const interval_t& left_interval_positive,
-                                                            const interval_t& left_interval_negative,
-                                                            const linear_expression_t& right_svalue,
-                                                            const linear_expression_t& right_uvalue,
-                                                            const interval_t& right_interval) const;
-    std::vector<linear_constraint_t> assume_signed_64bit_gt(bool strict, variable_t left_svalue, variable_t left_uvalue,
-                                                            const interval_t& left_interval_positive,
-                                                            const interval_t& left_interval_negative,
-                                                            const linear_expression_t& right_svalue,
-                                                            const linear_expression_t& right_uvalue,
-                                                            const interval_t& right_interval) const;
-    std::vector<linear_constraint_t> assume_signed_32bit_gt(bool strict, variable_t left_svalue, variable_t left_uvalue,
-                                                            const interval_t& left_interval_positive,
-                                                            const interval_t& left_interval_negative,
-                                                            const linear_expression_t& right_svalue,
-                                                            const linear_expression_t& right_uvalue,
-                                                            const interval_t& right_interval) const;
-    std::vector<linear_constraint_t> assume_signed_cst_interval(Condition::Op op, bool is64, variable_t left_svalue,
-                                                                variable_t left_uvalue,
-                                                                const linear_expression_t& right_svalue,
-                                                                const linear_expression_t& right_uvalue) const;
-    std::vector<linear_constraint_t>
-    assume_unsigned_64bit_lt(bool strict, variable_t left_svalue, variable_t left_uvalue,
-                             const interval_t& left_interval_low, const interval_t& left_interval_high,
-                             const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
-                             const interval_t& right_interval) const;
-    std::vector<linear_constraint_t> assume_unsigned_32bit_lt(bool strict, variable_t left_svalue,
-                                                              variable_t left_uvalue,
-                                                              const linear_expression_t& right_svalue,
-                                                              const linear_expression_t& right_uvalue) const;
-    std::vector<linear_constraint_t>
-    assume_unsigned_64bit_gt(bool strict, variable_t left_svalue, variable_t left_uvalue,
-                             const interval_t& left_interval_low, const interval_t& left_interval_high,
-                             const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
-                             const interval_t& right_interval) const;
-    std::vector<linear_constraint_t>
-    assume_unsigned_32bit_gt(bool strict, variable_t left_svalue, variable_t left_uvalue,
-                             const interval_t& left_interval_low, const interval_t& left_interval_high,
-                             const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
-                             const interval_t& right_interval) const;
-    std::vector<linear_constraint_t> assume_unsigned_cst_interval(Condition::Op op, bool is64, variable_t left_svalue,
-                                                                  variable_t left_uvalue,
-                                                                  const linear_expression_t& right_svalue,
-                                                                  const linear_expression_t& right_uvalue) const;
+    void get_unsigned_intervals(bool is64, Variable left_svalue, Variable left_uvalue,
+                                const LinearExpression& right_uvalue, Interval& left_interval, Interval& right_interval,
+                                Interval& left_interval_low, Interval& left_interval_high) const;
+    std::vector<LinearConstraint> assume_signed_64bit_lt(bool strict, Variable left_svalue, Variable left_uvalue,
+                                                         const Interval& left_interval_positive,
+                                                         const Interval& left_interval_negative,
+                                                         const LinearExpression& right_svalue,
+                                                         const LinearExpression& right_uvalue,
+                                                         const Interval& right_interval) const;
+    std::vector<LinearConstraint> assume_signed_32bit_lt(bool strict, Variable left_svalue, Variable left_uvalue,
+                                                         const Interval& left_interval_positive,
+                                                         const Interval& left_interval_negative,
+                                                         const LinearExpression& right_svalue,
+                                                         const LinearExpression& right_uvalue,
+                                                         const Interval& right_interval) const;
+    std::vector<LinearConstraint> assume_signed_64bit_gt(bool strict, Variable left_svalue, Variable left_uvalue,
+                                                         const Interval& left_interval_positive,
+                                                         const Interval& left_interval_negative,
+                                                         const LinearExpression& right_svalue,
+                                                         const LinearExpression& right_uvalue,
+                                                         const Interval& right_interval) const;
+    std::vector<LinearConstraint> assume_signed_32bit_gt(bool strict, Variable left_svalue, Variable left_uvalue,
+                                                         const Interval& left_interval_positive,
+                                                         const Interval& left_interval_negative,
+                                                         const LinearExpression& right_svalue,
+                                                         const LinearExpression& right_uvalue,
+                                                         const Interval& right_interval) const;
+    std::vector<LinearConstraint> assume_signed_cst_interval(Condition::Op op, bool is64, Variable left_svalue,
+                                                             Variable left_uvalue, const LinearExpression& right_svalue,
+                                                             const LinearExpression& right_uvalue) const;
+    std::vector<LinearConstraint>
+    assume_unsigned_64bit_lt(bool strict, Variable left_svalue, Variable left_uvalue, const Interval& left_interval_low,
+                             const Interval& left_interval_high, const LinearExpression& right_svalue,
+                             const LinearExpression& right_uvalue, const Interval& right_interval) const;
+    std::vector<LinearConstraint> assume_unsigned_32bit_lt(bool strict, Variable left_svalue, Variable left_uvalue,
+                                                           const LinearExpression& right_svalue,
+                                                           const LinearExpression& right_uvalue) const;
+    std::vector<LinearConstraint>
+    assume_unsigned_64bit_gt(bool strict, Variable left_svalue, Variable left_uvalue, const Interval& left_interval_low,
+                             const Interval& left_interval_high, const LinearExpression& right_svalue,
+                             const LinearExpression& right_uvalue, const Interval& right_interval) const;
+    std::vector<LinearConstraint>
+    assume_unsigned_32bit_gt(bool strict, Variable left_svalue, Variable left_uvalue, const Interval& left_interval_low,
+                             const Interval& left_interval_high, const LinearExpression& right_svalue,
+                             const LinearExpression& right_uvalue, const Interval& right_interval) const;
+    std::vector<LinearConstraint> assume_unsigned_cst_interval(Condition::Op op, bool is64, Variable left_svalue,
+                                                               Variable left_uvalue,
+                                                               const LinearExpression& right_svalue,
+                                                               const LinearExpression& right_uvalue) const;
 
-    void get_signed_intervals(bool is64, variable_t left_svalue, variable_t left_uvalue,
-                              const linear_expression_t& right_svalue, interval_t& left_interval,
-                              interval_t& right_interval, interval_t& left_interval_positive,
-                              interval_t& left_interval_negative) const;
+    void get_signed_intervals(bool is64, Variable left_svalue, Variable left_uvalue,
+                              const LinearExpression& right_svalue, Interval& left_interval, Interval& right_interval,
+                              Interval& left_interval_positive, Interval& left_interval_negative) const;
 
   public:
-    std::vector<linear_constraint_t> assume_cst_imm(Condition::Op op, bool is64, variable_t dst_svalue,
-                                                    variable_t dst_uvalue, int64_t imm) const;
-    std::vector<linear_constraint_t> assume_cst_reg(Condition::Op op, bool is64, variable_t dst_svalue,
-                                                    variable_t dst_uvalue, variable_t src_svalue,
-                                                    variable_t src_uvalue) const;
+    std::vector<LinearConstraint> assume_cst_imm(Condition::Op op, bool is64, Variable dst_svalue, Variable dst_uvalue,
+                                                 int64_t imm) const;
+    std::vector<LinearConstraint> assume_cst_reg(Condition::Op op, bool is64, Variable dst_svalue, Variable dst_uvalue,
+                                                 Variable src_svalue, Variable src_uvalue) const;
 };
 } // namespace prevail

--- a/src/crab/fwd_analyzer.hpp
+++ b/src/crab/fwd_analyzer.hpp
@@ -9,12 +9,12 @@
 
 namespace prevail {
 
-struct invariant_map_pair {
-    ebpf_domain_t pre;
-    ebpf_domain_t post;
+struct InvariantMapPair {
+    EbpfDomain pre;
+    EbpfDomain post;
 };
-using invariant_table_t = std::map<label_t, invariant_map_pair>;
+using InvariantTable = std::map<Label, InvariantMapPair>;
 
-invariant_table_t run_forward_analyzer(const Program& prog, ebpf_domain_t entry_inv);
+InvariantTable run_forward_analyzer(const Program& prog, EbpfDomain entry_inv);
 
 } // namespace prevail

--- a/src/crab/interval.cpp
+++ b/src/crab/interval.cpp
@@ -4,17 +4,17 @@
 
 namespace prevail {
 
-static interval_t make_dividend_when_both_nonzero(const interval_t& dividend, const interval_t& divisor) {
+static Interval make_dividend_when_both_nonzero(const Interval& dividend, const Interval& divisor) {
     if (dividend.ub() >= 0) {
         return dividend;
     }
     if (divisor.ub() < 0) {
-        return dividend + divisor + interval_t{1};
+        return dividend + divisor + Interval{1};
     }
-    return dividend + interval_t{1} - divisor;
+    return dividend + Interval{1} - divisor;
 }
 
-interval_t interval_t::operator*(const interval_t& x) const {
+Interval Interval::operator*(const Interval& x) const {
     if (is_bottom() || x.is_bottom()) {
         return bottom();
     }
@@ -24,11 +24,11 @@ interval_t interval_t::operator*(const interval_t& x) const {
         _ub * x._lb,
         _ub * x._ub,
     });
-    return interval_t{clb, cub};
+    return Interval{clb, cub};
 }
 
 // Signed division. eBPF has no instruction for this.
-interval_t interval_t::operator/(const interval_t& x) const {
+Interval Interval::operator/(const Interval& x) const {
     if (is_bottom() || x.is_bottom()) {
         return bottom();
     }
@@ -36,43 +36,43 @@ interval_t interval_t::operator/(const interval_t& x) const {
         // Divisor is a singleton:
         //   the linear interval solver can perform many divisions where
         //   the divisor is a singleton interval. We optimize for this case.
-        number_t c = *n;
+        Number c = *n;
         if (c == 1) {
             return *this;
         } else if (c > 0) {
-            return interval_t{_lb / c, _ub / c};
+            return Interval{_lb / c, _ub / c};
         } else if (c < 0) {
-            return interval_t{_ub / c, _lb / c};
+            return Interval{_ub / c, _lb / c};
         } else {
             // The eBPF ISA defines division by 0 as resulting in 0.
-            return interval_t{0};
+            return Interval{0};
         }
     }
     if (x.contains(0)) {
         // The divisor contains 0.
-        interval_t l{x._lb, -1};
-        interval_t u{1, x._ub};
-        return operator/(l) | operator/(u) | interval_t{0};
+        Interval l{x._lb, -1};
+        Interval u{1, x._ub};
+        return operator/(l) | operator/(u) | Interval{0};
     } else if (contains(0)) {
         // The dividend contains 0.
-        interval_t l{_lb, -1};
-        interval_t u{1, _ub};
-        return (l / x) | (u / x) | interval_t{0};
+        Interval l{_lb, -1};
+        Interval u{1, _ub};
+        return (l / x) | (u / x) | Interval{0};
     } else {
         // Neither the dividend nor the divisor contains 0
-        interval_t a = make_dividend_when_both_nonzero(*this, x);
+        Interval a = make_dividend_when_both_nonzero(*this, x);
         const auto [clb, cub] = std::minmax({
             a._lb / x._lb,
             a._lb / x._ub,
             a._ub / x._lb,
             a._ub / x._ub,
         });
-        return interval_t{clb, cub};
+        return Interval{clb, cub};
     }
 }
 
 // Signed division.
-interval_t interval_t::sdiv(const interval_t& x) const {
+Interval Interval::sdiv(const Interval& x) const {
     if (is_bottom() || x.is_bottom()) {
         return bottom();
     }
@@ -81,42 +81,42 @@ interval_t interval_t::sdiv(const interval_t& x) const {
             // Divisor is a singleton:
             //   the linear interval solver can perform many divisions where
             //   the divisor is a singleton interval. We optimize for this case.
-            number_t c{n->cast_to<int64_t>()};
+            Number c{n->cast_to<int64_t>()};
             if (c == 1) {
                 return *this;
             } else if (c != 0) {
-                return interval_t{_lb / c, _ub / c};
+                return Interval{_lb / c, _ub / c};
             } else {
                 // The eBPF ISA defines division by 0 as resulting in 0.
-                return interval_t{0};
+                return Interval{0};
             }
         }
     }
     if (x.contains(0)) {
         // The divisor contains 0.
-        interval_t l{x._lb, -1};
-        interval_t u{1, x._ub};
-        return sdiv(l) | sdiv(u) | interval_t{0};
+        Interval l{x._lb, -1};
+        Interval u{1, x._ub};
+        return sdiv(l) | sdiv(u) | Interval{0};
     } else if (contains(0)) {
         // The dividend contains 0.
-        interval_t l{_lb, -1};
-        interval_t u{1, _ub};
-        return l.sdiv(x) | u.sdiv(x) | interval_t{0};
+        Interval l{_lb, -1};
+        Interval u{1, _ub};
+        return l.sdiv(x) | u.sdiv(x) | Interval{0};
     } else {
         // Neither the dividend nor the divisor contains 0
-        interval_t a = make_dividend_when_both_nonzero(*this, x);
+        Interval a = make_dividend_when_both_nonzero(*this, x);
         const auto [clb, cub] = std::minmax({
             a._lb / x._lb,
             a._lb / x._ub,
             a._ub / x._lb,
             a._ub / x._ub,
         });
-        return interval_t{clb, cub};
+        return Interval{clb, cub};
     }
 }
 
 // Unsigned division.
-interval_t interval_t::udiv(const interval_t& x) const {
+Interval Interval::udiv(const Interval& x) const {
     if (is_bottom() || x.is_bottom()) {
         return bottom();
     }
@@ -125,42 +125,42 @@ interval_t interval_t::udiv(const interval_t& x) const {
             // Divisor is a singleton:
             //   the linear interval solver can perform many divisions where
             //   the divisor is a singleton interval. We optimize for this case.
-            number_t c{n->cast_to<uint64_t>()};
+            Number c{n->cast_to<uint64_t>()};
             if (c == 1) {
                 return *this;
             } else if (c > 0) {
-                return interval_t{_lb.udiv(c), _ub.udiv(c)};
+                return Interval{_lb.udiv(c), _ub.udiv(c)};
             } else {
                 // The eBPF ISA defines division by 0 as resulting in 0.
-                return interval_t{0};
+                return Interval{0};
             }
         }
     }
     if (x.contains(0)) {
         // The divisor contains 0.
-        interval_t l{x._lb, -1};
-        interval_t u{1, x._ub};
-        return udiv(l) | udiv(u) | interval_t{0};
+        Interval l{x._lb, -1};
+        Interval u{1, x._ub};
+        return udiv(l) | udiv(u) | Interval{0};
     }
     if (contains(0)) {
         // The dividend contains 0.
-        interval_t l{_lb, -1};
-        interval_t u{1, _ub};
-        return l.udiv(x) | u.udiv(x) | interval_t{0};
+        Interval l{_lb, -1};
+        Interval u{1, _ub};
+        return l.udiv(x) | u.udiv(x) | Interval{0};
     }
     // Neither the dividend nor the divisor contains 0
-    interval_t a = make_dividend_when_both_nonzero(*this, x);
+    Interval a = make_dividend_when_both_nonzero(*this, x);
     const auto [clb, cub] = std::minmax({
         a._lb.udiv(x._lb),
         a._lb.udiv(x._ub),
         a._ub.udiv(x._lb),
         a._ub.udiv(x._ub),
     });
-    return interval_t{clb, cub};
+    return Interval{clb, cub};
 }
 
 // Signed remainder (modulo).
-interval_t interval_t::srem(const interval_t& x) const {
+Interval Interval::srem(const Interval& x) const {
     // note that the sign of the divisor does not matter
 
     if (is_bottom() || x.is_bottom()) {
@@ -169,15 +169,15 @@ interval_t interval_t::srem(const interval_t& x) const {
     if (const auto dividend = singleton()) {
         if (const auto divisor = x.singleton()) {
             if (*divisor == 0) {
-                return interval_t{*dividend};
+                return Interval{*dividend};
             }
-            return interval_t{*dividend % *divisor};
+            return Interval{*dividend % *divisor};
         }
     }
     if (x.contains(0)) {
         // The divisor contains 0.
-        interval_t l{x._lb, -1};
-        interval_t u{1, x._ub};
+        Interval l{x._lb, -1};
+        Interval u{1, x._ub};
         return srem(l) | srem(u) | *this;
     }
     if (x.ub().is_finite() && x.lb().is_finite()) {
@@ -191,19 +191,19 @@ interval_t interval_t::srem(const interval_t& x) const {
 
         if (lb() < 0) {
             if (ub() > 0) {
-                return interval_t{-(max_divisor - 1), max_divisor - 1};
+                return Interval{-(max_divisor - 1), max_divisor - 1};
             } else {
-                return interval_t{-(max_divisor - 1), 0};
+                return Interval{-(max_divisor - 1), 0};
             }
         }
-        return interval_t{0, max_divisor - 1};
+        return Interval{0, max_divisor - 1};
     }
     // Divisor has infinite range, so result can be anything between the dividend and zero.
-    return *this | interval_t{0};
+    return *this | Interval{0};
 }
 
 // Unsigned remainder (modulo).
-interval_t interval_t::urem(const interval_t& x) const {
+Interval Interval::urem(const Interval& x) const {
     if (is_bottom() || x.is_bottom()) {
         return bottom();
     }
@@ -212,23 +212,23 @@ interval_t interval_t::urem(const interval_t& x) const {
             if (dividend->fits_cast_to<uint64_t>() && divisor->fits_cast_to<uint64_t>()) {
                 // The BPF ISA defines modulo by 0 as resulting in the original value.
                 if (*divisor == 0) {
-                    return interval_t{*dividend};
+                    return Interval{*dividend};
                 }
                 uint64_t dividend_val = dividend->cast_to<uint64_t>();
                 uint64_t divisor_val = divisor->cast_to<uint64_t>();
-                return interval_t{dividend_val % divisor_val};
+                return Interval{dividend_val % divisor_val};
             }
         }
     }
     if (x.contains(0)) {
         // The divisor contains 0.
-        interval_t l{x._lb, -1};
-        interval_t u{1, x._ub};
+        Interval l{x._lb, -1};
+        Interval u{1, x._ub};
         return urem(l) | urem(u) | *this;
     } else if (contains(0)) {
         // The dividend contains 0.
-        interval_t l{_lb, -1};
-        interval_t u{1, _ub};
+        Interval l{_lb, -1};
+        Interval u{1, _ub};
         return l.urem(x) | u.urem(x) | *this;
     } else {
         // Neither the dividend nor the divisor contains 0
@@ -236,153 +236,153 @@ interval_t interval_t::urem(const interval_t& x) const {
             // Divisor is infinite. A "negative" dividend could result in anything except
             // a value between the upper bound and 0, so set to top.  A "positive" dividend
             // could result in anything between 0 and the dividend - 1.
-            return _ub < 0 ? top() : (*this - interval_t{1}) | interval_t{0};
+            return _ub < 0 ? top() : (*this - Interval{1}) | Interval{0};
         } else if (_ub.is_finite() && _ub.number()->cast_to<uint64_t>() < x._lb.number()->cast_to<uint64_t>()) {
             // Dividend lower than divisor, so the dividend is the remainder.
             return *this;
         } else {
-            number_t max_divisor{x._ub.number()->cast_to<uint64_t>()};
-            return interval_t{0, max_divisor - 1};
+            Number max_divisor{x._ub.number()->cast_to<uint64_t>()};
+            return Interval{0, max_divisor - 1};
         }
     }
 }
 
 // Do a bitwise-AND between two uvalue intervals.
-interval_t interval_t::bitwise_and(const interval_t& x) const {
+Interval Interval::bitwise_and(const Interval& x) const {
     if (is_bottom() || x.is_bottom()) {
         return bottom();
     }
     assert(is_top() || (lb() >= 0));
     assert(x.is_top() || (x.lb() >= 0));
 
-    if (*this == interval_t{0} || x == interval_t{0}) {
-        return interval_t{0};
+    if (*this == Interval{0} || x == Interval{0}) {
+        return Interval{0};
     }
 
     if (const auto right = x.singleton()) {
         if (const auto left = singleton()) {
-            return interval_t{*left & *right};
+            return Interval{*left & *right};
         }
-        if (right == number_t::max_uint(32)) {
+        if (right == Number::max_uint(32)) {
             return zero_extend(32);
         }
-        if (right == number_t::max_uint(16)) {
+        if (right == Number::max_uint(16)) {
             return zero_extend(16);
         }
-        if (right == number_t::max_uint(8)) {
+        if (right == Number::max_uint(8)) {
             return zero_extend(8);
         }
     }
     if (x.contains(std::numeric_limits<uint64_t>::max())) {
         return truncate_to<uint64_t>();
     } else if (!is_top() && !x.is_top()) {
-        return interval_t{0, std::min(ub(), x.ub())};
+        return Interval{0, std::min(ub(), x.ub())};
     } else if (!x.is_top()) {
-        return interval_t{0, x.ub()};
+        return Interval{0, x.ub()};
     } else if (!is_top()) {
-        return interval_t{0, ub()};
+        return Interval{0, ub()};
     } else {
         return top();
     }
 }
 
-interval_t interval_t::bitwise_or(const interval_t& x) const {
+Interval Interval::bitwise_or(const Interval& x) const {
     if (is_bottom() || x.is_bottom()) {
         return bottom();
     }
     if (const auto left_op = singleton()) {
         if (const auto right_op = x.singleton()) {
-            return interval_t{*left_op | *right_op};
+            return Interval{*left_op | *right_op};
         }
     }
     if (lb() >= 0 && x.lb() >= 0) {
         if (const auto left_ub = ub().number()) {
             if (const auto right_ub = x.ub().number()) {
-                return interval_t{0, std::max(*left_ub, *right_ub).fill_ones()};
+                return Interval{0, std::max(*left_ub, *right_ub).fill_ones()};
             }
         }
-        return interval_t{0, bound_t::plus_infinity()};
+        return Interval{0, Bound::plus_infinity()};
     }
     return top();
 }
 
-interval_t interval_t::bitwise_xor(const interval_t& x) const {
+Interval Interval::bitwise_xor(const Interval& x) const {
     if (is_bottom() || x.is_bottom()) {
         return bottom();
     }
     if (const auto left_op = singleton()) {
         if (const auto right_op = x.singleton()) {
-            return interval_t{*left_op ^ *right_op};
+            return Interval{*left_op ^ *right_op};
         }
     }
     return bitwise_or(x);
 }
 
-interval_t interval_t::shl(const interval_t& x) const {
+Interval Interval::shl(const Interval& x) const {
     if (is_bottom() || x.is_bottom()) {
         return bottom();
     }
     if (const auto shift = x.singleton()) {
-        const number_t k = *shift;
+        const Number k = *shift;
         if (k < 0) {
             return top();
         }
         // Some crazy linux drivers generate shl instructions with huge shifts.
         // We limit the number of times the loop is run to avoid wasting too much time on it.
         if (k <= 128) {
-            number_t factor = 1;
+            Number factor = 1;
             for (int i = 0; k > i; i++) {
                 factor *= 2;
             }
-            return this->operator*(interval_t{factor});
+            return this->operator*(Interval{factor});
         }
     }
     return top();
 }
 
-interval_t interval_t::ashr(const interval_t& x) const {
+Interval Interval::ashr(const Interval& x) const {
     if (is_bottom() || x.is_bottom()) {
         return bottom();
     }
     if (const auto shift = x.singleton()) {
-        const number_t k = *shift;
+        const Number k = *shift;
         if (k < 0) {
             return top();
         }
         // Some crazy linux drivers generate ashr instructions with huge shifts.
         // We limit the number of times the loop is run to avoid wasting too much time on it.
         if (k <= 128) {
-            number_t factor = 1;
+            Number factor = 1;
             for (int i = 0; k > i; i++) {
                 factor *= 2;
             }
-            return this->operator/(interval_t{factor});
+            return this->operator/(Interval{factor});
         }
     }
     return top();
 }
 
-interval_t interval_t::lshr(const interval_t& x) const {
+Interval Interval::lshr(const Interval& x) const {
     if (is_bottom() || x.is_bottom()) {
         return bottom();
     }
     if (const auto shift = x.singleton()) {
         if (*shift > 0 && lb() >= 0 && ub().is_finite()) {
             const auto [lb, ub] = this->pair_number();
-            return interval_t{lb >> *shift, ub >> *shift};
+            return Interval{lb >> *shift, ub >> *shift};
         }
     }
     return top();
 }
 
-interval_t interval_t::sign_extend(const int width) const {
+Interval Interval::sign_extend(const int width) const {
     if (width <= 0) {
         CRAB_ERROR("Invalid width ", width);
     }
 
-    const interval_t full_range = signed_int(width);
+    const Interval full_range = signed_int(width);
     if (size() < full_range.size()) {
-        if (interval_t extended{_lb.sign_extend(width), _ub.sign_extend(width)}) {
+        if (Interval extended{_lb.sign_extend(width), _ub.sign_extend(width)}) {
             // If the sign–extended endpoints are in order, no wrap occurred.
             return extended;
         }
@@ -391,14 +391,14 @@ interval_t interval_t::sign_extend(const int width) const {
     return full_range;
 }
 
-interval_t interval_t::zero_extend(const int width) const {
+Interval Interval::zero_extend(const int width) const {
     if (width <= 0) {
         CRAB_ERROR("Invalid width ", width);
     }
 
-    const interval_t full_range = unsigned_int(width);
+    const Interval full_range = unsigned_int(width);
     if (size() < full_range.size()) {
-        if (interval_t extended{_lb.zero_extend(width), _ub.zero_extend(width)}) {
+        if (Interval extended{_lb.zero_extend(width), _ub.zero_extend(width)}) {
             // If the sign–extended endpoints are in order, no wrap occurred.
             return extended;
         }

--- a/src/crab/interval.hpp
+++ b/src/crab/interval.hpp
@@ -17,66 +17,65 @@
 
 namespace prevail {
 
-using bound_t = extended_number;
+using Bound = ExtendedNumber;
 
-class interval_t final {
-    bound_t _lb;
-    bound_t _ub;
+class Interval final {
+    Bound _lb;
+    Bound _ub;
 
   public:
-    static interval_t top() { return interval_t{bound_t::minus_infinity(), bound_t::plus_infinity()}; }
+    static Interval top() { return Interval{Bound::minus_infinity(), Bound::plus_infinity()}; }
 
-    static interval_t bottom() { return interval_t{}; }
+    static Interval bottom() { return Interval{}; }
 
     [[nodiscard]]
-    std::optional<number_t> finite_size() const {
+    std::optional<Number> finite_size() const {
         return (_ub - _lb).number();
     }
 
   private:
-    interval_t() : _lb(number_t{0}), _ub(-1) {}
+    Interval() : _lb(Number{0}), _ub(-1) {}
 
   public:
-    interval_t(const bound_t& lb, const bound_t& ub)
-        : _lb(lb > ub ? bound_t{number_t{0}} : lb), _ub(lb > ub ? bound_t{-1} : ub) {}
+    Interval(const Bound& lb, const Bound& ub) : _lb(lb > ub ? Bound{Number{0}} : lb), _ub(lb > ub ? Bound{-1} : ub) {}
 
     template <std::integral T>
-    interval_t(T lb, T ub) : _lb(bound_t{lb}), _ub(bound_t{ub}) {
+    Interval(T lb, T ub) : _lb(Bound{lb}), _ub(Bound{ub}) {
         if (lb > ub) {
-            _lb = bound_t{number_t{0}};
-            _ub = bound_t{-1};
+            _lb = Bound{Number{0}};
+            _ub = Bound{-1};
         }
     }
 
     template <is_enum T>
-    interval_t(T lb, T ub) : _lb(bound_t{lb}), _ub(bound_t{ub}) {
+    Interval(T lb, T ub) : _lb(Bound{lb}), _ub(Bound{ub}) {
         if (lb > ub) {
-            _lb = bound_t{number_t{0}};
-            _ub = bound_t{-1};
+            _lb = Bound{Number{0}};
+            _ub = Bound{-1};
         }
     }
-    explicit interval_t(const bound_t& b)
-        : _lb(b.is_infinite() ? bound_t{number_t{0}} : b), _ub(b.is_infinite() ? bound_t{-1} : b) {}
+    explicit Interval(const Bound& b)
+        : _lb(b.is_infinite() ? Bound{Number{0}} : b), _ub(b.is_infinite() ? Bound{-1} : b) {}
 
-    explicit interval_t(const number_t& n) : _lb(n), _ub(n) {}
-    explicit interval_t(std::integral auto n) : _lb(n), _ub(n) {}
+    explicit Interval(const Number& n) : _lb(n), _ub(n) {}
+    explicit Interval(std::integral auto n) : _lb(n), _ub(n) {}
 
-    interval_t(const interval_t& i) = default;
+    Interval(const Interval& i) = default;
 
-    interval_t& operator=(const interval_t& i) = default;
+    Interval& operator=(const Interval& i) = default;
 
     [[nodiscard]]
-    bound_t lb() const {
+    Bound lb() const {
         return _lb;
     }
 
     [[nodiscard]]
-    bound_t ub() const {
+    Bound ub() const {
         return _ub;
     }
 
     [[nodiscard]]
-    std::tuple<bound_t, bound_t> pair() const {
+    std::tuple<Bound, Bound> pair() const {
         return {_lb, _ub};
     }
 
@@ -87,14 +86,14 @@ class interval_t final {
     }
 
     [[nodiscard]]
-    std::tuple<number_t, number_t> pair_number() const {
+    std::tuple<Number, Number> pair_number() const {
         return {_lb.number().value(), _ub.number().value()};
     }
 
     template <std::integral T>
     [[nodiscard]]
     std::tuple<T, T> bound(T lb, T ub) const {
-        const interval_t b = interval_t{lb, ub} & *this;
+        const Interval b = Interval{lb, ub} & *this;
         if (b.is_bottom()) {
             CRAB_ERROR("Cannot convert bottom to tuple");
         }
@@ -124,7 +123,7 @@ class interval_t final {
         return _lb.is_infinite() && _ub.is_infinite();
     }
 
-    bool operator==(const interval_t& x) const {
+    bool operator==(const Interval& x) const {
         if (is_bottom()) {
             return x.is_bottom();
         } else {
@@ -132,9 +131,9 @@ class interval_t final {
         }
     }
 
-    bool operator!=(const interval_t& x) const { return !operator==(x); }
+    bool operator!=(const Interval& x) const { return !operator==(x); }
 
-    bool operator<=(const interval_t& x) const {
+    bool operator<=(const Interval& x) const {
         if (is_bottom()) {
             return true;
         } else if (x.is_bottom()) {
@@ -144,98 +143,97 @@ class interval_t final {
         }
     }
 
-    interval_t operator|(const interval_t& x) const {
+    Interval operator|(const Interval& x) const {
         if (is_bottom()) {
             return x;
         } else if (x.is_bottom()) {
             return *this;
         } else {
-            return interval_t{std::min(_lb, x._lb), std::max(_ub, x._ub)};
+            return Interval{std::min(_lb, x._lb), std::max(_ub, x._ub)};
         }
     }
 
-    interval_t operator&(const interval_t& x) const {
+    Interval operator&(const Interval& x) const {
         if (is_bottom() || x.is_bottom()) {
             return bottom();
         } else {
-            return interval_t{std::max(_lb, x._lb), std::min(_ub, x._ub)};
+            return Interval{std::max(_lb, x._lb), std::min(_ub, x._ub)};
         }
     }
 
     [[nodiscard]]
-    interval_t widen(const interval_t& x) const {
+    Interval widen(const Interval& x) const {
         if (is_bottom()) {
             return x;
         } else if (x.is_bottom()) {
             return *this;
         } else {
-            return interval_t{x._lb < _lb ? bound_t::minus_infinity() : _lb,
-                              _ub < x._ub ? bound_t::plus_infinity() : _ub};
+            return Interval{x._lb < _lb ? Bound::minus_infinity() : _lb, _ub < x._ub ? Bound::plus_infinity() : _ub};
         }
     }
 
     template <typename Thresholds>
-    interval_t widening_thresholds(interval_t x, const Thresholds& ts) {
+    Interval widening_thresholds(Interval x, const Thresholds& ts) {
         if (is_bottom()) {
             return x;
         } else if (x.is_bottom()) {
             return *this;
         } else {
-            const bound_t lb = x._lb < _lb ? ts.get_prev(x._lb) : _lb;
-            const bound_t ub = _ub < x._ub ? ts.get_next(x._ub) : _ub;
-            return interval_t{lb, ub};
+            const Bound lb = x._lb < _lb ? ts.get_prev(x._lb) : _lb;
+            const Bound ub = _ub < x._ub ? ts.get_next(x._ub) : _ub;
+            return Interval{lb, ub};
         }
     }
 
     [[nodiscard]]
-    interval_t narrow(const interval_t& x) const {
+    Interval narrow(const Interval& x) const {
         if (is_bottom() || x.is_bottom()) {
             return bottom();
         } else {
-            return interval_t{_lb.is_infinite() && x._lb.is_finite() ? x._lb : _lb,
-                              _ub.is_infinite() && x._ub.is_finite() ? x._ub : _ub};
+            return Interval{_lb.is_infinite() && x._lb.is_finite() ? x._lb : _lb,
+                            _ub.is_infinite() && x._ub.is_finite() ? x._ub : _ub};
         }
     }
 
-    interval_t operator+(const interval_t& x) const {
+    Interval operator+(const Interval& x) const {
         if (is_bottom() || x.is_bottom()) {
             return bottom();
         } else {
-            return interval_t{_lb + x._lb, _ub + x._ub};
+            return Interval{_lb + x._lb, _ub + x._ub};
         }
     }
 
-    interval_t& operator+=(const interval_t& x) { return operator=(operator+(x)); }
+    Interval& operator+=(const Interval& x) { return operator=(operator+(x)); }
 
-    interval_t operator-() const {
+    Interval operator-() const {
         if (is_bottom()) {
             return bottom();
         } else {
-            return interval_t{-_ub, -_lb};
+            return Interval{-_ub, -_lb};
         }
     }
 
-    interval_t operator-(const interval_t& x) const {
+    Interval operator-(const Interval& x) const {
         if (is_bottom() || x.is_bottom()) {
             return bottom();
         } else {
-            return interval_t{_lb - x._ub, _ub - x._lb};
+            return Interval{_lb - x._ub, _ub - x._lb};
         }
     }
 
-    interval_t& operator-=(const interval_t& x) { return operator=(operator-(x)); }
+    Interval& operator-=(const Interval& x) { return operator=(operator-(x)); }
 
-    interval_t operator*(const interval_t& x) const;
+    Interval operator*(const Interval& x) const;
 
-    interval_t& operator*=(const interval_t& x) { return operator=(operator*(x)); }
+    Interval& operator*=(const Interval& x) { return operator=(operator*(x)); }
 
-    interval_t operator/(const interval_t& x) const;
+    Interval operator/(const Interval& x) const;
 
-    interval_t& operator/=(const interval_t& x) { return operator=(operator/(x)); }
+    Interval& operator/=(const Interval& x) { return operator=(operator/(x)); }
 
-    bound_t size() const {
+    Bound size() const {
         if (is_bottom()) {
-            return bound_t{number_t{0}};
+            return Bound{Number{0}};
         }
         return _ub - _lb + 1;
     }
@@ -246,104 +244,102 @@ class interval_t final {
     }
 
     [[nodiscard]]
-    std::optional<number_t> singleton() const {
+    std::optional<Number> singleton() const {
         if (is_singleton()) {
             return _lb.number();
         } else {
-            return std::optional<number_t>();
+            return std::optional<Number>();
         }
     }
 
-    bool contains(const number_t& n) const {
+    bool contains(const Number& n) const {
         if (is_bottom()) {
             return false;
         }
-        const bound_t b{n};
+        const Bound b{n};
         return _lb <= b && b <= _ub;
     }
 
-    friend std::ostream& operator<<(std::ostream& o, const interval_t& interval);
+    friend std::ostream& operator<<(std::ostream& o, const Interval& interval);
 
     // division and remainder operations
 
     [[nodiscard]]
-    interval_t sdiv(const interval_t& x) const;
+    Interval sdiv(const Interval& x) const;
 
     [[nodiscard]]
-    interval_t udiv(const interval_t& x) const;
+    Interval udiv(const Interval& x) const;
 
     [[nodiscard]]
-    interval_t srem(const interval_t& x) const;
+    Interval srem(const Interval& x) const;
 
     [[nodiscard]]
-    interval_t urem(const interval_t& x) const;
+    Interval urem(const Interval& x) const;
 
     // bitwise operations
     [[nodiscard]]
-    interval_t bitwise_and(const interval_t& x) const;
+    Interval bitwise_and(const Interval& x) const;
 
     [[nodiscard]]
-    interval_t bitwise_or(const interval_t& x) const;
+    Interval bitwise_or(const Interval& x) const;
 
     [[nodiscard]]
-    interval_t bitwise_xor(const interval_t& x) const;
+    Interval bitwise_xor(const Interval& x) const;
 
     [[nodiscard]]
-    interval_t shl(const interval_t& x) const;
+    Interval shl(const Interval& x) const;
 
     [[nodiscard]]
-    interval_t lshr(const interval_t& x) const;
+    Interval lshr(const Interval& x) const;
 
     [[nodiscard]]
-    interval_t ashr(const interval_t& x) const;
+    Interval ashr(const Interval& x) const;
 
-    interval_t sign_extend(bool is64) const = delete;
+    Interval sign_extend(bool is64) const = delete;
     [[nodiscard]]
-    interval_t sign_extend(int width) const;
+    Interval sign_extend(int width) const;
 
-    interval_t zero_extend(bool is64) const = delete;
+    Interval zero_extend(bool is64) const = delete;
     [[nodiscard]]
-    interval_t zero_extend(int width) const;
+    Interval zero_extend(int width) const;
 
     template <std::signed_integral T>
     [[nodiscard]]
-    interval_t truncate_to() const {
+    Interval truncate_to() const {
         return sign_extend(static_cast<int>(sizeof(T)) * 8);
     }
 
     template <std::unsigned_integral T>
     [[nodiscard]]
-    interval_t truncate_to() const {
+    Interval truncate_to() const {
         return zero_extend(static_cast<int>(sizeof(T)) * 8);
     }
 
-    interval_t signed_int(bool is64) const = delete;
+    Interval signed_int(bool is64) const = delete;
     // Return an interval in the range [INT_MIN, INT_MAX] which can only
     // be represented as an svalue.
-    static interval_t signed_int(const int width) {
-        return interval_t{number_t::min_int(width), number_t::max_int(width)};
-    }
+    static Interval signed_int(const int width) { return Interval{Number::min_int(width), Number::max_int(width)}; }
 
-    interval_t unsigned_int(bool is64) const = delete;
+    Interval unsigned_int(bool is64) const = delete;
     // Return an interval in the range [0, UINT_MAX] which can only be
     // represented as a uvalue.
-    static interval_t unsigned_int(const int width) { return interval_t{0, number_t::max_uint(width)}; }
+    static Interval unsigned_int(const int width) { return Interval{0, Number::max_uint(width)}; }
 
-    interval_t nonnegative(bool is64) const = delete;
+    Interval nonnegative(bool is64) const = delete;
     // Return a non-negative interval in the range [0, INT_MAX],
     // which can be represented as both an svalue and a uvalue.
-    static interval_t nonnegative(const int width) { return interval_t{number_t{0}, number_t::max_int(width)}; }
+    static Interval nonnegative(const int width) { return Interval{Number{0}, Number::max_int(width)}; }
 
-    interval_t negative(bool is64) const = delete;
+    Interval negative(bool is64) const = delete;
     // Return a negative interval in the range [INT_MIN, -1],
     // which can be represented as both an svalue and a uvalue.
-    static interval_t negative(const int width) { return interval_t{number_t::min_int(width), number_t{-1}}; }
+    static Interval negative(const int width) { return Interval{Number::min_int(width), Number{-1}}; }
 
-    interval_t unsigned_high(bool is64) const = delete;
+    Interval unsigned_high(bool is64) const = delete;
     // Return an interval in the range [INT_MAX+1, UINT_MAX], which can only be represented as a uvalue.
     // The svalue equivalent using the same width would be negative().
-    static interval_t unsigned_high(const int width) {
-        return interval_t{number_t::max_int(width) + 1, number_t::max_uint(width)};
+    static Interval unsigned_high(const int width) {
+        return Interval{Number::max_int(width) + 1, Number::max_uint(width)};
     }
 
     [[nodiscard]]
@@ -352,24 +348,24 @@ class interval_t final {
 
 namespace interval_operators {
 
-inline interval_t operator+(const number_t& c, const interval_t& x) { return interval_t{c} + x; }
+inline Interval operator+(const Number& c, const Interval& x) { return Interval{c} + x; }
 
-inline interval_t operator+(const interval_t& x, const number_t& c) { return x + interval_t{c}; }
+inline Interval operator+(const Interval& x, const Number& c) { return x + Interval{c}; }
 
-inline interval_t operator*(const number_t& c, const interval_t& x) { return interval_t{c} * x; }
+inline Interval operator*(const Number& c, const Interval& x) { return Interval{c} * x; }
 
-inline interval_t operator*(const interval_t& x, const number_t& c) { return x * interval_t{c}; }
+inline Interval operator*(const Interval& x, const Number& c) { return x * Interval{c}; }
 
-inline interval_t operator/(const number_t& c, const interval_t& x) { return interval_t{c} / x; }
+inline Interval operator/(const Number& c, const Interval& x) { return Interval{c} / x; }
 
-inline interval_t operator/(const interval_t& x, const number_t& c) { return x / interval_t{c}; }
+inline Interval operator/(const Interval& x, const Number& c) { return x / Interval{c}; }
 
-inline interval_t operator-(const number_t& c, const interval_t& x) { return interval_t{c} - x; }
+inline Interval operator-(const Number& c, const Interval& x) { return Interval{c} - x; }
 
-inline interval_t operator-(const interval_t& x, const number_t& c) { return x - interval_t{c}; }
+inline Interval operator-(const Interval& x, const Number& c) { return x - Interval{c}; }
 
 } // namespace interval_operators
 
-std::string to_string(const interval_t& interval) noexcept;
+std::string to_string(const Interval& interval) noexcept;
 
 } // namespace prevail

--- a/src/crab/linear_constraint.hpp
+++ b/src/crab/linear_constraint.hpp
@@ -10,23 +10,23 @@
 //    <linear expression> <operator> 0
 namespace prevail {
 
-enum class constraint_kind_t { EQUALS_ZERO, LESS_THAN_OR_EQUALS_ZERO, LESS_THAN_ZERO, NOT_ZERO };
+enum class ConstraintKind { EQUALS_ZERO, LESS_THAN_OR_EQUALS_ZERO, LESS_THAN_ZERO, NOT_ZERO };
 
-class linear_constraint_t final {
+class LinearConstraint final {
   private:
-    linear_expression_t _expression = linear_expression_t(0);
-    constraint_kind_t _constraint_kind;
+    LinearExpression _expression = LinearExpression(0);
+    ConstraintKind _constraint_kind;
 
   public:
-    linear_constraint_t(linear_expression_t expression, constraint_kind_t constraint_kind)
+    LinearConstraint(LinearExpression expression, ConstraintKind constraint_kind)
         : _expression(std::move(expression)), _constraint_kind(constraint_kind) {}
 
     [[nodiscard]]
-    const linear_expression_t& expression() const {
+    const LinearExpression& expression() const {
         return _expression;
     }
     [[nodiscard]]
-    constraint_kind_t kind() const {
+    ConstraintKind kind() const {
         return _constraint_kind;
     }
 
@@ -36,12 +36,12 @@ class linear_constraint_t final {
         if (!_expression.is_constant()) {
             return false;
         }
-        const number_t constant = _expression.constant_term();
+        const Number constant = _expression.constant_term();
         switch (_constraint_kind) {
-        case constraint_kind_t::EQUALS_ZERO: return constant == 0;
-        case constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO: return constant <= 0;
-        case constraint_kind_t::LESS_THAN_ZERO: return constant < 0;
-        case constraint_kind_t::NOT_ZERO: return constant != 0;
+        case ConstraintKind::EQUALS_ZERO: return constant == 0;
+        case ConstraintKind::LESS_THAN_OR_EQUALS_ZERO: return constant <= 0;
+        case ConstraintKind::LESS_THAN_ZERO: return constant < 0;
+        case ConstraintKind::NOT_ZERO: return constant != 0;
         default: throw std::exception();
         }
     }
@@ -57,29 +57,25 @@ class linear_constraint_t final {
 
     // Construct the logical NOT of this constraint.
     [[nodiscard]]
-    linear_constraint_t negate() const {
+    LinearConstraint negate() const {
         switch (_constraint_kind) {
-        case constraint_kind_t::NOT_ZERO: return linear_constraint_t(_expression, constraint_kind_t::EQUALS_ZERO);
-        case constraint_kind_t::EQUALS_ZERO: return linear_constraint_t(_expression, constraint_kind_t::NOT_ZERO);
-        case constraint_kind_t::LESS_THAN_ZERO:
-            return linear_constraint_t(_expression.negate(), constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-        case constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO:
-            return linear_constraint_t(_expression.negate(), constraint_kind_t::LESS_THAN_ZERO);
+        case ConstraintKind::NOT_ZERO: return LinearConstraint(_expression, ConstraintKind::EQUALS_ZERO);
+        case ConstraintKind::EQUALS_ZERO: return LinearConstraint(_expression, ConstraintKind::NOT_ZERO);
+        case ConstraintKind::LESS_THAN_ZERO:
+            return LinearConstraint(_expression.negate(), ConstraintKind::LESS_THAN_OR_EQUALS_ZERO);
+        case ConstraintKind::LESS_THAN_OR_EQUALS_ZERO:
+            return LinearConstraint(_expression.negate(), ConstraintKind::LESS_THAN_ZERO);
         default: throw std::exception();
         }
     }
 
-    static linear_constraint_t false_const() {
-        return linear_constraint_t{linear_expression_t(0), constraint_kind_t::NOT_ZERO};
-    }
+    static LinearConstraint false_const() { return LinearConstraint{LinearExpression(0), ConstraintKind::NOT_ZERO}; }
 
-    static linear_constraint_t true_const() {
-        return linear_constraint_t{linear_expression_t(0), constraint_kind_t::EQUALS_ZERO};
-    }
+    static LinearConstraint true_const() { return LinearConstraint{LinearExpression(0), ConstraintKind::EQUALS_ZERO}; }
 };
 
 // Output a linear constraint to a stream.
-inline std::ostream& operator<<(std::ostream& o, const linear_constraint_t& constraint) {
+inline std::ostream& operator<<(std::ostream& o, const LinearConstraint& constraint) {
     if (constraint.is_contradiction()) {
         o << "false";
     } else if (constraint.is_tautology()) {

--- a/src/crab/linear_expression.hpp
+++ b/src/crab/linear_expression.hpp
@@ -13,19 +13,19 @@ namespace prevail {
 // That is, a sum of terms where each term is either a
 // coefficient * variable, or simply a coefficient
 // (of which there is only one such term).
-class linear_expression_t final {
+class LinearExpression final {
 
     // Use a map for the variable terms to simplify adding two expressions
     // with the same variable.
-    using variable_terms_t = std::map<variable_t, number_t>;
+    using VariableTerms = std::map<Variable, Number>;
 
   private:
-    number_t _constant_term{};
-    variable_terms_t _variable_terms{};
+    Number _constant_term{};
+    VariableTerms _variable_terms{};
 
     // Get the coefficient for a given variable, which is 0 if it has no term in the expression.
     [[nodiscard]]
-    number_t coefficient_of(const variable_t& variable) const {
+    Number coefficient_of(const Variable& variable) const {
         auto it = _variable_terms.find(variable);
         if (it == _variable_terms.end()) {
             return 0;
@@ -34,20 +34,19 @@ class linear_expression_t final {
     }
 
   public:
-    linear_expression_t(number_t coefficient) : _constant_term(std::move(coefficient)) {}
+    LinearExpression(Number coefficient) : _constant_term(std::move(coefficient)) {}
 
-    linear_expression_t(std::integral auto coefficient) : _constant_term(coefficient) {}
-    linear_expression_t(is_enum auto coefficient) : _constant_term(coefficient) {}
-    linear_expression_t(variable_t variable) { _variable_terms[variable] = 1; }
+    LinearExpression(std::integral auto coefficient) : _constant_term(coefficient) {}
+    LinearExpression(is_enum auto coefficient) : _constant_term(coefficient) {}
+    LinearExpression(Variable variable) { _variable_terms[variable] = 1; }
 
-    linear_expression_t(const number_t& coefficient, const variable_t& variable) {
+    LinearExpression(const Number& coefficient, const Variable& variable) {
         if (coefficient != 0) {
             _variable_terms[variable] = coefficient;
         }
     }
 
-    linear_expression_t(variable_terms_t variable_terms, number_t constant_term)
-        : _constant_term(std::move(constant_term)) {
+    LinearExpression(VariableTerms variable_terms, Number constant_term) : _constant_term(std::move(constant_term)) {
         for (const auto& [variable, coefficient] : variable_terms) {
             if (coefficient != 0) {
                 _variable_terms.emplace(variable, coefficient);
@@ -57,11 +56,11 @@ class linear_expression_t final {
 
     // Allow a caller to access individual terms.
     [[nodiscard]]
-    const variable_terms_t& variable_terms() const {
+    const VariableTerms& variable_terms() const {
         return _variable_terms;
     }
     [[nodiscard]]
-    const number_t& constant_term() const {
+    const Number& constant_term() const {
         return _constant_term;
     }
 
@@ -73,66 +72,66 @@ class linear_expression_t final {
 
     // Multiply a linear expression by a constant.
     [[nodiscard]]
-    linear_expression_t multiply(const finite_integral auto& constant) const {
-        variable_terms_t variable_terms;
+    LinearExpression multiply(const finite_integral auto& constant) const {
+        VariableTerms variable_terms;
         for (const auto& [variable, coefficient] : _variable_terms) {
             variable_terms.emplace(variable, coefficient * constant);
         }
-        return linear_expression_t(variable_terms, _constant_term * constant);
+        return LinearExpression(variable_terms, _constant_term * constant);
     }
 
     // Add a constant to a linear expression.
     [[nodiscard]]
-    linear_expression_t plus(const finite_integral auto& constant) const {
-        return linear_expression_t(variable_terms_t(_variable_terms), _constant_term + constant);
+    LinearExpression plus(const finite_integral auto& constant) const {
+        return LinearExpression(VariableTerms(_variable_terms), _constant_term + constant);
     }
 
     // Add a variable (with coefficient of 1) to a linear expression.
     [[nodiscard]]
-    linear_expression_t plus(const variable_t& variable) const {
-        variable_terms_t variable_terms = _variable_terms;
+    LinearExpression plus(const Variable& variable) const {
+        VariableTerms variable_terms = _variable_terms;
         variable_terms[variable] = coefficient_of(variable) + 1;
-        return linear_expression_t(variable_terms, _constant_term);
+        return LinearExpression(variable_terms, _constant_term);
     }
 
     // Add two expressions.
     [[nodiscard]]
-    linear_expression_t plus(const linear_expression_t& expression) const {
-        variable_terms_t variable_terms = _variable_terms;
+    LinearExpression plus(const LinearExpression& expression) const {
+        VariableTerms variable_terms = _variable_terms;
         for (const auto& [variable, coefficient] : expression.variable_terms()) {
             variable_terms[variable] = coefficient_of(variable) + coefficient;
         }
-        return linear_expression_t(variable_terms, _constant_term + expression.constant_term());
+        return LinearExpression(variable_terms, _constant_term + expression.constant_term());
     }
 
     // Apply unary minus to an expression.
     [[nodiscard]]
-    linear_expression_t negate() const {
+    LinearExpression negate() const {
         return multiply(-1);
     }
 
     // Subtract a constant from a linear expression.
     [[nodiscard]]
-    linear_expression_t subtract(const finite_integral auto& constant) const {
-        return linear_expression_t(variable_terms_t(_variable_terms), _constant_term - constant);
+    LinearExpression subtract(const finite_integral auto& constant) const {
+        return LinearExpression(VariableTerms(_variable_terms), _constant_term - constant);
     }
 
     // Subtract a variable (with coefficient of 1) from a linear expression.
     [[nodiscard]]
-    linear_expression_t subtract(const variable_t& variable) const {
-        variable_terms_t variable_terms = _variable_terms;
+    LinearExpression subtract(const Variable& variable) const {
+        VariableTerms variable_terms = _variable_terms;
         variable_terms[variable] = coefficient_of(variable) - 1;
-        return linear_expression_t(variable_terms, _constant_term);
+        return LinearExpression(variable_terms, _constant_term);
     }
 
     // Subtract one expression from another.
     [[nodiscard]]
-    linear_expression_t subtract(const linear_expression_t& expression) const {
-        variable_terms_t variable_terms = _variable_terms;
+    LinearExpression subtract(const LinearExpression& expression) const {
+        VariableTerms variable_terms = _variable_terms;
         for (const auto& [variable, coefficient] : expression.variable_terms()) {
             variable_terms[variable] = coefficient_of(variable) - coefficient;
         }
-        return linear_expression_t(variable_terms, _constant_term - expression.constant_term());
+        return LinearExpression(variable_terms, _constant_term - expression.constant_term());
     }
 
     // Output all variable terms to a stream.
@@ -152,11 +151,11 @@ class linear_expression_t final {
 };
 
 // Output a linear expression to a stream.
-inline std::ostream& operator<<(std::ostream& o, const linear_expression_t& expression) {
+inline std::ostream& operator<<(std::ostream& o, const LinearExpression& expression) {
     expression.output_variable_terms(o);
 
     // Output the constant term.
-    number_t constant = expression.constant_term();
+    Number constant = expression.constant_term();
     if (constant < 0) {
         o << constant;
     } else if (constant > 0) {

--- a/src/crab/thresholds.cpp
+++ b/src/crab/thresholds.cpp
@@ -6,23 +6,23 @@
 
 namespace prevail {
 
-void thresholds_t::add(const extended_number& v) {
+void Thresholds::add(const ExtendedNumber& v) {
     if (m_thresholds.size() < m_size) {
         if (std::ranges::find(m_thresholds, v) == m_thresholds.end()) {
             const auto ub = std::ranges::upper_bound(m_thresholds, v);
 
             // don't add consecutive thresholds
-            if (v > number_t{0}) {
+            if (v > Number{0}) {
                 auto prev = ub;
                 --prev;
                 if (prev != m_thresholds.begin()) {
-                    if (*prev + number_t{1} == v) {
+                    if (*prev + Number{1} == v) {
                         *prev = v;
                         return;
                     }
                 }
-            } else if (v < number_t{0}) {
-                if (*ub - number_t{1} == v) {
+            } else if (v < Number{0}) {
+                if (*ub - Number{1} == v) {
                     *ub = v;
                     return;
                 }
@@ -33,10 +33,10 @@ void thresholds_t::add(const extended_number& v) {
     }
 }
 
-std::ostream& operator<<(std::ostream& o, const thresholds_t& t) {
+std::ostream& operator<<(std::ostream& o, const Thresholds& t) {
     o << "{";
     for (auto it = t.m_thresholds.begin(), et = t.m_thresholds.end(); it != et;) {
-        extended_number b(*it);
+        ExtendedNumber b(*it);
         o << b;
         ++it;
         if (it != t.m_thresholds.end()) {
@@ -47,25 +47,25 @@ std::ostream& operator<<(std::ostream& o, const thresholds_t& t) {
     return o;
 }
 
-void wto_thresholds_t::get_thresholds(const label_t& label, thresholds_t& thresholds) const {}
+void WtoThresholds::get_thresholds(const Label& label, Thresholds& thresholds) const {}
 
-void wto_thresholds_t::operator()(const label_t& vertex) {
+void WtoThresholds::operator()(const Label& vertex) {
     if (m_stack.empty()) {
         return;
     }
 
-    const label_t head = m_stack.back();
+    const Label head = m_stack.back();
     const auto it = m_head_to_thresholds.find(head);
     if (it != m_head_to_thresholds.end()) {
-        thresholds_t& thresholds = it->second;
+        Thresholds& thresholds = it->second;
         get_thresholds(vertex, thresholds);
     } else {
         CRAB_ERROR("No head found while gathering thresholds");
     }
 }
 
-void wto_thresholds_t::operator()(const std::shared_ptr<wto_cycle_t>& cycle) {
-    thresholds_t thresholds(m_max_size);
+void WtoThresholds::operator()(const std::shared_ptr<WtoCycle>& cycle) {
+    Thresholds thresholds(m_max_size);
     const auto& head = cycle->head();
     get_thresholds(head, thresholds);
 
@@ -85,7 +85,7 @@ void wto_thresholds_t::operator()(const std::shared_ptr<wto_cycle_t>& cycle) {
     m_stack.pop_back();
 }
 
-std::ostream& operator<<(std::ostream& o, const wto_thresholds_t& t) {
+std::ostream& operator<<(std::ostream& o, const WtoThresholds& t) {
     for (const auto& [label, th] : t.m_head_to_thresholds) {
         o << to_string(label) << "=" << th << "\n";
     }

--- a/src/crab/thresholds.hpp
+++ b/src/crab/thresholds.hpp
@@ -16,17 +16,17 @@ namespace prevail {
     Class that represents a set of thresholds used by the widening operator
 **/
 
-class thresholds_t final {
+class Thresholds final {
 
   private:
-    std::vector<extended_number> m_thresholds;
+    std::vector<ExtendedNumber> m_thresholds;
     size_t m_size;
 
   public:
-    explicit thresholds_t(const size_t size = UINT_MAX) : m_size(size) {
-        m_thresholds.push_back(extended_number::minus_infinity());
-        m_thresholds.emplace_back(number_t{0});
-        m_thresholds.push_back(extended_number::plus_infinity());
+    explicit Thresholds(const size_t size = UINT_MAX) : m_size(size) {
+        m_thresholds.push_back(ExtendedNumber::minus_infinity());
+        m_thresholds.emplace_back(Number{0});
+        m_thresholds.push_back(ExtendedNumber::plus_infinity());
     }
 
     [[nodiscard]]
@@ -34,36 +34,36 @@ class thresholds_t final {
         return m_thresholds.size();
     }
 
-    void add(const extended_number& v1);
+    void add(const ExtendedNumber& v1);
 
-    friend std::ostream& operator<<(std::ostream& o, const thresholds_t& t);
+    friend std::ostream& operator<<(std::ostream& o, const Thresholds& t);
 };
 
 /**
    Collect thresholds per wto cycle (i.e. loop)
 **/
-class wto_thresholds_t final {
+class WtoThresholds final {
   private:
     // the cfg
-    cfg_t& m_cfg;
+    Cfg& m_cfg;
     // maximum number of thresholds
     size_t m_max_size;
     // keep a set of thresholds per wto head
-    std::map<label_t, thresholds_t> m_head_to_thresholds;
+    std::map<Label, Thresholds> m_head_to_thresholds;
     // the top of the stack is the current wto head
-    std::vector<label_t> m_stack;
+    std::vector<Label> m_stack;
 
-    void get_thresholds(const label_t& label, thresholds_t& thresholds) const;
+    void get_thresholds(const Label& label, Thresholds& thresholds) const;
 
   public:
-    wto_thresholds_t(cfg_t& cfg, const size_t max_size) : m_cfg(cfg), m_max_size(max_size) {}
+    WtoThresholds(Cfg& cfg, const size_t max_size) : m_cfg(cfg), m_max_size(max_size) {}
 
-    void operator()(const label_t& vertex);
+    void operator()(const Label& vertex);
 
-    void operator()(const std::shared_ptr<wto_cycle_t>& cycle);
+    void operator()(const std::shared_ptr<WtoCycle>& cycle);
 
-    friend std::ostream& operator<<(std::ostream& o, const wto_thresholds_t& t);
+    friend std::ostream& operator<<(std::ostream& o, const WtoThresholds& t);
 
-}; // class wto_thresholds_t
+}; // class WtoThresholds
 
 } // end namespace prevail

--- a/src/crab/type_domain.cpp
+++ b/src/crab/type_domain.cpp
@@ -22,29 +22,29 @@ static void operator++(T& t) {
     t = static_cast<T>(1 + static_cast<std::underlying_type_t<T>>(t));
 }
 
-std::vector<data_kind_t> iterate_kinds(const data_kind_t lb, const data_kind_t ub) {
+std::vector<DataKind> iterate_kinds(const DataKind lb, const DataKind ub) {
     if (lb > ub) {
         CRAB_ERROR("lower bound ", lb, " is greater than upper bound ", ub);
     }
     if (lb < KIND_MIN || ub > KIND_MAX) {
         CRAB_ERROR("bounds ", lb, " and ", ub, " are out of range");
     }
-    std::vector<data_kind_t> res;
-    for (data_kind_t i = lb; i <= ub; ++i) {
+    std::vector<DataKind> res;
+    for (DataKind i = lb; i <= ub; ++i) {
         res.push_back(i);
     }
     return res;
 }
 
-std::vector<type_encoding_t> iterate_types(const type_encoding_t lb, const type_encoding_t ub) {
+std::vector<TypeEncoding> iterate_types(const TypeEncoding lb, const TypeEncoding ub) {
     if (lb > ub) {
         CRAB_ERROR("lower bound ", lb, " is greater than upper bound ", ub);
     }
     if (lb < T_MIN || ub > T_MAX) {
         CRAB_ERROR("bounds ", lb, " and ", ub, " are out of range");
     }
-    std::vector<type_encoding_t> res;
-    for (type_encoding_t i = lb; i <= ub; ++i) {
+    std::vector<TypeEncoding> res;
+    for (TypeEncoding i = lb; i <= ub; ++i) {
         res.push_back(i);
     }
     return res;
@@ -59,34 +59,34 @@ static constexpr auto S_MAP = "map_fd";
 static constexpr auto S_NUM = "number";
 static constexpr auto S_SHARED = "shared";
 
-std::string name_of(const data_kind_t kind) {
+std::string name_of(const DataKind kind) {
     switch (kind) {
-    case data_kind_t::ctx_offsets: return "ctx_offset";
-    case data_kind_t::map_fds: return "map_fd";
-    case data_kind_t::packet_offsets: return "packet_offset";
-    case data_kind_t::shared_offsets: return "shared_offset";
-    case data_kind_t::shared_region_sizes: return "shared_region_size";
-    case data_kind_t::stack_numeric_sizes: return "stack_numeric_size";
-    case data_kind_t::stack_offsets: return "stack_offset";
-    case data_kind_t::svalues: return "svalue";
-    case data_kind_t::types: return "type";
-    case data_kind_t::uvalues: return "uvalue";
+    case DataKind::ctx_offsets: return "ctx_offset";
+    case DataKind::map_fds: return "map_fd";
+    case DataKind::packet_offsets: return "packet_offset";
+    case DataKind::shared_offsets: return "shared_offset";
+    case DataKind::shared_region_sizes: return "shared_region_size";
+    case DataKind::stack_numeric_sizes: return "stack_numeric_size";
+    case DataKind::stack_offsets: return "stack_offset";
+    case DataKind::svalues: return "svalue";
+    case DataKind::types: return "type";
+    case DataKind::uvalues: return "uvalue";
     }
     return {};
 }
 
-data_kind_t regkind(const std::string& s) {
-    static const std::map<std::string, data_kind_t> string_to_kind{
-        {"type", data_kind_t::types},
-        {"ctx_offset", data_kind_t::ctx_offsets},
-        {"map_fd", data_kind_t::map_fds},
-        {"packet_offset", data_kind_t::packet_offsets},
-        {"shared_offset", data_kind_t::shared_offsets},
-        {"stack_offset", data_kind_t::stack_offsets},
-        {"shared_region_size", data_kind_t::shared_region_sizes},
-        {"stack_numeric_size", data_kind_t::stack_numeric_sizes},
-        {"svalue", data_kind_t::svalues},
-        {"uvalue", data_kind_t::uvalues},
+DataKind regkind(const std::string& s) {
+    static const std::map<std::string, DataKind> string_to_kind{
+        {"type", DataKind::types},
+        {"ctx_offset", DataKind::ctx_offsets},
+        {"map_fd", DataKind::map_fds},
+        {"packet_offset", DataKind::packet_offsets},
+        {"shared_offset", DataKind::shared_offsets},
+        {"stack_offset", DataKind::stack_offsets},
+        {"shared_region_size", DataKind::shared_region_sizes},
+        {"stack_numeric_size", DataKind::stack_numeric_sizes},
+        {"svalue", DataKind::svalues},
+        {"uvalue", DataKind::uvalues},
     };
     if (string_to_kind.contains(s)) {
         return string_to_kind.at(s);
@@ -94,7 +94,7 @@ data_kind_t regkind(const std::string& s) {
     throw std::runtime_error(std::string() + "Bad kind: " + s);
 }
 
-std::ostream& operator<<(std::ostream& os, const type_encoding_t s) {
+std::ostream& operator<<(std::ostream& os, const TypeEncoding s) {
     switch (s) {
     case T_SHARED: return os << S_SHARED;
     case T_STACK: return os << S_STACK;
@@ -108,8 +108,8 @@ std::ostream& operator<<(std::ostream& os, const type_encoding_t s) {
     }
 }
 
-type_encoding_t string_to_type_encoding(const std::string& s) {
-    static std::map<std::string, type_encoding_t> string_to_type{
+TypeEncoding string_to_type_encoding(const std::string& s) {
+    static std::map<std::string, TypeEncoding> string_to_type{
         {S_UNINIT, T_UNINIT}, {S_MAP_PROGRAMS, T_MAP_PROGRAMS},
         {S_MAP, T_MAP},       {S_NUM, T_NUM},
         {S_CTX, T_CTX},       {S_STACK, T_STACK},
@@ -120,27 +120,27 @@ type_encoding_t string_to_type_encoding(const std::string& s) {
     }
     throw std::runtime_error(std::string("Unsupported type name: ") + s);
 }
-reg_pack_t reg_pack(const int i) {
+RegPack reg_pack(const int i) {
     return {
-        variable_t::reg(data_kind_t::svalues, i),
-        variable_t::reg(data_kind_t::uvalues, i),
-        variable_t::reg(data_kind_t::ctx_offsets, i),
-        variable_t::reg(data_kind_t::map_fds, i),
-        variable_t::reg(data_kind_t::packet_offsets, i),
-        variable_t::reg(data_kind_t::shared_offsets, i),
-        variable_t::reg(data_kind_t::stack_offsets, i),
-        variable_t::reg(data_kind_t::types, i),
-        variable_t::reg(data_kind_t::shared_region_sizes, i),
-        variable_t::reg(data_kind_t::stack_numeric_sizes, i),
+        Variable::reg(DataKind::svalues, i),
+        Variable::reg(DataKind::uvalues, i),
+        Variable::reg(DataKind::ctx_offsets, i),
+        Variable::reg(DataKind::map_fds, i),
+        Variable::reg(DataKind::packet_offsets, i),
+        Variable::reg(DataKind::shared_offsets, i),
+        Variable::reg(DataKind::stack_offsets, i),
+        Variable::reg(DataKind::types, i),
+        Variable::reg(DataKind::shared_region_sizes, i),
+        Variable::reg(DataKind::stack_numeric_sizes, i),
     };
 }
 
-void TypeDomain::add_extra_invariant(const NumAbsDomain& dst, std::map<variable_t, interval_t>& extra_invariants,
-                                     const variable_t type_variable, const type_encoding_t type, const data_kind_t kind,
+void TypeDomain::add_extra_invariant(const NumAbsDomain& dst, std::map<Variable, Interval>& extra_invariants,
+                                     const Variable type_variable, const TypeEncoding type, const DataKind kind,
                                      const NumAbsDomain& src) const {
     const bool dst_has_type = has_type(dst, type_variable, type);
     const bool src_has_type = has_type(src, type_variable, type);
-    variable_t v = variable_t::kind_var(kind, type_variable);
+    Variable v = Variable::kind_var(kind, type_variable);
 
     // If type is contained in exactly one of dst or src,
     // we need to remember the value.
@@ -176,17 +176,17 @@ void TypeDomain::selectively_join_based_on_type(NumAbsDomain& dst, NumAbsDomain&
     // Output:
     //   r1.type={stack,packet}, r1.stack_offset=100, r1.packet_offset=4
 
-    std::map<variable_t, interval_t> extra_invariants;
+    std::map<Variable, Interval> extra_invariants;
     if (!dst.is_bottom()) {
-        for (const variable_t v : variable_t::get_type_variables()) {
-            add_extra_invariant(dst, extra_invariants, v, T_CTX, data_kind_t::ctx_offsets, src);
-            add_extra_invariant(dst, extra_invariants, v, T_MAP, data_kind_t::map_fds, src);
-            add_extra_invariant(dst, extra_invariants, v, T_MAP_PROGRAMS, data_kind_t::map_fds, src);
-            add_extra_invariant(dst, extra_invariants, v, T_PACKET, data_kind_t::packet_offsets, src);
-            add_extra_invariant(dst, extra_invariants, v, T_SHARED, data_kind_t::shared_offsets, src);
-            add_extra_invariant(dst, extra_invariants, v, T_STACK, data_kind_t::stack_offsets, src);
-            add_extra_invariant(dst, extra_invariants, v, T_SHARED, data_kind_t::shared_region_sizes, src);
-            add_extra_invariant(dst, extra_invariants, v, T_STACK, data_kind_t::stack_numeric_sizes, src);
+        for (const Variable v : Variable::get_type_variables()) {
+            add_extra_invariant(dst, extra_invariants, v, T_CTX, DataKind::ctx_offsets, src);
+            add_extra_invariant(dst, extra_invariants, v, T_MAP, DataKind::map_fds, src);
+            add_extra_invariant(dst, extra_invariants, v, T_MAP_PROGRAMS, DataKind::map_fds, src);
+            add_extra_invariant(dst, extra_invariants, v, T_PACKET, DataKind::packet_offsets, src);
+            add_extra_invariant(dst, extra_invariants, v, T_SHARED, DataKind::shared_offsets, src);
+            add_extra_invariant(dst, extra_invariants, v, T_STACK, DataKind::stack_offsets, src);
+            add_extra_invariant(dst, extra_invariants, v, T_SHARED, DataKind::shared_region_sizes, src);
+            add_extra_invariant(dst, extra_invariants, v, T_STACK, DataKind::stack_numeric_sizes, src);
         }
     }
 
@@ -203,46 +203,46 @@ void TypeDomain::assign_type(NumAbsDomain& inv, const Reg& lhs, const Reg& rhs) 
     inv.assign(reg_pack(lhs).type, reg_pack(rhs).type);
 }
 
-void TypeDomain::assign_type(NumAbsDomain& inv, const std::optional<variable_t> lhs, const linear_expression_t& t) {
+void TypeDomain::assign_type(NumAbsDomain& inv, const std::optional<Variable> lhs, const LinearExpression& t) {
     inv.assign(lhs, t);
 }
 
-void TypeDomain::assign_type(NumAbsDomain& inv, const Reg& lhs, const std::optional<linear_expression_t>& rhs) {
+void TypeDomain::assign_type(NumAbsDomain& inv, const Reg& lhs, const std::optional<LinearExpression>& rhs) {
     inv.assign(reg_pack(lhs).type, rhs);
 }
 
 void TypeDomain::havoc_type(NumAbsDomain& inv, const Reg& r) { inv.havoc(reg_pack(r).type); }
 
-type_encoding_t TypeDomain::get_type(const NumAbsDomain& inv, const linear_expression_t& v) const {
+TypeEncoding TypeDomain::get_type(const NumAbsDomain& inv, const LinearExpression& v) const {
     const auto res = inv.eval_interval(v).singleton();
     if (!res) {
         return T_UNINIT;
     }
-    return res->narrow<type_encoding_t>();
+    return res->narrow<TypeEncoding>();
 }
 
-type_encoding_t TypeDomain::get_type(const NumAbsDomain& inv, const Reg& r) const {
+TypeEncoding TypeDomain::get_type(const NumAbsDomain& inv, const Reg& r) const {
     const auto res = inv.eval_interval(reg_pack(r).type).singleton();
     if (!res) {
         return T_UNINIT;
     }
-    return res->narrow<type_encoding_t>();
+    return res->narrow<TypeEncoding>();
 }
 
 // Check whether a given type value is within the range of a given type variable's value.
-bool TypeDomain::has_type(const NumAbsDomain& inv, const Reg& r, const type_encoding_t type) const {
-    const interval_t interval = inv.eval_interval(reg_pack(r).type);
+bool TypeDomain::has_type(const NumAbsDomain& inv, const Reg& r, const TypeEncoding type) const {
+    const Interval interval = inv.eval_interval(reg_pack(r).type);
     return interval.contains(type);
 }
 
-bool TypeDomain::has_type(const NumAbsDomain& inv, const linear_expression_t& v, const type_encoding_t type) const {
-    const interval_t interval = inv.eval_interval(v);
+bool TypeDomain::has_type(const NumAbsDomain& inv, const LinearExpression& v, const TypeEncoding type) const {
+    const Interval interval = inv.eval_interval(v);
     return interval.contains(type);
 }
 
 NumAbsDomain TypeDomain::join_over_types(const NumAbsDomain& inv, const Reg& reg,
-                                         const std::function<void(NumAbsDomain&, type_encoding_t)>& transition) const {
-    interval_t types = inv.eval_interval(reg_pack(reg).type);
+                                         const std::function<void(NumAbsDomain&, TypeEncoding)>& transition) const {
+    Interval types = inv.eval_interval(reg_pack(reg).type);
     if (types.is_bottom()) {
         return NumAbsDomain::bottom();
     }
@@ -253,7 +253,7 @@ NumAbsDomain TypeDomain::join_over_types(const NumAbsDomain& inv, const Reg& reg
     }
     NumAbsDomain res = NumAbsDomain::bottom();
     auto [lb, ub] = types.bound(T_MIN, T_MAX);
-    for (type_encoding_t type : iterate_types(lb, ub)) {
+    for (TypeEncoding type : iterate_types(lb, ub)) {
         NumAbsDomain tmp(inv);
         transition(tmp, type);
         selectively_join_based_on_type(res, std::move(tmp)); // res |= tmp;
@@ -261,7 +261,7 @@ NumAbsDomain TypeDomain::join_over_types(const NumAbsDomain& inv, const Reg& reg
     return res;
 }
 
-NumAbsDomain TypeDomain::join_by_if_else(const NumAbsDomain& inv, const linear_constraint_t& condition,
+NumAbsDomain TypeDomain::join_by_if_else(const NumAbsDomain& inv, const LinearConstraint& condition,
                                          const std::function<void(NumAbsDomain&)>& if_true,
                                          const std::function<void(NumAbsDomain&)>& if_false) const {
     NumAbsDomain true_case(inv.when(condition));
@@ -273,7 +273,7 @@ NumAbsDomain TypeDomain::join_by_if_else(const NumAbsDomain& inv, const linear_c
     return true_case | false_case;
 }
 
-static linear_constraint_t eq_types(const Reg& a, const Reg& b) {
+static LinearConstraint eq_types(const Reg& a, const Reg& b) {
     using namespace dsl_syntax;
     return eq(reg_pack(a).type, reg_pack(b).type);
 }
@@ -282,14 +282,13 @@ bool TypeDomain::same_type(const NumAbsDomain& inv, const Reg& a, const Reg& b) 
     return inv.entail(eq_types(a, b));
 }
 
-bool TypeDomain::implies_type(const NumAbsDomain& inv, const linear_constraint_t& a,
-                              const linear_constraint_t& b) const {
+bool TypeDomain::implies_type(const NumAbsDomain& inv, const LinearConstraint& a, const LinearConstraint& b) const {
     return inv.when(a).entail(b);
 }
 
 bool TypeDomain::is_in_group(const NumAbsDomain& inv, const Reg& r, const TypeGroup group) const {
     using namespace dsl_syntax;
-    const variable_t t = reg_pack(r).type;
+    const Variable t = reg_pack(r).type;
     switch (group) {
     case TypeGroup::number: return inv.entail(t == T_NUM);
     case TypeGroup::map_fd: return inv.entail(t == T_MAP);
@@ -308,7 +307,7 @@ bool TypeDomain::is_in_group(const NumAbsDomain& inv, const Reg& r, const TypeGr
     }
 }
 
-std::string typeset_to_string(const std::vector<type_encoding_t>& items) {
+std::string typeset_to_string(const std::vector<TypeEncoding>& items) {
     std::stringstream ss;
     ss << "{";
     for (auto it = items.begin(); it != items.end(); ++it) {

--- a/src/crab/type_domain.hpp
+++ b/src/crab/type_domain.hpp
@@ -14,55 +14,54 @@
 
 namespace prevail {
 
-struct reg_pack_t {
-    variable_t svalue; // int64_t value.
-    variable_t uvalue; // uint64_t value.
-    variable_t ctx_offset;
-    variable_t map_fd;
-    variable_t packet_offset;
-    variable_t shared_offset;
-    variable_t stack_offset;
-    variable_t type;
-    variable_t shared_region_size;
-    variable_t stack_numeric_size;
+struct RegPack {
+    Variable svalue; // int64_t value.
+    Variable uvalue; // uint64_t value.
+    Variable ctx_offset;
+    Variable map_fd;
+    Variable packet_offset;
+    Variable shared_offset;
+    Variable stack_offset;
+    Variable type;
+    Variable shared_region_size;
+    Variable stack_numeric_size;
 };
 
-reg_pack_t reg_pack(int i);
-inline reg_pack_t reg_pack(const Reg r) { return reg_pack(r.v); }
+RegPack reg_pack(int i);
+inline RegPack reg_pack(const Reg r) { return reg_pack(r.v); }
 
 struct TypeDomain {
     void assign_type(NumAbsDomain& inv, const Reg& lhs, const Reg& rhs);
-    void assign_type(NumAbsDomain& inv, const Reg& lhs, const std::optional<linear_expression_t>& rhs);
-    void assign_type(NumAbsDomain& inv, std::optional<variable_t> lhs, const linear_expression_t& t);
+    void assign_type(NumAbsDomain& inv, const Reg& lhs, const std::optional<LinearExpression>& rhs);
+    void assign_type(NumAbsDomain& inv, std::optional<Variable> lhs, const LinearExpression& t);
 
     void havoc_type(NumAbsDomain& inv, const Reg& r);
 
     [[nodiscard]]
-    type_encoding_t get_type(const NumAbsDomain& inv, const linear_expression_t& v) const;
+    TypeEncoding get_type(const NumAbsDomain& inv, const LinearExpression& v) const;
     [[nodiscard]]
-    type_encoding_t get_type(const NumAbsDomain& inv, const Reg& r) const;
+    TypeEncoding get_type(const NumAbsDomain& inv, const Reg& r) const;
 
     [[nodiscard]]
-    bool has_type(const NumAbsDomain& inv, const linear_expression_t& v, type_encoding_t type) const;
+    bool has_type(const NumAbsDomain& inv, const LinearExpression& v, TypeEncoding type) const;
     [[nodiscard]]
-    bool has_type(const NumAbsDomain& inv, const Reg& r, type_encoding_t type) const;
+    bool has_type(const NumAbsDomain& inv, const Reg& r, TypeEncoding type) const;
 
     [[nodiscard]]
     bool same_type(const NumAbsDomain& inv, const Reg& a, const Reg& b) const;
     [[nodiscard]]
-    bool implies_type(const NumAbsDomain& inv, const linear_constraint_t& a, const linear_constraint_t& b) const;
+    bool implies_type(const NumAbsDomain& inv, const LinearConstraint& a, const LinearConstraint& b) const;
 
     [[nodiscard]]
     NumAbsDomain join_over_types(const NumAbsDomain& inv, const Reg& reg,
-                                 const std::function<void(NumAbsDomain&, type_encoding_t)>& transition) const;
+                                 const std::function<void(NumAbsDomain&, TypeEncoding)>& transition) const;
     [[nodiscard]]
-    NumAbsDomain join_by_if_else(const NumAbsDomain& inv, const linear_constraint_t& condition,
+    NumAbsDomain join_by_if_else(const NumAbsDomain& inv, const LinearConstraint& condition,
                                  const std::function<void(NumAbsDomain&)>& if_true,
                                  const std::function<void(NumAbsDomain&)>& if_false) const;
     void selectively_join_based_on_type(NumAbsDomain& dst, NumAbsDomain&& src) const;
-    void add_extra_invariant(const NumAbsDomain& dst, std::map<variable_t, interval_t>& extra_invariants,
-                             variable_t type_variable, type_encoding_t type, data_kind_t kind,
-                             const NumAbsDomain& src) const;
+    void add_extra_invariant(const NumAbsDomain& dst, std::map<Variable, Interval>& extra_invariants,
+                             Variable type_variable, TypeEncoding type, DataKind kind, const NumAbsDomain& src) const;
 
     [[nodiscard]]
     bool is_in_group(const NumAbsDomain& inv, const Reg& r, TypeGroup group) const;

--- a/src/crab/type_encoding.hpp
+++ b/src/crab/type_encoding.hpp
@@ -7,8 +7,8 @@
 
 namespace prevail {
 
-// data_kind_t is eBPF-specific.
-enum class data_kind_t {
+// DataKind is eBPF-specific.
+enum class DataKind {
     types,
     svalues,
     uvalues,
@@ -20,16 +20,16 @@ enum class data_kind_t {
     shared_region_sizes,
     stack_numeric_sizes
 };
-constexpr auto KIND_MIN = data_kind_t::types;
-constexpr auto KIND_MAX = data_kind_t::stack_numeric_sizes;
+constexpr auto KIND_MIN = DataKind::types;
+constexpr auto KIND_MAX = DataKind::stack_numeric_sizes;
 
-std::string name_of(data_kind_t kind);
-data_kind_t regkind(const std::string& s);
-std::vector<data_kind_t> iterate_kinds(data_kind_t lb = KIND_MIN, data_kind_t ub = KIND_MAX);
-std::ostream& operator<<(std::ostream& o, const data_kind_t& s);
+std::string name_of(DataKind kind);
+DataKind regkind(const std::string& s);
+std::vector<DataKind> iterate_kinds(DataKind lb = KIND_MIN, DataKind ub = KIND_MAX);
+std::ostream& operator<<(std::ostream& o, const DataKind& s);
 
-// The exact numbers are taken advantage of in ebpf_domain_t
-enum type_encoding_t {
+// The exact numbers are taken advantage of in EbpfDomain
+enum TypeEncoding {
     T_UNINIT = -7,
     T_MAP_PROGRAMS = -6,
     T_MAP = -5,
@@ -40,14 +40,14 @@ enum type_encoding_t {
     T_SHARED = 0
 };
 
-constexpr type_encoding_t T_MIN = T_UNINIT;
-constexpr type_encoding_t T_MAX = T_SHARED;
+constexpr TypeEncoding T_MIN = T_UNINIT;
+constexpr TypeEncoding T_MAX = T_SHARED;
 
-std::vector<type_encoding_t> iterate_types(type_encoding_t lb, type_encoding_t ub);
-std::string typeset_to_string(const std::vector<type_encoding_t>& items);
+std::vector<TypeEncoding> iterate_types(TypeEncoding lb, TypeEncoding ub);
+std::string typeset_to_string(const std::vector<TypeEncoding>& items);
 
-std::ostream& operator<<(std::ostream& os, type_encoding_t s);
-type_encoding_t string_to_type_encoding(const std::string& s);
+std::ostream& operator<<(std::ostream& os, TypeEncoding s);
+TypeEncoding string_to_type_encoding(const std::string& s);
 
 enum class TypeGroup {
     number,

--- a/src/crab/variable.hpp
+++ b/src/crab/variable.hpp
@@ -15,10 +15,10 @@ std::vector<std::string> default_variable_names();
 
 // Wrapper for typed variables used by the abstract domains and linear_constraints.
 // Being a class (instead of a type alias) enables overloading in dsl_syntax
-class variable_t final {
+class Variable final {
     uint64_t _id;
 
-    explicit variable_t(const uint64_t id) : _id(id) {}
+    explicit Variable(const uint64_t id) : _id(id) {}
 
   public:
     [[nodiscard]]
@@ -26,12 +26,12 @@ class variable_t final {
         return _id;
     }
 
-    bool operator==(const variable_t o) const { return _id == o._id; }
+    bool operator==(const Variable o) const { return _id == o._id; }
 
-    bool operator!=(const variable_t o) const { return (!(operator==(o))); }
+    bool operator!=(const Variable o) const { return (!(operator==(o))); }
 
     // for flat_map
-    bool operator<(const variable_t o) const { return _id < o._id; }
+    bool operator<(const Variable o) const { return _id < o._id; }
 
     [[nodiscard]]
     std::string name() const {
@@ -48,35 +48,35 @@ class variable_t final {
         return names->at(_id).find(".uvalue") != std::string::npos;
     }
 
-    friend std::ostream& operator<<(std::ostream& o, const variable_t v) { return o << names->at(v._id); }
+    friend std::ostream& operator<<(std::ostream& o, const Variable v) { return o << names->at(v._id); }
 
     // var_factory portion.
     // This singleton is eBPF-specific, to avoid lifetime issues and/or passing factory explicitly everywhere:
   private:
-    static variable_t make(const std::string& name);
+    static Variable make(const std::string& name);
 
     /**
      * @brief Factory to always return the initial variable names.
      *
      * @tparam[in] T Should always be std::vector<std::string>.
      */
-    static thread_local lazy_allocator<std::vector<std::string>, default_variable_names> names;
+    static thread_local LazyAllocator<std::vector<std::string>, default_variable_names> names;
 
   public:
     static void clear_thread_local_state();
 
-    static std::vector<variable_t> get_type_variables();
-    static variable_t reg(data_kind_t, int);
-    static variable_t stack_frame_var(data_kind_t kind, int i, const std::string& prefix);
-    static variable_t cell_var(data_kind_t array, const number_t& offset, const number_t& size);
-    static variable_t kind_var(data_kind_t kind, variable_t type_variable);
-    static variable_t meta_offset();
-    static variable_t packet_size();
-    static std::vector<variable_t> get_loop_counters();
-    static variable_t loop_counter(const std::string& label);
+    static std::vector<Variable> get_type_variables();
+    static Variable reg(DataKind, int);
+    static Variable stack_frame_var(DataKind kind, int i, const std::string& prefix);
+    static Variable cell_var(DataKind array, const Number& offset, const Number& size);
+    static Variable kind_var(DataKind kind, Variable type_variable);
+    static Variable meta_offset();
+    static Variable packet_size();
+    static std::vector<Variable> get_loop_counters();
+    static Variable loop_counter(const std::string& label);
     [[nodiscard]]
     bool is_in_stack() const;
-    static bool printing_order(const variable_t& a, const variable_t& b);
-}; // class variable_t
+    static bool printing_order(const Variable& a, const Variable& b);
+}; // class Variable
 
 } // namespace prevail

--- a/src/crab_utils/adapt_sgraph.hpp
+++ b/src/crab_utils/adapt_sgraph.hpp
@@ -10,34 +10,34 @@ namespace prevail {
 
 class TreeSMap final {
   public:
-    using key_t = uint16_t;
-    using val_t = size_t;
+    using Key = uint16_t;
+    using Val = size_t;
 
   private:
-    using col = boost::container::flat_map<key_t, val_t>;
+    using col = boost::container::flat_map<Key, Val>;
     col map;
 
   public:
-    using elt_iter_t = col::const_iterator;
+    using EltIter = col::const_iterator;
     [[nodiscard]]
     size_t size() const {
         return map.size();
     }
 
-    class key_iter_t {
+    class KeyIter {
       public:
-        key_iter_t() = default;
-        explicit key_iter_t(const col::const_iterator& _e) : e(_e) {}
+        KeyIter() = default;
+        explicit KeyIter(const col::const_iterator& _e) : e(_e) {}
 
         /// return canonical empty iterator
-        static key_iter_t empty_iterator() {
-            static key_iter_t empty_iter;
+        static KeyIter empty_iterator() {
+            static KeyIter empty_iter;
             return empty_iter;
         }
 
-        key_t operator*() const { return e->first; }
-        bool operator!=(const key_iter_t& o) const { return e != o.e; }
-        key_iter_t& operator++() {
+        Key operator*() const { return e->first; }
+        bool operator!=(const KeyIter& o) const { return e != o.e; }
+        KeyIter& operator++() {
             ++e;
             return *this;
         }
@@ -45,31 +45,31 @@ class TreeSMap final {
         col::const_iterator e;
     };
 
-    class key_const_range_t {
+    class KeyConstRange {
       public:
-        using iterator = key_iter_t;
+        using iterator = KeyIter;
 
-        explicit key_const_range_t(const col& c) : c{c} {}
+        explicit KeyConstRange(const col& c) : c{c} {}
         [[nodiscard]]
         size_t size() const {
             return c.size();
         }
 
         [[nodiscard]]
-        key_iter_t begin() const {
-            return key_iter_t(c.cbegin());
+        KeyIter begin() const {
+            return KeyIter(c.cbegin());
         }
         [[nodiscard]]
-        key_iter_t end() const {
-            return key_iter_t(c.cend());
+        KeyIter end() const {
+            return KeyIter(c.cend());
         }
 
         const col& c;
     };
 
-    class elt_range_t {
+    class EltRange {
       public:
-        elt_range_t(const col& c) : c{c} {}
+        EltRange(const col& c) : c{c} {}
         [[nodiscard]]
         size_t size() const {
             return c.size();
@@ -87,9 +87,9 @@ class TreeSMap final {
         const col& c;
     };
 
-    class elt_const_range_t {
+    class EltConstRange {
       public:
-        elt_const_range_t(const col& c) : c{c} {}
+        EltConstRange(const col& c) : c{c} {}
         [[nodiscard]]
         size_t size() const {
             return c.size();
@@ -108,21 +108,21 @@ class TreeSMap final {
     };
 
     [[nodiscard]]
-    elt_range_t elts() const {
-        return elt_range_t(map);
+    EltRange elts() const {
+        return EltRange(map);
     }
     [[nodiscard]]
-    key_const_range_t keys() const {
-        return key_const_range_t(map);
+    KeyConstRange keys() const {
+        return KeyConstRange(map);
     }
 
     [[nodiscard]]
-    bool contains(key_t k) const {
+    bool contains(Key k) const {
         return map.count(k);
     }
 
     [[nodiscard]]
-    std::optional<val_t> lookup(key_t k) const {
+    std::optional<Val> lookup(Key k) const {
         auto v = map.find(k);
         if (v != map.end()) {
             return {v->second};
@@ -131,10 +131,10 @@ class TreeSMap final {
     }
 
     // precondition: k \in S
-    void remove(key_t k) { map.erase(k); }
+    void remove(Key k) { map.erase(k); }
 
     // precondition: k \notin S
-    void add(key_t k, const val_t& v) { map.insert_or_assign(k, v); }
+    void add(Key k, const Val& v) { map.insert_or_assign(k, v); }
     void clear() { map.clear(); }
 };
 
@@ -146,7 +146,7 @@ class AdaptGraph final {
      *
      * 1) basic integer type: e.g., long
      * 2) safei64
-     * 3) number_t
+     * 3) Number
      *
      * 1) is the fastest but things can go wrong if some DBM
      * operation overflows. 2) is slower than 1) but it checks for
@@ -155,8 +155,8 @@ class AdaptGraph final {
      * overflow is not a concern, but it might not be what you need
      * when reasoning about programs with wraparound semantics.
      **/
-    using Weight = number_t; // previously template
-    using vert_id = unsigned int;
+    using Weight = Number; // previously template
+    using VertId = unsigned int;
 
     AdaptGraph() : edge_count(0) {}
 
@@ -173,7 +173,7 @@ class AdaptGraph final {
         AdaptGraph g;
         g.growTo(o.size());
 
-        for (vert_id s : o.verts()) {
+        for (VertId s : o.verts()) {
             for (const auto& e : o.e_succs(s)) {
                 g.add_edge(s, e.val, e.vert);
             }
@@ -181,36 +181,36 @@ class AdaptGraph final {
         return g;
     }
 
-    struct vert_const_iterator {
-        vert_id v{};
+    struct VertConstIterator {
+        VertId v{};
         const std::vector<int>& is_free;
 
-        vert_id operator*() const { return v; }
+        VertId operator*() const { return v; }
 
-        bool operator!=(const vert_const_iterator& o) {
+        bool operator!=(const VertConstIterator& o) {
             while (v < o.v && is_free[v]) {
                 ++v;
             }
             return v < o.v;
         }
 
-        vert_const_iterator& operator++() {
+        VertConstIterator& operator++() {
             ++v;
             return *this;
         }
     };
-    struct vert_const_range {
+    struct VertConstRange {
         const std::vector<int>& is_free;
 
-        explicit vert_const_range(const std::vector<int>& _is_free) : is_free(_is_free) {}
+        explicit VertConstRange(const std::vector<int>& _is_free) : is_free(_is_free) {}
 
         [[nodiscard]]
-        vert_const_iterator begin() const {
-            return vert_const_iterator{0, is_free};
+        VertConstIterator begin() const {
+            return VertConstIterator{0, is_free};
         }
         [[nodiscard]]
-        vert_const_iterator end() const {
-            return vert_const_iterator{static_cast<vert_id>(is_free.size()), is_free};
+        VertConstIterator end() const {
+            return VertConstIterator{static_cast<VertId>(is_free.size()), is_free};
         }
 
         [[nodiscard]]
@@ -219,20 +219,20 @@ class AdaptGraph final {
         }
     };
     [[nodiscard]]
-    vert_const_range verts() const {
-        return vert_const_range{is_free};
+    VertConstRange verts() const {
+        return VertConstRange{is_free};
     }
 
     struct edge_const_iter {
-        struct edge_ref {
-            vert_id vert{};
+        struct EdgeRef {
+            VertId vert{};
             Weight val;
         };
 
-        TreeSMap::elt_iter_t it{};
+        TreeSMap::EltIter it{};
         const std::vector<Weight>* ws{};
 
-        edge_const_iter(const TreeSMap::elt_iter_t& _it, const std::vector<Weight>& _ws) : it(_it), ws(&_ws) {}
+        edge_const_iter(const TreeSMap::EltIter& _it, const std::vector<Weight>& _ws) : it(_it), ws(&_ws) {}
         edge_const_iter(const edge_const_iter& o) = default;
         edge_const_iter& operator=(const edge_const_iter& o) = default;
         edge_const_iter() = default;
@@ -243,7 +243,7 @@ class AdaptGraph final {
             return empty_iter;
         }
 
-        edge_ref operator*() const { return edge_ref{it->first, (*ws)[it->second]}; }
+        EdgeRef operator*() const { return EdgeRef{it->first, (*ws)[it->second]}; }
         edge_const_iter operator++() {
             ++it;
             return *this;
@@ -252,10 +252,10 @@ class AdaptGraph final {
     };
 
     struct edge_const_range_t {
-        using elt_range_t = TreeSMap::elt_range_t;
+        using EltRange = TreeSMap::EltRange;
         using iterator = edge_const_iter;
 
-        elt_range_t r;
+        EltRange r;
         const std::vector<Weight>& ws;
 
         [[nodiscard]]
@@ -272,36 +272,36 @@ class AdaptGraph final {
         }
     };
 
-    using fwd_edge_const_iter = edge_const_iter;
-    using rev_edge_const_iter = edge_const_iter;
+    using FwdEdgeConstIter = edge_const_iter;
+    using RevEdgeConstIter = edge_const_iter;
 
-    using adj_range_t = TreeSMap::key_const_range_t;
-    using adj_const_range_t = TreeSMap::key_const_range_t;
-    using neighbour_range = adj_range_t;
-    using neighbour_const_range = adj_const_range_t;
+    using AdjRange = TreeSMap::KeyConstRange;
+    using AdjConstRange = TreeSMap::KeyConstRange;
+    using NeighbourRange = AdjRange;
+    using NeighbourConstRange = AdjConstRange;
 
     [[nodiscard]]
-    adj_const_range_t succs(vert_id v) const {
+    AdjConstRange succs(VertId v) const {
         return _succs[v].keys();
     }
     [[nodiscard]]
-    adj_const_range_t preds(vert_id v) const {
+    AdjConstRange preds(VertId v) const {
         return _preds[v].keys();
     }
 
-    using fwd_edge_range = edge_const_range_t;
-    using rev_edge_range = edge_const_range_t;
+    using FwdEdgeRange = edge_const_range_t;
+    using RevEdgeRange = edge_const_range_t;
 
     [[nodiscard]]
-    edge_const_range_t e_succs(vert_id v) const {
+    edge_const_range_t e_succs(VertId v) const {
         return {_succs[v].elts(), _ws};
     }
     [[nodiscard]]
-    edge_const_range_t e_preds(vert_id v) const {
+    edge_const_range_t e_preds(VertId v) const {
         return {_preds[v].elts(), _ws};
     }
 
-    using e_neighbour_const_range = edge_const_range_t;
+    using ENeighbourConstRange = edge_const_range_t;
 
     // Management
     [[nodiscard]]
@@ -316,15 +316,15 @@ class AdaptGraph final {
     size_t num_edges() const {
         return edge_count;
     }
-    vert_id new_vertex() {
-        vert_id v;
+    VertId new_vertex() {
+        VertId v;
         if (!free_id.empty()) {
             v = free_id.back();
             assert(v < _succs.size());
             free_id.pop_back();
             is_free[v] = false;
         } else {
-            v = static_cast<vert_id>(_succs.size());
+            v = static_cast<VertId>(_succs.size());
             is_free.push_back(false);
             _succs.emplace_back();
             _preds.emplace_back();
@@ -341,7 +341,7 @@ class AdaptGraph final {
         }
     }
 
-    void forget(vert_id v) {
+    void forget(VertId v) {
         if (is_free[v]) {
             return;
         }
@@ -353,7 +353,7 @@ class AdaptGraph final {
         edge_count -= _succs[v].size();
         _succs[v].clear();
 
-        for (TreeSMap::key_t k : _preds[v].keys()) {
+        for (TreeSMap::Key k : _preds[v].keys()) {
             _succs[k].remove(v);
         }
         edge_count -= _preds[v].size();
@@ -365,7 +365,7 @@ class AdaptGraph final {
 
     void clear_edges() {
         _ws.clear();
-        for (vert_id v : verts()) {
+        for (VertId v : verts()) {
             _succs[v].clear();
             _preds[v].clear();
         }
@@ -383,15 +383,15 @@ class AdaptGraph final {
     }
 
     [[nodiscard]]
-    bool elem(vert_id s, vert_id d) const {
+    bool elem(VertId s, VertId d) const {
         return _succs[s].contains(d);
     }
 
-    const Weight& edge_val(vert_id s, vert_id d) const { return _ws[*_succs[s].lookup(d)]; }
+    const Weight& edge_val(VertId s, VertId d) const { return _ws[*_succs[s].lookup(d)]; }
 
-    class mut_val_ref_t {
+    class MutValRef {
       public:
-        mut_val_ref_t() : w(nullptr) {}
+        MutValRef() : w(nullptr) {}
         operator Weight() const {
             assert(w);
             return *w;
@@ -411,7 +411,7 @@ class AdaptGraph final {
         Weight* w;
     };
 
-    bool lookup(vert_id s, vert_id d, mut_val_ref_t* w) {
+    bool lookup(VertId s, VertId d, MutValRef* w) {
         if (auto idx = _succs[s].lookup(d)) {
             *w = &_ws[*idx];
             return true;
@@ -420,14 +420,14 @@ class AdaptGraph final {
     }
 
     [[nodiscard]]
-    std::optional<Weight> lookup(vert_id s, vert_id d) const {
+    std::optional<Weight> lookup(VertId s, VertId d) const {
         if (auto idx = _succs[s].lookup(d)) {
             return _ws[*idx];
         }
         return {};
     }
 
-    void add_edge(vert_id s, Weight w, vert_id d) {
+    void add_edge(VertId s, Weight w, VertId d) {
         size_t idx;
         if (!free_widx.empty()) {
             idx = free_widx.back();
@@ -443,7 +443,7 @@ class AdaptGraph final {
         edge_count++;
     }
 
-    void update_edge(vert_id s, Weight w, vert_id d) {
+    void update_edge(VertId s, Weight w, VertId d) {
         if (auto idx = _succs[s].lookup(d)) {
             _ws[*idx] = std::min(_ws[*idx], w);
         } else {
@@ -451,7 +451,7 @@ class AdaptGraph final {
         }
     }
 
-    void set_edge(vert_id s, Weight w, vert_id d) {
+    void set_edge(VertId s, Weight w, VertId d) {
         if (auto idx = _succs[s].lookup(d)) {
             _ws[*idx] = w;
         } else {
@@ -463,7 +463,7 @@ class AdaptGraph final {
     friend std::ostream& operator<<(std::ostream& o, AdaptGraph& g) {
         o << "[|";
         bool first = true;
-        for (vert_id v : g.verts()) {
+        for (VertId v : g.verts()) {
             auto it = g.e_succs(v).begin();
             auto end = g.e_succs(v).end();
 
@@ -495,7 +495,7 @@ class AdaptGraph final {
     size_t edge_count{};
 
     std::vector<int> is_free{};
-    std::vector<vert_id> free_id{};
+    std::vector<VertId> free_id{};
     std::vector<size_t> free_widx{};
 };
 } // namespace prevail

--- a/src/crab_utils/debug.hpp
+++ b/src/crab_utils/debug.hpp
@@ -14,43 +14,43 @@
 
 namespace prevail {
 
-#define CRAB_LOG(TAG, CODE)                                            \
-    do {                                                               \
+#define CRAB_LOG(TAG, CODE)                          \
+    do {                                             \
         if (CrabLogFlag && CrabLog.count(TAG) > 0) { \
-            CODE;                                                      \
-        }                                                              \
+            CODE;                                    \
+        }                                            \
     } while (0)
 extern bool CrabLogFlag;
 extern std::set<std::string> CrabLog;
 
 extern unsigned CrabVerbosity;
-#define CRAB_VERBOSE_IF(LEVEL, CODE)           \
-    do {                                       \
+#define CRAB_VERBOSE_IF(LEVEL, CODE)  \
+    do {                              \
         if (CrabVerbosity >= LEVEL) { \
-            CODE;                              \
-        }                                      \
+            CODE;                     \
+        }                             \
     } while (0)
 
 template <typename... ArgTypes>
 void ___print___(std::ostream& os, ArgTypes... args) {
     // trick to expand variadic argument pack without recursion
-    using expand_variadic_pack = int[];
+    using ExpandVariadicPack = int[];
     // first zero is to prevent empty braced-init-list
-    // void() is to prevent overloaded operator, messing things up
+    // void() is to prevent Overloaded operator, messing things up
     // trick is to use the side effect of list-initializer to call a function
     // on every argument.
     // (void) is to suppress "statement has no effect" warnings
-    (void)expand_variadic_pack{0, ((os << args), void(), 0)...};
+    (void)ExpandVariadicPack{0, ((os << args), void(), 0)...};
 }
 
-#define CRAB_ERROR(...)                                                         \
-    do {                                                                        \
-        std::ostringstream os;                                                  \
-        os << "CRAB ERROR: ";                                                   \
+#define CRAB_ERROR(...)                                                \
+    do {                                                               \
+        std::ostringstream os;                                         \
+        os << "CRAB ERROR: ";                                          \
         ___print___(os, __VA_ARGS__);                                  \
         ___print___(os, "; function ", __func__, ", line ", __LINE__); \
-        os << "\n";                                                             \
-        throw std::runtime_error(os.str());                                     \
+        os << "\n";                                                    \
+        throw std::runtime_error(os.str());                            \
     } while (0)
 
 extern bool CrabWarningFlag;
@@ -58,7 +58,7 @@ void CrabEnableWarningMsg(bool b);
 
 #define CRAB_WARN(...)                           \
     do {                                         \
-        if (CrabWarningFlag) {          \
+        if (CrabWarningFlag) {                   \
             std::cerr << "CRAB WARNING: ";       \
             ___print___(std::cerr, __VA_ARGS__); \
             std::cerr << "\n";                   \

--- a/src/crab_utils/graph_ops.hpp
+++ b/src/crab_utils/graph_ops.hpp
@@ -23,12 +23,12 @@ namespace prevail {
 template <class G>
 class GraphPerm {
   public:
-    using vert_id = typename G::vert_id;
-    constexpr static vert_id invalid_vert = std::numeric_limits<vert_id>::max();
+    using VertId = typename G::VertId;
+    constexpr static VertId invalid_vert = std::numeric_limits<VertId>::max();
     using Weight = typename G::Weight;
-    using mut_val_ref_t = typename G::mut_val_ref_t;
+    using MutValRef = typename G::MutValRef;
 
-    GraphPerm(const std::vector<vert_id>& _perm, G& _g) : g{_g}, perm{_perm}, inv(_g.size(), invalid_vert) {
+    GraphPerm(const std::vector<VertId>& _perm, G& _g) : g{_g}, perm{_perm}, inv(_g.size(), invalid_vert) {
         for (unsigned int vi = 0; vi < perm.size(); vi++) {
             if (perm[vi] == invalid_vert) {
                 continue;
@@ -39,21 +39,21 @@ class GraphPerm {
     }
 
     // Check whether an edge is live
-    bool elem(vert_id x, vert_id y) const {
+    bool elem(VertId x, VertId y) const {
         if (perm[x] > g.size() || perm[y] > g.size()) {
             return false;
         }
         return g.elem(perm[x], perm[y]);
     }
 
-    bool lookup(vert_id x, vert_id y, mut_val_ref_t* w) {
+    bool lookup(VertId x, VertId y, MutValRef* w) {
         if (perm[x] > g.size() || perm[y] > g.size()) {
             return false;
         }
         return g.lookup(perm[x], perm[y], w);
     }
 
-    std::optional<Weight> lookup(vert_id x, vert_id y) const {
+    std::optional<Weight> lookup(VertId x, VertId y) const {
         if (perm[x] > g.size() || perm[y] > g.size()) {
             return {};
         }
@@ -61,13 +61,13 @@ class GraphPerm {
     }
 
     // Precondition: elem(x, y) is true.
-    Weight edge_val(vert_id x, vert_id y) const {
+    Weight edge_val(VertId x, VertId y) const {
         //      assert(perm[x] < g.size() && perm[y] < g.size());
         return g.edge_val(perm[x], perm[y]);
     }
 
     // Precondition: elem(x, y) is true.
-    Weight operator()(vert_id x, vert_id y) const {
+    Weight operator()(VertId x, VertId y) const {
         //      assert(perm[x] < g.size() && perm[y] < g.size());
         return g(perm[x], perm[y]);
     }
@@ -78,12 +78,12 @@ class GraphPerm {
         return perm.size();
     }
 
-    class vert_const_range final {
+    class VertConstRange final {
       public:
         class iterator final {
           public:
-            explicit iterator(const vert_id _v) : v{_v} {}
-            vert_id operator*() const { return v; }
+            explicit iterator(const VertId _v) : v{_v} {}
+            VertId operator*() const { return v; }
             iterator& operator++() {
                 ++v;
                 return *this;
@@ -95,35 +95,35 @@ class GraphPerm {
             bool operator!=(const iterator& o) const { return v < o.v; }
 
           private:
-            vert_id v;
+            VertId v;
         };
-        explicit vert_const_range(const vert_id _after) : after{_after} {}
+        explicit VertConstRange(const VertId _after) : after{_after} {}
 
         iterator begin() const { return iterator{0}; }
         iterator end() const { return iterator{after}; }
 
       private:
-        vert_id after;
+        VertId after;
     };
-    using vert_const_iterator = typename vert_const_range::iterator;
+    using VertConstIterator = typename VertConstRange::iterator;
 
-    vert_const_range verts() const { return vert_const_range(gsl::narrow<vert_id>(perm.size())); }
+    VertConstRange verts() const { return VertConstRange(gsl::narrow<VertId>(perm.size())); }
 
     // GKG: Should probably modify this to handle cases where
-    // the vertex iterator isn't just a vert_id*.
+    // the vertex iterator isn't just a VertId*.
     template <class ItG>
-    class adj_const_iterator final {
+    class AdjConstIterator final {
       public:
-        adj_const_iterator(const std::vector<vert_id>& _inv, const ItG& _v) : inv(_inv), v(_v) {}
+        AdjConstIterator(const std::vector<VertId>& _inv, const ItG& _v) : inv(_inv), v(_v) {}
 
-        vert_id operator*() const { return inv[*v]; }
+        VertId operator*() const { return inv[*v]; }
 
-        adj_const_iterator& operator++() {
+        AdjConstIterator& operator++() {
             ++v;
             return *this;
         }
 
-        bool operator!=(const adj_const_iterator& other) {
+        bool operator!=(const AdjConstIterator& other) {
             while (v != other.v && inv[*v] == invalid_vert) {
                 ++v;
             }
@@ -131,25 +131,25 @@ class GraphPerm {
         }
 
       private:
-        const std::vector<vert_id>& inv;
+        const std::vector<VertId>& inv;
         ItG v;
     };
 
     template <class ItG>
-    class e_adj_const_iterator final {
+    class EAdjConstIterator final {
       public:
-        using edge_ref = typename ItG::edge_ref;
+        using EdgeRef = typename ItG::EdgeRef;
 
-        e_adj_const_iterator(const std::vector<vert_id>& _inv, const ItG& _v) : inv(_inv), v(_v) {}
+        EAdjConstIterator(const std::vector<VertId>& _inv, const ItG& _v) : inv(_inv), v(_v) {}
 
-        edge_ref operator*() const { return edge_ref{inv[(*v).vert], (*v).val}; }
+        EdgeRef operator*() const { return EdgeRef{inv[(*v).vert], (*v).val}; }
 
-        e_adj_const_iterator& operator++() {
+        EAdjConstIterator& operator++() {
             ++v;
             return *this;
         }
 
-        bool operator!=(const e_adj_const_iterator& other) {
+        bool operator!=(const EAdjConstIterator& other) {
             while (v != other.v && inv[(*v).vert] == invalid_vert) {
                 ++v;
             }
@@ -157,21 +157,21 @@ class GraphPerm {
         }
 
       private:
-        const std::vector<vert_id>& inv;
+        const std::vector<VertId>& inv;
         ItG v;
     };
 
     template <class RG, class It>
-    class adj_list final {
+    class AdjList final {
       public:
         using ItG = typename RG::iterator;
 
         using iterator = It;
 
-        adj_list(const std::vector<vert_id>& _perm, const std::vector<vert_id>& _inv, const RG& _adj)
+        AdjList(const std::vector<VertId>& _perm, const std::vector<VertId>& _inv, const RG& _adj)
             : perm(_perm), inv(_inv), adj(_adj) {}
 
-        adj_list(const std::vector<vert_id>& _perm, const std::vector<vert_id>& _inv) : perm(_perm), inv(_inv), adj() {}
+        AdjList(const std::vector<VertId>& _perm, const std::vector<VertId>& _inv) : perm(_perm), inv(_inv), adj() {}
 
         iterator begin() const {
             if (adj) {
@@ -195,22 +195,22 @@ class GraphPerm {
         }
 
       private:
-        const std::vector<vert_id>& perm;
-        const std::vector<vert_id>& inv;
+        const std::vector<VertId>& perm;
+        const std::vector<VertId>& inv;
         std::optional<RG> adj;
     };
 
     template <class RG, class It>
-    class const_adj_list final {
+    class ConstAdjList final {
       public:
         using ItG = typename RG::iterator;
 
         using iterator = It;
 
-        const_adj_list(const std::vector<vert_id>& _perm, const std::vector<vert_id>& _inv, const RG& _adj)
+        ConstAdjList(const std::vector<VertId>& _perm, const std::vector<VertId>& _inv, const RG& _adj)
             : perm(_perm), inv(_inv), adj(_adj) {}
 
-        const_adj_list(const std::vector<vert_id>& _perm, const std::vector<vert_id>& _inv)
+        ConstAdjList(const std::vector<VertId>& _perm, const std::vector<VertId>& _inv)
             : perm(_perm), inv(_inv), adj() {}
 
         iterator begin() const {
@@ -235,73 +235,73 @@ class GraphPerm {
         }
 
       private:
-        const std::vector<vert_id>& perm;
-        const std::vector<vert_id>& inv;
+        const std::vector<VertId>& perm;
+        const std::vector<VertId>& inv;
         std::optional<RG> adj;
     };
 
-    using neighbour_const_range = const_adj_list<typename G::neighbour_const_range,
-                                                 adj_const_iterator<typename G::neighbour_const_range::iterator>>;
-    using e_neighbour_const_range = const_adj_list<typename G::e_neighbour_const_range,
-                                                   e_adj_const_iterator<typename G::e_neighbour_const_range::iterator>>;
+    using NeighbourConstRange =
+        ConstAdjList<typename G::NeighbourConstRange, AdjConstIterator<typename G::NeighbourConstRange::iterator>>;
+    using ENeighbourConstRange =
+        ConstAdjList<typename G::ENeighbourConstRange, EAdjConstIterator<typename G::ENeighbourConstRange::iterator>>;
 
-    neighbour_const_range succs(vert_id v) const {
+    NeighbourConstRange succs(VertId v) const {
         if (perm[v] == invalid_vert) {
-            return neighbour_const_range(perm, inv);
+            return NeighbourConstRange(perm, inv);
         }
-        return neighbour_const_range(perm, inv, g.succs(perm[v]));
+        return NeighbourConstRange(perm, inv, g.succs(perm[v]));
     }
-    neighbour_const_range preds(vert_id v) const {
+    NeighbourConstRange preds(VertId v) const {
         if (perm[v] == invalid_vert) {
-            return neighbour_const_range(perm, inv);
+            return NeighbourConstRange(perm, inv);
         }
-        return neighbour_const_range(perm, inv, g.preds(perm[v]));
+        return NeighbourConstRange(perm, inv, g.preds(perm[v]));
     }
 
-    e_neighbour_const_range e_succs(vert_id v) const {
+    ENeighbourConstRange e_succs(VertId v) const {
         if (perm[v] == invalid_vert) {
-            return e_neighbour_const_range(perm, inv);
+            return ENeighbourConstRange(perm, inv);
         }
-        return e_neighbour_const_range(perm, inv, g.e_succs(perm[v]));
+        return ENeighbourConstRange(perm, inv, g.e_succs(perm[v]));
     }
-    e_neighbour_const_range e_preds(vert_id v) const {
+    ENeighbourConstRange e_preds(VertId v) const {
         if (perm[v] == invalid_vert) {
-            return e_neighbour_const_range(perm, inv);
+            return ENeighbourConstRange(perm, inv);
         }
-        return e_neighbour_const_range(perm, inv, g.e_preds(perm[v]));
+        return ENeighbourConstRange(perm, inv, g.e_preds(perm[v]));
     }
 
     const G& g;
-    std::vector<vert_id> perm;
-    std::vector<vert_id> inv;
+    std::vector<VertId> perm;
+    std::vector<VertId> inv;
 };
 
 // View of a graph, omitting a given vertex
 template <class G>
 class SubGraph {
   public:
-    using vert_id = typename G::vert_id;
+    using VertId = typename G::VertId;
     using Weight = typename G::Weight;
 
-    using g_neighbour_const_range = typename G::neighbour_const_range;
-    using g_e_neighbour_const_range = typename G::e_neighbour_const_range;
+    using GNeighbourConstRange = typename G::NeighbourConstRange;
+    using GENeighbourConstRange = typename G::ENeighbourConstRange;
 
-    using mut_val_ref_t = typename G::mut_val_ref_t;
+    using MutValRef = typename G::MutValRef;
 
-    SubGraph(G& _g, vert_id _v_ex) : g(_g), v_ex(_v_ex) {}
+    SubGraph(G& _g, VertId _v_ex) : g(_g), v_ex(_v_ex) {}
 
-    bool elem(vert_id x, vert_id y) const { return x != v_ex && y != v_ex && g.elem(x, y); }
+    bool elem(VertId x, VertId y) const { return x != v_ex && y != v_ex && g.elem(x, y); }
 
-    bool lookup(vert_id x, vert_id y, mut_val_ref_t* w) { return x != v_ex && y != v_ex && g.lookup(x, y, w); }
+    bool lookup(VertId x, VertId y, MutValRef* w) { return x != v_ex && y != v_ex && g.lookup(x, y, w); }
 
-    std::optional<Weight> lookup(vert_id x, vert_id y) const {
+    std::optional<Weight> lookup(VertId x, VertId y) const {
         return (x != v_ex && y != v_ex) ? g.lookup(x, y) : std::optional<Weight>{};
     }
 
-    Weight edge_val(vert_id x, vert_id y) const { return g.edge_val(x, y); }
+    Weight edge_val(VertId x, VertId y) const { return g.edge_val(x, y); }
 
     // Precondition: elem(x, y) is true.
-    Weight operator()(vert_id x, vert_id y) const { return g(x, y); }
+    Weight operator()(VertId x, VertId y) const { return g(x, y); }
 
     void clear_edges() { g.clear_edges(); }
 
@@ -312,65 +312,65 @@ class SubGraph {
     }
 
     // Assumption: (x, y) not in mtx
-    void add_edge(vert_id x, Weight wt, vert_id y) {
+    void add_edge(VertId x, Weight wt, VertId y) {
         //      assert(x != v_ex && y != v_ex);
         g.add_edge(x, wt, y);
     }
 
-    void set_edge(vert_id s, Weight w, vert_id d) {
+    void set_edge(VertId s, Weight w, VertId d) {
         //      assert(s != v_ex && d != v_ex);
         g.set_edge(s, w, d);
     }
 
     template <class Op>
-    void update_edge(vert_id s, Weight w, vert_id d, Op& op) {
+    void update_edge(VertId s, Weight w, VertId d, Op& op) {
         //      assert(s != v_ex && d != v_ex);
         g.update_edge(s, w, d, op);
     }
 
-    class vert_const_iterator {
+    class VertConstIterator {
       public:
-        vert_const_iterator(const typename G::vert_const_iterator& _iG, vert_id _v_ex) : v_ex(_v_ex), iG(_iG) {}
+        VertConstIterator(const typename G::VertConstIterator& _iG, VertId _v_ex) : v_ex(_v_ex), iG(_iG) {}
 
         // Skipping of v_ex is done entirely by !=.
         // So we _MUST_ test it != verts.end() before dereferencing.
-        vert_id operator*() { return *iG; }
-        vert_const_iterator operator++() {
+        VertId operator*() { return *iG; }
+        VertConstIterator operator++() {
             ++iG;
             return *this;
         }
-        bool operator!=(const vert_const_iterator& o) {
+        bool operator!=(const VertConstIterator& o) {
             if (iG != o.iG && (*iG) == v_ex) {
                 ++iG;
             }
             return iG != o.iG;
         }
 
-        vert_id v_ex;
-        typename G::vert_const_iterator iG;
+        VertId v_ex;
+        typename G::VertConstIterator iG;
     };
-    class vert_const_range {
+    class VertConstRange {
       public:
-        vert_const_range(const typename G::vert_const_range& _rG, vert_id _v_ex) : rG(_rG), v_ex(_v_ex) {}
+        VertConstRange(const typename G::VertConstRange& _rG, VertId _v_ex) : rG(_rG), v_ex(_v_ex) {}
 
-        vert_const_iterator begin() const { return vert_const_iterator(rG.begin(), v_ex); }
-        vert_const_iterator end() const { return vert_const_iterator(rG.end(), v_ex); }
+        VertConstIterator begin() const { return VertConstIterator(rG.begin(), v_ex); }
+        VertConstIterator end() const { return VertConstIterator(rG.end(), v_ex); }
 
-        typename G::vert_const_range rG;
-        vert_id v_ex;
+        typename G::VertConstRange rG;
+        VertId v_ex;
     };
-    vert_const_range verts() const { return vert_const_range(g.verts(), v_ex); }
+    VertConstRange verts() const { return VertConstRange(g.verts(), v_ex); }
 
     template <class It>
-    class adj_iterator {
+    class AdjIterator {
       public:
-        adj_iterator(const It& _iG, vert_id _v_ex) : iG(_iG), v_ex(_v_ex) {}
-        vert_id operator*() const { return *iG; }
-        adj_iterator& operator++() {
+        AdjIterator(const It& _iG, VertId _v_ex) : iG(_iG), v_ex(_v_ex) {}
+        VertId operator*() const { return *iG; }
+        AdjIterator& operator++() {
             ++iG;
             return *this;
         }
-        bool operator!=(const adj_iterator& o) {
+        bool operator!=(const AdjIterator& o) {
             if (iG != o.iG && (*iG) == v_ex) {
                 ++iG;
             }
@@ -378,21 +378,21 @@ class SubGraph {
         }
 
         It iG;
-        vert_id v_ex;
+        VertId v_ex;
     };
 
     template <class It>
-    class e_adj_iterator {
+    class EAdjIterator {
       public:
-        using edge_ref = typename It::edge_ref;
+        using EdgeRef = typename It::EdgeRef;
 
-        e_adj_iterator(const It& _iG, vert_id _v_ex) : iG(_iG), v_ex(_v_ex) {}
-        edge_ref operator*() const { return *iG; }
-        e_adj_iterator& operator++() {
+        EAdjIterator(const It& _iG, VertId _v_ex) : iG(_iG), v_ex(_v_ex) {}
+        EdgeRef operator*() const { return *iG; }
+        EAdjIterator& operator++() {
             ++iG;
             return *this;
         }
-        bool operator!=(const e_adj_iterator& o) {
+        bool operator!=(const EAdjIterator& o) {
             if (iG != o.iG && (*iG).vert == v_ex) {
                 ++iG;
             }
@@ -400,40 +400,38 @@ class SubGraph {
         }
 
         It iG;
-        vert_id v_ex;
+        VertId v_ex;
     };
 
     template <class R, class It>
-    class adj_list {
+    class AdjList {
       public:
         using iterator = It;
 
-        adj_list(const R& _rG, vert_id _v_ex) : rG(_rG), v_ex(_v_ex) {}
+        AdjList(const R& _rG, VertId _v_ex) : rG(_rG), v_ex(_v_ex) {}
         iterator begin() const { return iterator(rG.begin(), v_ex); }
         iterator end() const { return iterator(rG.end(), v_ex); }
 
       private:
         R rG;
-        vert_id v_ex;
+        VertId v_ex;
     };
-    using neighbour_const_range =
-        adj_list<g_neighbour_const_range, adj_iterator<typename g_neighbour_const_range::iterator>>;
-    using e_neighbour_const_range =
-        adj_list<g_e_neighbour_const_range, e_adj_iterator<typename g_e_neighbour_const_range::iterator>>;
+    using NeighbourConstRange = AdjList<GNeighbourConstRange, AdjIterator<typename GNeighbourConstRange::iterator>>;
+    using ENeighbourConstRange = AdjList<GENeighbourConstRange, EAdjIterator<typename GENeighbourConstRange::iterator>>;
 
-    neighbour_const_range succs(vert_id v) const {
+    NeighbourConstRange succs(VertId v) const {
         //      assert(v != v_ex);
-        return neighbour_const_range(g.succs(v), v_ex);
+        return NeighbourConstRange(g.succs(v), v_ex);
     }
-    neighbour_const_range preds(vert_id v) const {
+    NeighbourConstRange preds(VertId v) const {
         //      assert(v != v_ex);
-        return neighbour_const_range(g.preds(v), v_ex);
+        return NeighbourConstRange(g.preds(v), v_ex);
     }
-    e_neighbour_const_range e_succs(vert_id v) const { return e_neighbour_const_range(g.e_succs(v), v_ex); }
-    e_neighbour_const_range e_preds(vert_id v) const { return e_neighbour_const_range(g.e_preds(v), v_ex); }
+    ENeighbourConstRange e_succs(VertId v) const { return ENeighbourConstRange(g.e_succs(v), v_ex); }
+    ENeighbourConstRange e_preds(VertId v) const { return ENeighbourConstRange(g.e_preds(v), v_ex); }
 
     G& g;
-    vert_id v_ex;
+    VertId v_ex;
 };
 
 // Viewing a graph with all edges reversed.
@@ -442,23 +440,23 @@ class SubGraph {
 template <class G>
 class GraphRev {
   public:
-    using vert_id = typename G::vert_id;
+    using VertId = typename G::VertId;
     using Weight = typename G::Weight;
-    using mut_val_ref_t = typename G::mut_val_ref_t;
+    using MutValRef = typename G::MutValRef;
 
     explicit GraphRev(G& _g) : g(_g) {}
 
     // Check whether an edge is live
-    bool elem(vert_id x, vert_id y) const { return g.elem(y, x); }
+    bool elem(VertId x, VertId y) const { return g.elem(y, x); }
 
-    bool lookup(vert_id x, vert_id y, mut_val_ref_t* w) { return g.lookup(y, x, w); }
-    std::optional<Weight> lookup(vert_id x, vert_id y) const { return g.lookup(y, x); }
-
-    // Precondition: elem(x, y) is true.
-    Weight edge_val(vert_id x, vert_id y) const { return g.edge_val(y, x); }
+    bool lookup(VertId x, VertId y, MutValRef* w) { return g.lookup(y, x, w); }
+    std::optional<Weight> lookup(VertId x, VertId y) const { return g.lookup(y, x); }
 
     // Precondition: elem(x, y) is true.
-    Weight operator()(vert_id x, vert_id y) const { return g(y, x); }
+    Weight edge_val(VertId x, VertId y) const { return g.edge_val(y, x); }
+
+    // Precondition: elem(x, y) is true.
+    Weight operator()(VertId x, VertId y) const { return g(y, x); }
 
     // Number of allocated vertices
     [[nodiscard]]
@@ -466,32 +464,32 @@ class GraphRev {
         return g.size();
     }
 
-    using neighbour_const_range = typename G::neighbour_const_range;
-    using e_neighbour_const_range = typename G::e_neighbour_const_range;
+    using NeighbourConstRange = typename G::NeighbourConstRange;
+    using ENeighbourConstRange = typename G::ENeighbourConstRange;
 
-    typename G::vert_const_range verts() const { return g.verts(); }
+    typename G::VertConstRange verts() const { return g.verts(); }
 
-    neighbour_const_range succs(vert_id v) const { return g.preds(v); }
-    neighbour_const_range preds(vert_id v) const { return g.succs(v); }
+    NeighbourConstRange succs(VertId v) const { return g.preds(v); }
+    NeighbourConstRange preds(VertId v) const { return g.succs(v); }
 
-    e_neighbour_const_range e_succs(vert_id v) const { return g.e_preds(v); }
-    e_neighbour_const_range e_preds(vert_id v) const { return g.e_succs(v); }
+    ENeighbourConstRange e_succs(VertId v) const { return g.e_preds(v); }
+    ENeighbourConstRange e_preds(VertId v) const { return g.e_succs(v); }
     G& g;
 };
 
 // GKG - What's the best way to split this out?
 class GraphOps {
   public:
-    // The following code assumes vert_id is an integer.
-    using graph_t = AdaptGraph;
-    using Weight = typename graph_t::Weight;
-    using vert_id = typename graph_t::vert_id;
+    // The following code assumes VertId is an integer.
+    using Graph = AdaptGraph;
+    using Weight = typename Graph::Weight;
+    using VertId = typename Graph::VertId;
     using WeightVector = std::vector<Weight>;
 
-    using PotentialFunction = std::function<Weight(vert_id)>;
-    using mut_val_ref_t = typename graph_t::mut_val_ref_t;
+    using PotentialFunction = std::function<Weight(VertId)>;
+    using MutValRef = typename Graph::MutValRef;
 
-    using edge_vector = std::vector<std::tuple<vert_id, vert_id, Weight>>;
+    using EdgeVector = std::vector<std::tuple<VertId, VertId, Weight>>;
 
     //===========================================
     // Enums used to mark vertices/edges during algorithms
@@ -507,20 +505,20 @@ class GraphOps {
     // Scratch space needed by the graph algorithms.
     // Should really switch to some kind of arena allocator, rather
     // than having all these static structures.
-    static inline thread_local lazy_allocator<std::vector<char>> edge_marks;
+    static inline thread_local LazyAllocator<std::vector<char>> edge_marks;
 
     // Used for Bellman-Ford queueing
-    static inline thread_local lazy_allocator<std::vector<vert_id>> dual_queue;
-    static inline thread_local lazy_allocator<std::vector<int>> vert_marks;
+    static inline thread_local LazyAllocator<std::vector<VertId>> dual_queue;
+    static inline thread_local LazyAllocator<std::vector<int>> vert_marks;
     static inline thread_local size_t scratch_sz;
 
     // For locality, should combine dists & dist_ts.
     // Weight must have an empty constructor, but does _not_ need a top or infty element.
     // dist_ts tells us which distances are current, and ts_idx prevents wraparound problems,
     // in the unlikely circumstance that we have more than 2^sizeof(uint) iterations.
-    static inline thread_local lazy_allocator<std::vector<Weight>> dists;
-    static inline thread_local lazy_allocator<std::vector<Weight>> dists_alt;
-    static inline thread_local lazy_allocator<std::vector<unsigned int>> dist_ts;
+    static inline thread_local LazyAllocator<std::vector<Weight>> dists;
+    static inline thread_local LazyAllocator<std::vector<Weight>> dists_alt;
+    static inline thread_local LazyAllocator<std::vector<unsigned int>> dist_ts;
     static inline thread_local unsigned int ts;
     static inline thread_local unsigned int ts_idx;
 
@@ -567,18 +565,18 @@ class GraphOps {
 
   public:
     // Syntactic join.
-    static graph_t join(auto& l, auto& r) {
+    static Graph join(auto& l, auto& r) {
         // For the join, potentials are preserved
         assert(l.size() == r.size());
         const size_t sz = l.size();
 
-        graph_t g;
+        Graph g;
         g.growTo(sz);
 
-        mut_val_ref_t wr;
-        for (const vert_id s : l.verts()) {
+        MutValRef wr;
+        for (const VertId s : l.verts()) {
             for (const auto e : l.e_succs(s)) {
-                const vert_id d = e.vert;
+                const VertId d = e.vert;
                 if (r.lookup(s, d, &wr)) {
                     g.add_edge(s, std::max(e.val, static_cast<Weight>(wr)), d);
                 }
@@ -588,12 +586,12 @@ class GraphOps {
     }
 
     // Syntactic meet
-    static graph_t meet(const auto& l, const auto& r, bool& is_closed) {
+    static Graph meet(const auto& l, const auto& r, bool& is_closed) {
         assert(l.size() == r.size());
-        graph_t g(graph_t::copy(l));
+        Graph g(Graph::copy(l));
 
-        mut_val_ref_t wg;
-        for (vert_id s : r.verts()) {
+        MutValRef wg;
+        for (VertId s : r.verts()) {
             for (const auto e : r.e_succs(s)) {
                 if (!g.lookup(s, e.vert, &wg)) {
                     g.add_edge(s, e.val, e.vert);
@@ -608,14 +606,14 @@ class GraphOps {
         return g;
     }
 
-    static graph_t widen(const auto& l, const auto& r, std::unordered_set<vert_id>& unstable) {
+    static Graph widen(const auto& l, const auto& r, std::unordered_set<VertId>& unstable) {
         assert(l.size() == r.size());
         const size_t sz = l.size();
-        graph_t g;
+        Graph g;
         g.growTo(sz);
-        for (const vert_id s : r.verts()) {
+        for (const VertId s : r.verts()) {
             for (const auto e : r.e_succs(s)) {
-                const vert_id d = e.vert;
+                const VertId d = e.vert;
                 if (auto wl = l.lookup(s, d)) {
                     if (e.val <= *wl) {
                         g.add_edge(s, *wl, d);
@@ -624,7 +622,7 @@ class GraphOps {
             }
 
             // Check if this vertex is stable
-            for (const vert_id d : l.succs(s)) {
+            for (const VertId d : l.succs(s)) {
                 if (!g.elem(s, d)) {
                     unstable.insert(s);
                     break;
@@ -639,8 +637,8 @@ class GraphOps {
     // Compute the strongly connected components.
     // Duped pretty much verbatim from Wikipedia.
     // Abuses 'dual_queue' to store indices.
-    static void strong_connect(const auto& x, std::vector<vert_id>& stack, int& index, vert_id v,
-                               std::vector<std::vector<vert_id>>& sccs) {
+    static void strong_connect(const auto& x, std::vector<VertId>& stack, int& index, VertId v,
+                               std::vector<std::vector<VertId>>& sccs) {
         vert_marks->at(v) = (index << 1) | 1;
         // assert(vert_marks->at(v)&1);
         dual_queue->at(v) = index;
@@ -649,21 +647,21 @@ class GraphOps {
         stack.push_back(v);
 
         // Consider successors of v
-        for (const vert_id w : x.succs(v)) {
+        for (const VertId w : x.succs(v)) {
             if (!vert_marks->at(w)) {
                 strong_connect(x, stack, index, w, sccs);
                 dual_queue->at(v) = std::min(dual_queue->at(v), dual_queue->at(w));
             } else if (vert_marks->at(w) & 1) {
                 // W is on the stack
-                dual_queue->at(v) = std::min(dual_queue->at(v), gsl::narrow<vert_id>(vert_marks->at(w) >> 1));
+                dual_queue->at(v) = std::min(dual_queue->at(v), gsl::narrow<VertId>(vert_marks->at(w) >> 1));
             }
         }
 
         // If v is a root node, pop the stack and generate an SCC
-        if (dual_queue->at(v) == gsl::narrow<vert_id>(vert_marks->at(v) >> 1)) {
+        if (dual_queue->at(v) == gsl::narrow<VertId>(vert_marks->at(v) >> 1)) {
             sccs.emplace_back();
-            std::vector<vert_id>& scc(sccs.back());
-            vert_id w;
+            std::vector<VertId>& scc(sccs.back());
+            VertId w;
             do {
                 w = stack.back();
                 stack.pop_back();
@@ -673,22 +671,22 @@ class GraphOps {
         }
     }
 
-    static void compute_sccs(const auto& x, std::vector<std::vector<vert_id>>& out_scc) {
+    static void compute_sccs(const auto& x, std::vector<std::vector<VertId>>& out_scc) {
         const size_t sz = x.size();
         grow_scratch(sz);
 
-        for (vert_id v : x.verts()) {
+        for (VertId v : x.verts()) {
             vert_marks->at(v) = 0;
         }
-        for (vert_id v : x.verts()) {
+        for (VertId v : x.verts()) {
             if (!vert_marks->at(v)) {
-                std::vector<vert_id> stack;
+                std::vector<VertId> stack;
                 int index = 1;
                 strong_connect(x, stack, index, v, out_scc);
             }
         }
 
-        for (vert_id v : x.verts()) {
+        for (VertId v : x.verts()) {
             vert_marks->at(v) = 0;
         }
     }
@@ -701,7 +699,7 @@ class GraphOps {
         assert(potentials.size() >= sz);
         grow_scratch(sz);
 
-        std::vector<std::vector<vert_id>> sccs;
+        std::vector<std::vector<VertId>> sccs;
         compute_sccs(g, sccs);
 
         // Currently trusting the call-site to select reasonable initial values.
@@ -709,14 +707,14 @@ class GraphOps {
             // Zero existing potentials.
             // Not strictly necessary, but means we're less likely to run into over/underflow.
             // Though this hurts our chances of early cutoff.
-            for (vert_id v : g.verts()) {
+            for (VertId v : g.verts()) {
                 potentials[v] = 0;
             }
         }
 
         // Run Bellman-ford on each SCC.
         // Current implementation returns sccs in reverse topological order.
-        for (const std::vector<vert_id>& scc : sccs) {
+        for (const std::vector<VertId>& scc : sccs) {
 
             auto qhead = dual_queue->begin();
             auto qtail = qhead;
@@ -724,23 +722,23 @@ class GraphOps {
             auto next_head = dual_queue->begin() + sz;
             auto next_tail = next_head;
 
-            for (vert_id v : scc) {
+            for (VertId v : scc) {
                 *qtail = v;
                 vert_marks->at(v) = BF_SCC | BF_QUEUED;
                 ++qtail;
             }
 
             for ([[maybe_unused]]
-                 vert_id _ : scc) {
+                 VertId _ : scc) {
                 while (qtail != qhead) {
-                    vert_id s = *--qtail;
+                    VertId s = *--qtail;
                     // If it _was_ on the queue, it must be in the SCC
                     vert_marks->at(s) = BF_SCC;
 
                     Weight s_pot = potentials[s];
 
                     for (const auto e : g.e_succs(s)) {
-                        vert_id d = e.vert;
+                        VertId d = e.vert;
                         Weight sd_pot = s_pot + e.val;
                         if (sd_pot < potentials[d]) {
                             potentials[d] = sd_pot;
@@ -762,13 +760,13 @@ class GraphOps {
             }
             // Check if the SCC is feasible.
             while (qtail != qhead) {
-                vert_id s = *--qtail;
+                VertId s = *--qtail;
                 Weight s_pot = potentials[s];
                 for (const auto e : g.e_succs(s)) {
-                    vert_id d = e.vert;
+                    VertId d = e.vert;
                     if (s_pot + e.val < potentials[d]) {
                         // Cleanup vertex marks
-                        for (vert_id v : g.verts()) {
+                        for (VertId v : g.verts()) {
                             vert_marks->at(v) = BF_NONE;
                         }
                         return false;
@@ -780,20 +778,20 @@ class GraphOps {
     }
 
     template <class G, class G1, class G2>
-    static edge_vector close_after_meet(const G& g, const PotentialFunction& pots, const G1& l, const G2& r) {
+    static EdgeVector close_after_meet(const G& g, const PotentialFunction& pots, const G1& l, const G2& r) {
         // We assume the syntactic meet has already been computed, and potentials have been initialized.
         // We just want to restore closure.
         assert(l.size() == r.size());
         const size_t sz = l.size();
         grow_scratch(sz);
 
-        std::vector<std::vector<vert_id>> colour_succs(2 * sz);
+        std::vector<std::vector<VertId>> colour_succs(2 * sz);
 
         // Partition edges into r-only/rb/b-only.
-        for (vert_id s : g.verts()) {
+        for (VertId s : g.verts()) {
             for (const auto e : g.e_succs(s)) {
                 unsigned char mark = 0;
-                const vert_id d = e.vert;
+                const VertId d = e.vert;
                 if (const auto w = l.lookup(s, d)) {
                     if (*w == e.val) {
                         mark |= E_LEFT;
@@ -817,9 +815,9 @@ class GraphOps {
         }
 
         // We can run the chromatic Dijkstra variant on each source.
-        std::vector<std::tuple<vert_id, Weight>> adjs;
-        edge_vector delta;
-        for (vert_id v : g.verts()) {
+        std::vector<std::tuple<VertId, Weight>> adjs;
+        EdgeVector delta;
+        for (VertId v : g.verts()) {
             adjs.clear();
             chrome_dijkstra(g, pots, colour_succs, v, adjs);
 
@@ -830,7 +828,7 @@ class GraphOps {
         return delta;
     }
 
-    static void apply_delta(graph_t& g, const edge_vector& delta) {
+    static void apply_delta(Graph& g, const EdgeVector& delta) {
         for (const auto& [s, d, w] : delta) {
             //        assert(s != d);
             //        assert(s < g.size());
@@ -845,8 +843,8 @@ class GraphOps {
     // P is some vector-alike holding a valid system of potentials.
     // Don't need to clear/initialize
     template <class G>
-    static void chrome_dijkstra(const G& g, const PotentialFunction& p, std::vector<std::vector<vert_id>>& colour_succs,
-                                vert_id src, std::vector<std::tuple<vert_id, Weight>>& out) {
+    static void chrome_dijkstra(const G& g, const PotentialFunction& p, std::vector<std::vector<VertId>>& colour_succs,
+                                VertId src, std::vector<std::tuple<VertId, Weight>>& out) {
         const size_t sz = g.size();
         if (sz == 0) {
             return;
@@ -863,7 +861,7 @@ class GraphOps {
         Heap heap(dists_compare);
 
         for (const auto e : g.e_succs(src)) {
-            const vert_id dest = e.vert;
+            const VertId dest = e.vert;
             dists->at(dest) = p(src) + e.val - p(dest);
             dist_ts->at(dest) = ts;
 
@@ -887,9 +885,9 @@ class GraphOps {
             }
 
             // Pick the appropriate set of successors
-            const std::vector<vert_id>& es_succs =
+            const std::vector<VertId>& es_succs =
                 (vert_marks->at(es) == E_LEFT) ? colour_succs[2 * es + 1] : colour_succs[2 * es];
-            for (vert_id ed : es_succs) {
+            for (VertId ed : es_succs) {
                 const Weight v = es_cost + g.edge_val(es, ed) - p(ed);
                 if (dist_ts->at(ed) != ts || v < dists->at(ed)) {
                     dists->at(ed) = v;
@@ -911,8 +909,8 @@ class GraphOps {
     // Run Dijkstra's algorithm, but similar to the chromatic algorithm, avoid expanding anything that _was_ stable.
     // GKG: Factor out common elements of this & the previous algorithm.
     template <class G, class S>
-    static void dijkstra_recover(const G& g, const PotentialFunction& p, const S& is_stable, vert_id src,
-                                 edge_vector& delta) {
+    static void dijkstra_recover(const G& g, const PotentialFunction& p, const S& is_stable, VertId src,
+                                 EdgeVector& delta) {
         const size_t sz = g.size();
         if (sz == 0) {
             return;
@@ -933,7 +931,7 @@ class GraphOps {
         Heap heap(dists_compare);
 
         for (const auto e : g.e_succs(src)) {
-            const vert_id dest = e.vert;
+            const VertId dest = e.vert;
             dists->at(dest) = p(src) + e.val - p(dest);
             dist_ts->at(dest) = ts;
 
@@ -959,7 +957,7 @@ class GraphOps {
 
             // Pick the appropriate set of successors
             for (const auto e : g.e_succs(es)) {
-                const vert_id ed = e.vert;
+                const VertId ed = e.vert;
                 const Weight v = es_cost + e.val - p(ed);
                 if (dist_ts->at(ed) != ts || v < dists->at(ed)) {
                     dists->at(ed) = v;
@@ -980,13 +978,13 @@ class GraphOps {
 
   public:
     template <class G>
-    static bool repair_potential(const G& g, WeightVector& p, vert_id ii, vert_id jj) {
+    static bool repair_potential(const G& g, WeightVector& p, VertId ii, VertId jj) {
         // Ensure there's enough scratch space.
         const size_t sz = g.size();
         // assert(src < (int) sz && dest < (int) sz);
         grow_scratch(sz);
 
-        for (vert_id vi : g.verts()) {
+        for (VertId vi : g.verts()) {
             dists->at(vi) = Weight(0);
             dists_alt->at(vi) = p[vi];
         }
@@ -1006,7 +1004,7 @@ class GraphOps {
             dists_alt->at(es) = p[es] + dists->at(es);
 
             for (const auto e : g.e_succs(es)) {
-                vert_id ed = e.vert;
+                VertId ed = e.vert;
                 if (dists_alt->at(ed) == p[ed]) {
                     Weight gnext_ed = dists_alt->at(es) + e.val - dists_alt->at(ed);
                     if (gnext_ed < dists->at(ed)) {
@@ -1024,7 +1022,7 @@ class GraphOps {
             return false;
         }
 
-        for (vert_id v : g.verts()) {
+        for (VertId v : g.verts()) {
             p[v] = dists_alt->at(v);
         }
 
@@ -1032,18 +1030,18 @@ class GraphOps {
     }
 
     template <class G, class V>
-    static edge_vector close_after_widen(const G& g, const PotentialFunction& p, const V& is_stable) {
+    static EdgeVector close_after_widen(const G& g, const PotentialFunction& p, const V& is_stable) {
         const size_t sz = g.size();
         grow_scratch(sz);
         //      assert(orig.size() == sz);
 
-        for (vert_id v : g.verts()) {
+        for (VertId v : g.verts()) {
             // We're abusing edge_marks to store _vertex_ flags.
             // Should really just switch this to allocating types of a fixed-size buffer.
             edge_marks->at(v) = is_stable[v] ? V_STABLE : V_UNSTABLE;
         }
-        edge_vector delta;
-        for (vert_id v : g.verts()) {
+        EdgeVector delta;
+        for (VertId v : g.verts()) {
             if (!edge_marks->at(v)) {
                 dijkstra_recover(g, p, *edge_marks, v, delta);
             }
@@ -1055,10 +1053,10 @@ class GraphOps {
     // Compute the transitive closure of edges reachable from v, assuming
     // (1) the subgraph G \ {v} is closed, and
     // (2) P is a valid model of G.
-    static void close_after_assign_fwd(const auto& g, const PotentialFunction& p, vert_id v,
-                                       std::vector<std::tuple<vert_id, Weight>>& aux) {
+    static void close_after_assign_fwd(const auto& g, const PotentialFunction& p, VertId v,
+                                       std::vector<std::tuple<VertId, Weight>>& aux) {
         // Initialize the queue and distances.
-        for (vert_id u : g.verts()) {
+        for (VertId u : g.verts()) {
             vert_marks->at(u) = 0;
         }
 
@@ -1067,7 +1065,7 @@ class GraphOps {
         auto adj_head = dual_queue->begin();
         auto adj_tail = adj_head;
         for (const auto e : g.e_succs(v)) {
-            vert_id d = e.vert;
+            VertId d = e.vert;
             vert_marks->at(d) = BF_QUEUED;
             dists->at(d) = e.val;
             //        assert(p(v) + dists->at(d) - p(d) >= Weight(0));
@@ -1077,15 +1075,15 @@ class GraphOps {
 
         // Sort the immediate edges by increasing slack.
         std::sort(adj_head, adj_tail,
-                  [&p](vert_id d1, vert_id d2) { return dists->at(d1) - p(d1) < dists->at(d2) - p(d2); });
+                  [&p](VertId d1, VertId d2) { return dists->at(d1) - p(d1) < dists->at(d2) - p(d2); });
 
         auto reach_tail = adj_tail;
         for (; adj_head < adj_tail; ++adj_head) {
-            vert_id d = *adj_head;
+            VertId d = *adj_head;
 
             Weight d_wt = dists->at(d);
             for (const auto edge : g.e_succs(d)) {
-                vert_id e = edge.vert;
+                VertId e = edge.vert;
                 Weight e_wt = d_wt + edge.val;
                 if (!vert_marks->at(e)) {
                     dists->at(e) = e_wt;
@@ -1107,20 +1105,20 @@ class GraphOps {
     }
 
   public:
-    static void close_over_edge(graph_t& g, vert_id ii, vert_id jj) {
+    static void close_over_edge(Graph& g, VertId ii, VertId jj) {
         assert(ii != 0 && jj != 0);
-        SubGraph<graph_t> g_excl(g, 0);
+        SubGraph<Graph> g_excl(g, 0);
 
         Weight c = g_excl.edge_val(ii, jj);
 
-        std::vector<std::pair<vert_id, Weight>> src_dec;
+        std::vector<std::pair<VertId, Weight>> src_dec;
         for (const auto edge : g_excl.e_preds(ii)) {
-            vert_id se = edge.vert;
+            VertId se = edge.vert;
             Weight wt_sij = edge.val + c;
 
             assert(g_excl.succs(se).begin() != g_excl.succs(se).end());
             if (se != jj) {
-                typename graph_t::mut_val_ref_t w;
+                typename Graph::MutValRef w;
                 if (g_excl.lookup(se, jj, &w)) {
                     if (w.get() <= wt_sij) {
                         continue;
@@ -1133,12 +1131,12 @@ class GraphOps {
             }
         }
 
-        std::vector<std::pair<vert_id, Weight>> dest_dec;
+        std::vector<std::pair<VertId, Weight>> dest_dec;
         for (const auto edge : g_excl.e_succs(jj)) {
-            vert_id de = edge.vert;
+            VertId de = edge.vert;
             Weight wt_ijd = edge.val + c;
             if (de != ii) {
-                typename graph_t::mut_val_ref_t w;
+                typename Graph::MutValRef w;
                 if (g_excl.lookup(ii, de, &w)) {
                     if (w.get() <= wt_ijd) {
                         continue;
@@ -1155,7 +1153,7 @@ class GraphOps {
             Weight wt_sij = c + p1;
             for (const auto& [de, p2] : dest_dec) {
                 Weight wt_sijd = wt_sij + p2;
-                typename graph_t::mut_val_ref_t w;
+                typename Graph::MutValRef w;
                 if (g.lookup(se, de, &w)) {
                     if (w.get() <= wt_sijd) {
                         continue;
@@ -1170,22 +1168,22 @@ class GraphOps {
         // Closure is now updated.
     }
 
-    static edge_vector close_after_assign(const auto& g, const PotentialFunction& p, vert_id v) {
+    static EdgeVector close_after_assign(const auto& g, const PotentialFunction& p, VertId v) {
         const size_t sz = g.size();
         grow_scratch(sz);
-        edge_vector delta;
+        EdgeVector delta;
         {
-            std::vector<std::tuple<vert_id, Weight>> aux;
+            std::vector<std::tuple<VertId, Weight>> aux;
             close_after_assign_fwd(g, p, v, aux);
             for (const auto& [vid, wt] : aux) {
                 delta.emplace_back(v, vid, wt);
             }
         }
         {
-            std::vector<std::tuple<vert_id, Weight>> aux;
+            std::vector<std::tuple<VertId, Weight>> aux;
             GraphRev g_rev{g};
 
-            close_after_assign_fwd(g_rev, [&](vert_id v) { return -(p(v)); }, v, aux);
+            close_after_assign_fwd(g_rev, [&](VertId v) { return -(p(v)); }, v, aux);
             for (const auto& [vid, wt] : aux) {
                 delta.emplace_back(vid, v, wt);
             }

--- a/src/crab_utils/lazy_allocator.hpp
+++ b/src/crab_utils/lazy_allocator.hpp
@@ -15,7 +15,7 @@ namespace prevail {
  * The caller can provide a custom factory to create the object in a specific way.
  */
 template <typename T, T (*factory)() = nullptr>
-class lazy_allocator {
+class LazyAllocator {
     std::optional<T> _value;
 
   public:

--- a/src/crab_utils/num_big.hpp
+++ b/src/crab_utils/num_big.hpp
@@ -16,20 +16,20 @@ using boost::multiprecision::cpp_int;
 
 namespace prevail {
 
-class number_t final {
+class Number final {
     cpp_int _n{};
 
   public:
-    number_t() = default;
-    number_t(cpp_int n) : _n(std::move(n)) {}
-    number_t(std::integral auto n) : _n{n} {}
-    number_t(is_enum auto n) : _n{static_cast<std::underlying_type_t<decltype(n)>>(n)} {}
-    explicit number_t(const std::string& s) { _n = cpp_int(s); }
+    Number() = default;
+    Number(cpp_int n) : _n(std::move(n)) {}
+    Number(std::integral auto n) : _n{n} {}
+    Number(is_enum auto n) : _n{static_cast<std::underlying_type_t<decltype(n)>>(n)} {}
+    explicit Number(const std::string& s) { _n = cpp_int(s); }
 
     template <std::integral T>
     T narrow() const {
         if (!fits<T>()) {
-            CRAB_ERROR("number_t ", _n, " does not fit into ", typeid(T).name());
+            CRAB_ERROR("Number ", _n, " does not fit into ", typeid(T).name());
         }
         return static_cast<T>(_n);
     }
@@ -47,7 +47,7 @@ class number_t final {
     explicit operator cpp_int() const { return _n; }
 
     [[nodiscard]]
-    friend std::size_t hash_value(const number_t& z) {
+    friend std::size_t hash_value(const Number& z) {
         return hash_value(z._n);
     }
 
@@ -60,7 +60,7 @@ class number_t final {
     template <std::integral T>
     [[nodiscard]]
     bool fits_cast_to() const {
-        return fits<T>() || fits<swap_signedness<T>>();
+        return fits<T>() || fits<SwapSignedness<T>>();
     }
 
     template <std::integral T>
@@ -69,16 +69,16 @@ class number_t final {
         if (fits<T>()) {
             return static_cast<T>(_n);
         }
-        using Q = swap_signedness<T>;
+        using Q = SwapSignedness<T>;
         if (fits<Q>()) {
             return static_cast<T>(static_cast<Q>(_n));
         }
-        CRAB_ERROR("number_t ", _n, " does not fit into ", typeid(T).name());
+        CRAB_ERROR("Number ", _n, " does not fit into ", typeid(T).name());
     }
 
     // Allow casting to intX_t as needed for finite width operations.
     [[nodiscard]]
-    number_t cast_to_sint(const int width) const {
+    Number cast_to_sint(const int width) const {
         switch (width) {
         case 0: return *this; // No finite width.
         case 8: return cast_to<int8_t>();
@@ -91,7 +91,7 @@ class number_t final {
 
     // Allow casting to uintX_t as needed for finite width operations.
     [[nodiscard]]
-    number_t cast_to_uint(const int width) const {
+    Number cast_to_uint(const int width) const {
         switch (width) {
         case 0: return *this; // No finite width.
         case 8: return cast_to<uint8_t>();
@@ -112,7 +112,7 @@ class number_t final {
     // Allow truncating to signed int as needed for finite width operations.
     // Unlike casting, sign_extend will not throw a prevail error if the number doesn't fit.
     [[nodiscard]]
-    number_t sign_extend(const int width) const {
+    Number sign_extend(const int width) const {
         using namespace boost::multiprecision;
         if (width <= 0) {
             return *this;
@@ -134,7 +134,7 @@ class number_t final {
     // Allow truncating to unsigned int as needed for finite width operations.
     // Unlike casting, zero_extend will not throw a prevail error if the number doesn't fit.
     [[nodiscard]]
-    number_t zero_extend(const int width) const {
+    Number zero_extend(const int width) const {
         using namespace boost::multiprecision;
         if (width <= 0) {
             return *this;
@@ -144,146 +144,146 @@ class number_t final {
         return truncated;
     }
 
-    static number_t max_uint(const int width) { return max_int(width + 1); }
+    static Number max_uint(const int width) { return max_int(width + 1); }
 
-    static number_t max_int(const int width) { return number_t{(cpp_int(1) << (width - 1)) - 1}; }
+    static Number max_int(const int width) { return Number{(cpp_int(1) << (width - 1)) - 1}; }
 
-    static number_t min_int(const int width) { return number_t{-(cpp_int(1) << (width - 1))}; }
+    static Number min_int(const int width) { return Number{-(cpp_int(1) << (width - 1))}; }
 
-    number_t operator+(const number_t& x) const { return number_t(_n + x._n); }
+    Number operator+(const Number& x) const { return Number(_n + x._n); }
 
-    number_t operator*(const number_t& x) const { return number_t(_n * x._n); }
+    Number operator*(const Number& x) const { return Number(_n * x._n); }
 
-    number_t operator-(const number_t& x) const { return number_t(_n - x._n); }
+    Number operator-(const Number& x) const { return Number(_n - x._n); }
 
-    number_t operator-() const { return number_t(-_n); }
+    Number operator-() const { return Number(-_n); }
 
-    number_t operator/(const number_t& x) const {
+    Number operator/(const Number& x) const {
         if (x._n.is_zero()) {
-            CRAB_ERROR("number_t: division by zero [1]");
+            CRAB_ERROR("Number: division by zero [1]");
         }
-        return number_t(_n / x._n);
+        return Number(_n / x._n);
     }
 
-    number_t operator%(const number_t& x) const {
+    Number operator%(const Number& x) const {
         if (x._n.is_zero()) {
-            CRAB_ERROR("number_t: division by zero [2]");
+            CRAB_ERROR("Number: division by zero [2]");
         }
-        return number_t(_n % x._n);
+        return Number(_n % x._n);
     }
 
-    number_t& operator+=(const number_t& x) {
+    Number& operator+=(const Number& x) {
         _n += x._n;
         return *this;
     }
 
-    number_t& operator*=(const number_t& x) {
+    Number& operator*=(const Number& x) {
         _n *= x._n;
         return *this;
     }
 
-    number_t& operator-=(const number_t& x) {
+    Number& operator-=(const Number& x) {
         _n -= x._n;
         return *this;
     }
 
-    number_t& operator/=(const number_t& x) {
+    Number& operator/=(const Number& x) {
         if (x._n.is_zero()) {
-            CRAB_ERROR("number_t: division by zero [3]");
+            CRAB_ERROR("Number: division by zero [3]");
         }
         _n /= x._n;
         return *this;
     }
 
-    number_t& operator%=(const number_t& x) {
+    Number& operator%=(const Number& x) {
         if (x._n.is_zero()) {
-            CRAB_ERROR("number_t: division by zero [4]");
+            CRAB_ERROR("Number: division by zero [4]");
         }
         _n %= x._n;
         return *this;
     }
 
-    number_t& operator--() & {
+    Number& operator--() & {
         --_n;
         return *this;
     }
 
-    number_t& operator++() & {
+    Number& operator++() & {
         ++_n;
         return *this;
     }
 
-    number_t operator++(int) & {
-        number_t r(*this);
+    Number operator++(int) & {
+        Number r(*this);
         ++*this;
         return r;
     }
 
-    number_t operator--(int) & {
-        number_t r(*this);
+    Number operator--(int) & {
+        Number r(*this);
         --*this;
         return r;
     }
 
-    bool operator==(const number_t& x) const { return _n == x._n; }
+    bool operator==(const Number& x) const { return _n == x._n; }
 
-    bool operator!=(const number_t& x) const { return _n != x._n; }
+    bool operator!=(const Number& x) const { return _n != x._n; }
 
-    bool operator<(const number_t& x) const { return _n < x._n; }
+    bool operator<(const Number& x) const { return _n < x._n; }
 
-    bool operator<=(const number_t& x) const { return _n <= x._n; }
+    bool operator<=(const Number& x) const { return _n <= x._n; }
 
-    bool operator>(const number_t& x) const { return _n > x._n; }
+    bool operator>(const Number& x) const { return _n > x._n; }
 
-    bool operator>=(const number_t& x) const { return _n >= x._n; }
+    bool operator>=(const Number& x) const { return _n >= x._n; }
 
-    number_t abs() const { return _n < 0 ? -_n : _n; }
+    Number abs() const { return _n < 0 ? -_n : _n; }
 
-    number_t operator&(const number_t& x) const { return number_t(_n & x._n); }
+    Number operator&(const Number& x) const { return Number(_n & x._n); }
 
-    number_t operator|(const number_t& x) const { return number_t(_n | x._n); }
+    Number operator|(const Number& x) const { return Number(_n | x._n); }
 
-    number_t operator^(const number_t& x) const { return number_t(_n ^ x._n); }
+    Number operator^(const Number& x) const { return Number(_n ^ x._n); }
 
-    number_t operator<<(const number_t& x) const {
+    Number operator<<(const Number& x) const {
         if (x < 0) {
             CRAB_ERROR("Shift amount cannot be negative");
         }
         if (!x.fits<int32_t>()) {
-            CRAB_ERROR("number_t ", x._n, " does not fit into an int32");
+            CRAB_ERROR("Number ", x._n, " does not fit into an int32");
         }
-        return number_t(_n << x.narrow<int32_t>());
+        return Number(_n << x.narrow<int32_t>());
     }
 
-    number_t operator>>(const number_t& x) const {
+    Number operator>>(const Number& x) const {
         if (x < 0) {
             CRAB_ERROR("Shift amount cannot be negative");
         }
         if (!x.fits<int32_t>()) {
-            CRAB_ERROR("number_t ", x._n, " does not fit into an int32");
+            CRAB_ERROR("Number ", x._n, " does not fit into an int32");
         }
-        return number_t(_n >> x.narrow<int32_t>());
+        return Number(_n >> x.narrow<int32_t>());
     }
 
     [[nodiscard]]
-    number_t fill_ones() const {
+    Number fill_ones() const {
         if (_n.is_zero()) {
-            return number_t(static_cast<signed long long>(0));
+            return Number(static_cast<signed long long>(0));
         }
-        return number_t{(cpp_int(1) << (msb(_n) + 1)) - 1};
+        return Number{(cpp_int(1) << (msb(_n) + 1)) - 1};
     }
 
-    friend std::ostream& operator<<(std::ostream& o, const number_t& z);
+    friend std::ostream& operator<<(std::ostream& o, const Number& z);
 
     [[nodiscard]]
     std::string to_string() const;
 };
-// class number_t
+// class Number
 
-bool operator<=(std::integral auto left, const number_t& rhs) { return rhs >= left; }
-bool operator<=(is_enum auto left, const number_t& rhs) { return rhs >= left; }
+bool operator<=(std::integral auto left, const Number& rhs) { return rhs >= left; }
+bool operator<=(is_enum auto left, const Number& rhs) { return rhs >= left; }
 
 template <typename T>
-concept finite_integral = std::integral<T> || std::is_same_v<T, number_t>;
+concept finite_integral = std::integral<T> || std::is_same_v<T, Number>;
 
 } // namespace prevail

--- a/src/crab_utils/num_extended.hpp
+++ b/src/crab_utils/num_extended.hpp
@@ -11,11 +11,11 @@
 
 namespace prevail {
 
-class extended_number final {
+class ExtendedNumber final {
     bool _is_infinite;
-    number_t _n;
+    Number _n;
 
-    extended_number(const bool is_infinite, const number_t& n) : _is_infinite(is_infinite), _n(n) {
+    ExtendedNumber(const bool is_infinite, const Number& n) : _is_infinite(is_infinite), _n(n) {
         if (is_infinite) {
             if (n > 0) {
                 _n = 1;
@@ -26,11 +26,11 @@ class extended_number final {
     }
 
   public:
-    static extended_number plus_infinity() { return extended_number(true, 1); }
+    static ExtendedNumber plus_infinity() { return ExtendedNumber(true, 1); }
 
-    static extended_number minus_infinity() { return extended_number(true, -1); }
+    static ExtendedNumber minus_infinity() { return ExtendedNumber(true, -1); }
 
-    explicit extended_number(const std::string& s) : _n(1) {
+    explicit ExtendedNumber(const std::string& s) : _n(1) {
         if (s == "+oo") {
             _is_infinite = true;
         } else if (s == "-oo") {
@@ -38,16 +38,16 @@ class extended_number final {
             _n = -1;
         } else {
             _is_infinite = false;
-            _n = number_t(s);
+            _n = Number(s);
         }
     }
 
-    extended_number(number_t n) : _is_infinite(false), _n(std::move(n)) {}
-    extended_number(std::integral auto n) : _is_infinite(false), _n{n} {}
+    ExtendedNumber(Number n) : _is_infinite(false), _n(std::move(n)) {}
+    ExtendedNumber(std::integral auto n) : _is_infinite(false), _n{n} {}
 
-    extended_number(const extended_number& o) = default;
+    ExtendedNumber(const ExtendedNumber& o) = default;
 
-    extended_number(extended_number&&) noexcept = default;
+    ExtendedNumber(ExtendedNumber&&) noexcept = default;
 
     template <std::integral T>
     T narrow() const {
@@ -62,9 +62,9 @@ class extended_number final {
         return static_cast<T>(narrow<std::underlying_type_t<T>>());
     }
 
-    extended_number& operator=(extended_number&&) noexcept = default;
+    ExtendedNumber& operator=(ExtendedNumber&&) noexcept = default;
 
-    extended_number& operator=(const extended_number& o) {
+    ExtendedNumber& operator=(const ExtendedNumber& o) {
         if (this != &o) {
             _is_infinite = o._is_infinite;
             _n = o._n;
@@ -92,12 +92,12 @@ class extended_number final {
         return (is_infinite() && _n < 0);
     }
 
-    extended_number operator-() const { return extended_number(_is_infinite, -_n); }
+    ExtendedNumber operator-() const { return ExtendedNumber(_is_infinite, -_n); }
 
-    extended_number operator+(const extended_number& x) const {
+    ExtendedNumber operator+(const ExtendedNumber& x) const {
         if (is_finite()) {
             if (x.is_finite()) {
-                return extended_number(_n + x._n);
+                return ExtendedNumber(_n + x._n);
             }
             return x;
         }
@@ -107,26 +107,26 @@ class extended_number final {
         CRAB_ERROR("Bound: undefined operation -oo + +oo");
     }
 
-    extended_number& operator+=(const extended_number& x) { return operator=(operator+(x)); }
+    ExtendedNumber& operator+=(const ExtendedNumber& x) { return operator=(operator+(x)); }
 
-    extended_number operator-(const extended_number& x) const { return operator+(x.operator-()); }
+    ExtendedNumber operator-(const ExtendedNumber& x) const { return operator+(x.operator-()); }
 
-    extended_number& operator-=(const extended_number& x) { return operator=(operator-(x)); }
+    ExtendedNumber& operator-=(const ExtendedNumber& x) { return operator=(operator-(x)); }
 
-    extended_number operator*(const extended_number& x) const {
+    ExtendedNumber operator*(const ExtendedNumber& x) const {
         if (x._n == 0) {
             return x;
         } else if (_n == 0) {
             return *this;
         } else {
-            return extended_number(_is_infinite || x._is_infinite, _n * x._n);
+            return ExtendedNumber(_is_infinite || x._is_infinite, _n * x._n);
         }
     }
 
-    extended_number& operator*=(const extended_number& x) { return operator=(operator*(x)); }
+    ExtendedNumber& operator*=(const ExtendedNumber& x) { return operator=(operator*(x)); }
 
   private:
-    extended_number AbsDiv(const extended_number& x, extended_number (*f)(number_t, number_t)) const {
+    ExtendedNumber AbsDiv(const ExtendedNumber& x, ExtendedNumber (*f)(Number, Number)) const {
         if (x._n == 0) {
             CRAB_ERROR("Bound: division by zero");
         }
@@ -134,7 +134,7 @@ class extended_number final {
             if (is_infinite()) {
                 CRAB_ERROR("Bound: inf / inf");
             }
-            return number_t{0};
+            return Number{0};
         }
         if (is_infinite()) {
             return *this;
@@ -143,46 +143,46 @@ class extended_number final {
     }
 
   public:
-    extended_number operator/(const extended_number& x) const {
-        return AbsDiv(x, [](number_t dividend, number_t divisor) { return extended_number{dividend / divisor}; });
+    ExtendedNumber operator/(const ExtendedNumber& x) const {
+        return AbsDiv(x, [](Number dividend, Number divisor) { return ExtendedNumber{dividend / divisor}; });
     }
 
-    extended_number operator%(const extended_number& x) const {
-        return AbsDiv(x, [](number_t dividend, number_t divisor) { return extended_number{dividend % divisor}; });
+    ExtendedNumber operator%(const ExtendedNumber& x) const {
+        return AbsDiv(x, [](Number dividend, Number divisor) { return ExtendedNumber{dividend % divisor}; });
     }
 
     [[nodiscard]]
-    extended_number udiv(const extended_number& x) const {
+    ExtendedNumber udiv(const ExtendedNumber& x) const {
         using M = uint64_t;
-        return AbsDiv(x, [](number_t dividend, number_t divisor) {
-            dividend = dividend >= 0 ? dividend : number_t{dividend.cast_to<M>()};
-            divisor = divisor >= 0 ? divisor : number_t{divisor.cast_to<M>()};
-            return extended_number{dividend / divisor};
+        return AbsDiv(x, [](Number dividend, Number divisor) {
+            dividend = dividend >= 0 ? dividend : Number{dividend.cast_to<M>()};
+            divisor = divisor >= 0 ? divisor : Number{divisor.cast_to<M>()};
+            return ExtendedNumber{dividend / divisor};
         });
     }
 
     [[nodiscard]]
-    extended_number urem(const extended_number& x) const {
+    ExtendedNumber urem(const ExtendedNumber& x) const {
         using M = uint64_t;
-        return AbsDiv(x, [](number_t dividend, number_t divisor) {
-            dividend = dividend >= 0 ? dividend : number_t{dividend.cast_to<M>()};
-            divisor = divisor >= 0 ? divisor : number_t{divisor.cast_to<M>()};
-            return extended_number{dividend % divisor};
+        return AbsDiv(x, [](Number dividend, Number divisor) {
+            dividend = dividend >= 0 ? dividend : Number{dividend.cast_to<M>()};
+            divisor = divisor >= 0 ? divisor : Number{divisor.cast_to<M>()};
+            return ExtendedNumber{dividend % divisor};
         });
     }
 
-    extended_number& operator/=(const extended_number& x) { return operator=(operator/(x)); }
+    ExtendedNumber& operator/=(const ExtendedNumber& x) { return operator=(operator/(x)); }
 
-    bool operator<(const extended_number& x) const { return !operator>=(x); }
+    bool operator<(const ExtendedNumber& x) const { return !operator>=(x); }
 
-    bool operator>(const extended_number& x) const { return !operator<=(x); }
+    bool operator>(const ExtendedNumber& x) const { return !operator<=(x); }
 
-    bool operator==(const extended_number& x) const { return (_is_infinite == x._is_infinite && _n == x._n); }
+    bool operator==(const ExtendedNumber& x) const { return (_is_infinite == x._is_infinite && _n == x._n); }
 
-    bool operator!=(const extended_number& x) const { return !operator==(x); }
+    bool operator!=(const ExtendedNumber& x) const { return !operator==(x); }
 
     [[nodiscard]]
-    number_t sign_extend(const int width) const {
+    Number sign_extend(const int width) const {
         if (is_infinite()) {
             CRAB_ERROR("Bound: infinity cannot be sign_extended");
         }
@@ -190,7 +190,7 @@ class extended_number final {
     }
 
     [[nodiscard]]
-    number_t zero_extend(const int width) const {
+    Number zero_extend(const int width) const {
         if (is_infinite()) {
             CRAB_ERROR("Bound: infinity cannot be zero_extended");
         }
@@ -201,7 +201,7 @@ class extended_number final {
      *	results include up to 20% improvements in performance in the octagon domain
      *	over a more naive implementation.
      */
-    bool operator<=(const extended_number& x) const {
+    bool operator<=(const ExtendedNumber& x) const {
         if (_is_infinite xor x._is_infinite) {
             if (_is_infinite) {
                 return _n < 0;
@@ -211,7 +211,7 @@ class extended_number final {
         return _n <= x._n;
     }
 
-    bool operator>=(const extended_number& x) const {
+    bool operator>=(const ExtendedNumber& x) const {
         if (_is_infinite xor x._is_infinite) {
             if (_is_infinite) {
                 return _n > 0;
@@ -222,8 +222,8 @@ class extended_number final {
     }
 
     [[nodiscard]]
-    extended_number abs() const {
-        if (operator>=(number_t{0})) {
+    ExtendedNumber abs() const {
+        if (operator>=(Number{0})) {
             return *this;
         } else {
             return operator-();
@@ -231,7 +231,7 @@ class extended_number final {
     }
 
     [[nodiscard]]
-    std::optional<number_t> number() const {
+    std::optional<Number> number() const {
         if (is_infinite()) {
             return {};
         } else {
@@ -239,7 +239,7 @@ class extended_number final {
         }
     }
 
-    friend std::ostream& operator<<(std::ostream& o, const extended_number& b) {
+    friend std::ostream& operator<<(std::ostream& o, const ExtendedNumber& b) {
         if (b.is_plus_infinity()) {
             o << "+oo";
         } else if (b.is_minus_infinity()) {
@@ -250,6 +250,6 @@ class extended_number final {
         return o;
     }
 
-}; // class extended_number
+}; // class ExtendedNumber
 
 } // namespace prevail

--- a/src/crab_utils/num_safeint.hpp
+++ b/src/crab_utils/num_safeint.hpp
@@ -16,7 +16,7 @@
 
 namespace prevail {
 
-class safe_i64 {
+class SafeI64 {
     // Current implementation is based on
     // https://blog.regehr.org/archives/1139 using wider integers.
 
@@ -24,9 +24,9 @@ class safe_i64 {
     // TODO/FIXME: the current code compiles assuming the type __int128
     // exists. Both clang and gcc supports __int128 if the targeted
     // architecture is x86/64, but it won't work with 32 bits.
-    using wideint_t = __int128;
+    using WideInt = __int128;
 #else
-    using wideint_t = boost::multiprecision::int128_t;
+    using WideInt = boost::multiprecision::int128_t;
 #endif
 
     [[nodiscard]]
@@ -39,7 +39,7 @@ class safe_i64 {
     }
 
     static std::optional<int64_t> checked_add(const int64_t a, const int64_t b) {
-        const wideint_t lr = static_cast<wideint_t>(a) + static_cast<wideint_t>(b);
+        const WideInt lr = static_cast<WideInt>(a) + static_cast<WideInt>(b);
         if (lr > get_max() || lr < get_min()) {
             return {};
         }
@@ -47,21 +47,21 @@ class safe_i64 {
     }
 
     static std::optional<int64_t> checked_sub(const int64_t a, const int64_t b) {
-        const wideint_t lr = static_cast<wideint_t>(a) - static_cast<wideint_t>(b);
+        const WideInt lr = static_cast<WideInt>(a) - static_cast<WideInt>(b);
         if (lr > get_max() || lr < get_min()) {
             return {};
         }
         return static_cast<int64_t>(lr);
     }
     static std::optional<int64_t> checked_mul(const int64_t a, const int64_t b) {
-        const wideint_t lr = static_cast<wideint_t>(a) * static_cast<wideint_t>(b);
+        const WideInt lr = static_cast<WideInt>(a) * static_cast<WideInt>(b);
         if (lr > get_max() || lr < get_min()) {
             return {};
         }
         return static_cast<int64_t>(lr);
     }
     static std::optional<int64_t> checked_div(const int64_t a, const int64_t b) {
-        const wideint_t lr = static_cast<wideint_t>(a) / static_cast<wideint_t>(b);
+        const WideInt lr = static_cast<WideInt>(a) / static_cast<WideInt>(b);
         if (lr > get_max() || lr < get_min()) {
             return {};
         }
@@ -69,68 +69,68 @@ class safe_i64 {
     }
 
   public:
-    safe_i64() : m_num{0} {}
+    SafeI64() : m_num{0} {}
 
-    safe_i64(const int64_t num) : m_num{num} {}
+    SafeI64(const int64_t num) : m_num{num} {}
 
-    safe_i64(const number_t& n) : m_num{n.narrow<int64_t>()} {}
+    SafeI64(const Number& n) : m_num{n.narrow<int64_t>()} {}
 
     operator int64_t() const { return m_num; }
 
     // TODO: output parameters whether operation overflows
-    safe_i64 operator+(const safe_i64 x) const {
+    SafeI64 operator+(const SafeI64 x) const {
         if (const auto z = checked_add(m_num, x.m_num)) {
-            return safe_i64(*z);
+            return SafeI64(*z);
         }
         CRAB_ERROR("Integer overflow during addition");
     }
 
     // TODO: output parameters whether operation overflows
-    safe_i64 operator-(const safe_i64 x) const {
+    SafeI64 operator-(const SafeI64 x) const {
         if (const auto z = checked_sub(m_num, x.m_num)) {
-            return safe_i64(*z);
+            return SafeI64(*z);
         }
         CRAB_ERROR("Integer overflow during subtraction");
     }
 
     // TODO: output parameters whether operation overflows
-    safe_i64 operator*(const safe_i64 x) const {
+    SafeI64 operator*(const SafeI64 x) const {
         if (const auto z = checked_mul(m_num, x.m_num)) {
-            return safe_i64(*z);
+            return SafeI64(*z);
         }
         CRAB_ERROR("Integer overflow during multiplication");
     }
 
     // TODO: output parameters whether operation overflows
-    safe_i64 operator/(const safe_i64 x) const {
+    SafeI64 operator/(const SafeI64 x) const {
         if (const auto z = checked_div(m_num, x.m_num)) {
-            return safe_i64(*z);
+            return SafeI64(*z);
         }
         CRAB_ERROR("Integer overflow during division");
     }
 
     // TODO: output parameters whether operation overflows
-    safe_i64 operator-() const { return safe_i64(0) - *this; }
+    SafeI64 operator-() const { return SafeI64(0) - *this; }
 
     // TODO: output parameters whether operation overflows
-    safe_i64& operator+=(const safe_i64 x) { return *this = *this + x; }
+    SafeI64& operator+=(const SafeI64 x) { return *this = *this + x; }
 
     // TODO: output parameters whether operation overflows
-    safe_i64& operator-=(const safe_i64 x) { return *this = *this - x; }
+    SafeI64& operator-=(const SafeI64 x) { return *this = *this - x; }
 
-    bool operator==(const safe_i64 x) const { return m_num == x.m_num; }
+    bool operator==(const SafeI64 x) const { return m_num == x.m_num; }
 
-    bool operator!=(const safe_i64 x) const { return m_num != x.m_num; }
+    bool operator!=(const SafeI64 x) const { return m_num != x.m_num; }
 
-    bool operator<(const safe_i64 x) const { return m_num < x.m_num; }
+    bool operator<(const SafeI64 x) const { return m_num < x.m_num; }
 
-    bool operator<=(const safe_i64 x) const { return m_num <= x.m_num; }
+    bool operator<=(const SafeI64 x) const { return m_num <= x.m_num; }
 
-    bool operator>(const safe_i64 x) const { return m_num > x.m_num; }
+    bool operator>(const SafeI64 x) const { return m_num > x.m_num; }
 
-    bool operator>=(const safe_i64 x) const { return m_num >= x.m_num; }
+    bool operator>=(const SafeI64 x) const { return m_num >= x.m_num; }
 
-    friend std::ostream& operator<<(std::ostream& o, const safe_i64& n) { return o << n.m_num; }
+    friend std::ostream& operator<<(std::ostream& o, const SafeI64& n) { return o << n.m_num; }
 
   private:
     int64_t m_num;

--- a/src/crab_utils/num_safety.hpp
+++ b/src/crab_utils/num_safety.hpp
@@ -12,7 +12,7 @@ template <typename T>
 concept is_enum = std::is_enum_v<T>;
 
 template <std::integral T>
-using swap_signedness = std::conditional_t<std::is_signed_v<T>, std::make_unsigned_t<T>, std::make_signed_t<T>>;
+using SwapSignedness = std::conditional_t<std::is_signed_v<T>, std::make_unsigned_t<T>, std::make_signed_t<T>>;
 
 constexpr auto to_signed(std::unsigned_integral auto x) -> std::make_signed_t<decltype(x)> {
     return static_cast<std::make_signed_t<decltype(x)>>(x);

--- a/src/crab_utils/stats.cpp
+++ b/src/crab_utils/stats.cpp
@@ -13,8 +13,8 @@
 
 namespace prevail {
 
-thread_local lazy_allocator<std::map<std::string, unsigned>> CrabStats::counters;
-thread_local lazy_allocator<std::map<std::string, Stopwatch>> CrabStats::sw;
+thread_local LazyAllocator<std::map<std::string, unsigned>> CrabStats::counters;
+thread_local LazyAllocator<std::map<std::string, Stopwatch>> CrabStats::sw;
 
 void CrabStats::clear_thread_local_state() {
     counters.clear();

--- a/src/crab_utils/stats.hpp
+++ b/src/crab_utils/stats.hpp
@@ -36,8 +36,8 @@ class CrabStats {
     /// Controls whether statistics collection is active.
     /// When false, all statistics methods become no-ops for better performance.
     static constexpr bool enabled = false;
-    static thread_local lazy_allocator<std::map<std::string, unsigned>> counters;
-    static thread_local lazy_allocator<std::map<std::string, Stopwatch>> sw;
+    static thread_local LazyAllocator<std::map<std::string, unsigned>> counters;
+    static thread_local LazyAllocator<std::map<std::string, Stopwatch>> sw;
 
   public:
     static void clear_thread_local_state();

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -20,22 +20,22 @@
 using std::string;
 
 namespace prevail {
-thread_local lazy_allocator<program_info> thread_local_program_info;
+thread_local LazyAllocator<ProgramInfo> thread_local_program_info;
 thread_local ebpf_verifier_options_t thread_local_options;
 void ebpf_verifier_clear_before_analysis();
 
-bool Invariants::is_valid_after(const label_t& label, const string_invariant& state) const {
-    const ebpf_domain_t abstract_state =
-        ebpf_domain_t::from_constraints(state.value(), thread_local_options.setup_constraints);
+bool Invariants::is_valid_after(const Label& label, const StringInvariant& state) const {
+    const EbpfDomain abstract_state =
+        EbpfDomain::from_constraints(state.value(), thread_local_options.setup_constraints);
     return abstract_state <= invariants.at(label).post;
 }
 
-string_invariant Invariants::invariant_at(const label_t& label) const { return invariants.at(label).post.to_set(); }
+StringInvariant Invariants::invariant_at(const Label& label) const { return invariants.at(label).post.to_set(); }
 
-interval_t Invariants::exit_value() const { return invariants.at(label_t::exit).post.get_r0(); }
+Interval Invariants::exit_value() const { return invariants.at(Label::exit).post.get_r0(); }
 
 int Invariants::max_loop_count() const {
-    extended_number max_loop_count{0};
+    ExtendedNumber max_loop_count{0};
     // Gather the upper bound of loop counts from post-invariants.
     for (const auto& inv_pair : std::views::values(invariants)) {
         max_loop_count = std::max(max_loop_count, inv_pair.post.get_loop_count_upper_bound());
@@ -47,19 +47,18 @@ int Invariants::max_loop_count() const {
     return std::numeric_limits<int>::max();
 }
 
-Invariants analyze(const Program& prog, ebpf_domain_t&& entry_invariant) {
+Invariants analyze(const Program& prog, EbpfDomain&& entry_invariant) {
     return Invariants{run_forward_analyzer(prog, std::move(entry_invariant))};
 }
 
 Invariants analyze(const Program& prog) {
     ebpf_verifier_clear_before_analysis();
-    return analyze(prog, ebpf_domain_t::setup_entry(thread_local_options.setup_constraints));
+    return analyze(prog, EbpfDomain::setup_entry(thread_local_options.setup_constraints));
 }
 
-Invariants analyze(const Program& prog, const string_invariant& entry_invariant) {
+Invariants analyze(const Program& prog, const StringInvariant& entry_invariant) {
     ebpf_verifier_clear_before_analysis();
-    return analyze(prog,
-                   ebpf_domain_t::from_constraints(entry_invariant.value(), thread_local_options.setup_constraints));
+    return analyze(prog, EbpfDomain::from_constraints(entry_invariant.value(), thread_local_options.setup_constraints));
 }
 
 bool Invariants::verified(const Program& prog) const {
@@ -100,7 +99,7 @@ Report Invariants::check_assertions(const Program& prog) const {
 
 void ebpf_verifier_clear_before_analysis() {
     clear_thread_local_state();
-    variable_t::clear_thread_local_state();
+    Variable::clear_thread_local_state();
 }
 
 void ebpf_verifier_clear_thread_local_state() {

--- a/src/crab_verifier.hpp
+++ b/src/crab_verifier.hpp
@@ -10,8 +10,8 @@
 
 namespace prevail {
 class Report final {
-    std::map<label_t, std::vector<std::string>> warnings;
-    std::map<label_t, std::vector<std::string>> reachability;
+    std::map<Label, std::vector<std::string>> warnings;
+    std::map<Label, std::vector<std::string>> reachability;
     friend class Invariants;
 
   public:
@@ -51,18 +51,18 @@ class Report final {
 };
 
 class Invariants final {
-    invariant_table_t invariants;
+    InvariantTable invariants;
 
   public:
-    explicit Invariants(invariant_table_t&& invariants) : invariants(std::move(invariants)) {}
+    explicit Invariants(InvariantTable&& invariants) : invariants(std::move(invariants)) {}
     Invariants(Invariants&& invariants) = default;
     Invariants(const Invariants& invariants) = default;
 
-    bool is_valid_after(const label_t& label, const string_invariant& state) const;
+    bool is_valid_after(const Label& label, const StringInvariant& state) const;
 
-    string_invariant invariant_at(const label_t& label) const;
+    StringInvariant invariant_at(const Label& label) const;
 
-    interval_t exit_value() const;
+    Interval exit_value() const;
 
     int max_loop_count() const;
     bool verified(const Program& prog) const;
@@ -72,7 +72,7 @@ class Invariants final {
 };
 
 Invariants analyze(const Program& prog);
-Invariants analyze(const Program& prog, const string_invariant& entry_invariant);
+Invariants analyze(const Program& prog, const StringInvariant& entry_invariant);
 inline bool verify(const Program& prog) { return analyze(prog).verified(prog); }
 
 int create_map_crab(const EbpfMapType& map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries,

--- a/src/ebpf_vm_isa.hpp
+++ b/src/ebpf_vm_isa.hpp
@@ -10,13 +10,13 @@ namespace prevail {
 // See https://github.com/ebpffoundation/ebpf-docs/blob/update/rst/instruction-set.rst
 // for documentation.
 
-struct ebpf_inst {
+struct EbpfInst {
     std::uint8_t opcode;
     std::uint8_t dst : 4; //< Destination register
     std::uint8_t src : 4; //< Source register
     std::int16_t offset;
     std::int32_t imm; //< Immediate constant
-    constexpr bool operator==(const ebpf_inst&) const = default;
+    constexpr bool operator==(const EbpfInst&) const = default;
 };
 
 enum {

--- a/src/linux/linux_platform.cpp
+++ b/src/linux/linux_platform.cpp
@@ -17,7 +17,7 @@
 
 namespace prevail {
 // Map definitions as they appear in an ELF file, so field width matters.
-struct bpf_load_map_def {
+struct BpfLoadMapDef {
     uint32_t type;
     uint32_t key_size;
     uint32_t value_size;
@@ -149,9 +149,9 @@ void parse_maps_section_linux(std::vector<EbpfMapDescriptor>& map_descriptors, c
                               const size_t map_def_size, const int map_count, const ebpf_platform_t* platform,
                               const ebpf_verifier_options_t options) {
     // Copy map definitions from the ELF section into a local list.
-    auto mapdefs = std::vector<bpf_load_map_def>();
+    auto mapdefs = std::vector<BpfLoadMapDef>();
     for (int i = 0; i < map_count; i++) {
-        bpf_load_map_def def = {0};
+        BpfLoadMapDef def = {0};
         memcpy(&def, data + i * map_def_size, std::min(map_def_size, sizeof(def)));
         mapdefs.emplace_back(def);
     }
@@ -241,7 +241,7 @@ EbpfMapDescriptor& get_map_descriptor_linux(const int map_fd) {
 const ebpf_platform_t g_ebpf_platform_linux = {get_program_type_linux,
                                                get_helper_prototype_linux,
                                                is_helper_usable_linux,
-                                               sizeof(bpf_load_map_def),
+                                               sizeof(BpfLoadMapDef),
                                                parse_maps_section_linux,
                                                get_map_descriptor_linux,
                                                get_map_type_linux,

--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -21,16 +21,16 @@ using std::vector;
 
 using namespace prevail;
 
-static size_t hash(const raw_program& raw_prog) {
+static size_t hash(const RawProgram& raw_prog) {
     const char* start = reinterpret_cast<const char*>(raw_prog.prog.data());
-    const char* end = start + raw_prog.prog.size() * sizeof(ebpf_inst);
+    const char* end = start + raw_prog.prog.size() * sizeof(EbpfInst);
     return boost::hash_range(start, end);
 }
 
 template <void(on_exit)()>
-struct at_scope_exit {
-    at_scope_exit() = default;
-    ~at_scope_exit() { on_exit(); }
+struct AtScopeExit {
+    AtScopeExit() = default;
+    ~AtScopeExit() { on_exit(); }
 };
 
 static const std::map<std::string, bpf_conformance_groups_t> _conformance_groups = {
@@ -54,12 +54,12 @@ static std::set<std::string> _get_conformance_group_names() {
     return result;
 }
 
-static std::optional<raw_program> find_program(vector<raw_program>& raw_progs, const std::string& desired_program) {
+static std::optional<RawProgram> find_program(vector<RawProgram>& raw_progs, const std::string& desired_program) {
     if (desired_program.empty() && raw_progs.size() == 1) {
         // Select the last program section.
         return raw_progs.back();
     }
-    for (raw_program current_program : raw_progs) {
+    for (RawProgram current_program : raw_progs) {
         if (current_program.function_name == desired_program) {
             return current_program;
         }
@@ -69,7 +69,7 @@ static std::optional<raw_program> find_program(vector<raw_program>& raw_progs, c
 
 int main(int argc, char** argv) {
     // Always call ebpf_verifier_clear_thread_local_state on scope exit.
-    at_scope_exit<ebpf_verifier_clear_thread_local_state> clear_thread_local_state;
+    AtScopeExit<ebpf_verifier_clear_thread_local_state> clear_thread_local_state;
 
     ebpf_verifier_options_t ebpf_verifier_options;
 
@@ -196,7 +196,7 @@ int main(int argc, char** argv) {
     }
 
     // Read a set of raw program sections from an ELF file.
-    vector<raw_program> raw_progs;
+    vector<RawProgram> raw_progs;
     try {
         raw_progs = read_elf(filename, desired_section, ebpf_verifier_options, &platform);
     } catch (std::runtime_error& e) {
@@ -204,7 +204,7 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    std::optional<raw_program> found_prog = find_program(raw_progs, desired_program);
+    std::optional<RawProgram> found_prog = find_program(raw_progs, desired_program);
     if (list || !found_prog) {
         if (!list) {
             std::cout << "please specify a program\n";
@@ -215,13 +215,13 @@ int main(int argc, char** argv) {
             // of possibilities.
             raw_progs = read_elf(filename, string(), ebpf_verifier_options, &platform);
         }
-        for (const raw_program& raw_prog : raw_progs) {
+        for (const RawProgram& raw_prog : raw_progs) {
             std::cout << "section=" << raw_prog.section_name << " function=" << raw_prog.function_name << std::endl;
         }
         std::cout << "\n";
         return list ? 0 : 64;
     }
-    raw_program raw_prog = *found_prog;
+    RawProgram raw_prog = *found_prog;
 
     // Convert the raw program section to a set of instructions.
     std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog);

--- a/src/main/linux_verifier.cpp
+++ b/src/main/linux_verifier.cpp
@@ -20,7 +20,7 @@ static int do_bpf(const bpf_cmd cmd, union bpf_attr& attr) { return syscall(321,
  *  \return A pair (passed, elapsed_secs)
  */
 
-std::tuple<bool, double> bpf_verify_program(const EbpfProgramType& type, const std::vector<ebpf_inst>& raw_prog,
+std::tuple<bool, double> bpf_verify_program(const EbpfProgramType& type, const std::vector<EbpfInst>& raw_prog,
                                             ebpf_verifier_options_t* options) {
     std::vector<char> buf(options->verbosity_opts.print_failures ? 1000000 : 10);
     buf[0] = 0;

--- a/src/main/linux_verifier.hpp
+++ b/src/main/linux_verifier.hpp
@@ -16,7 +16,7 @@
 namespace prevail {
 int create_map_linux(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries,
                      ebpf_verifier_options_t options);
-std::tuple<bool, double> bpf_verify_program(const EbpfProgramType& type, const std::vector<ebpf_inst>& raw_prog,
+std::tuple<bool, double> bpf_verify_program(const EbpfProgramType& type, const std::vector<EbpfInst>& raw_prog,
                                             ebpf_verifier_options_t* options);
 
 } // namespace prevail
@@ -25,7 +25,7 @@ std::tuple<bool, double> bpf_verify_program(const EbpfProgramType& type, const s
 namespace prevail {
 #define create_map_linux (nullptr)
 
-inline std::tuple<bool, double> bpf_verify_program(EbpfProgramType type, const std::vector<ebpf_inst>& raw_prog,
+inline std::tuple<bool, double> bpf_verify_program(EbpfProgramType type, const std::vector<EbpfInst>& raw_prog,
                                                    ebpf_verifier_options_t* options) {
     std::cerr << "linux domain is unsupported on this machine\n";
     exit(64);

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -13,18 +13,18 @@
 
 namespace prevail {
 class Program {
-    friend struct cfg_builder_t;
+    friend struct CfgBuilder;
 
-    std::map<label_t, Instruction> m_instructions{{label_t::entry, Undefined{}}, {label_t::exit, Undefined{}}};
+    std::map<Label, Instruction> m_instructions{{Label::entry, Undefined{}}, {Label::exit, Undefined{}}};
 
     // This is a cache. The assertions can also be computed on the fly.
-    std::map<label_t, std::vector<Assertion>> m_assertions{{label_t::entry, {}}, {label_t::exit, {}}};
-    cfg_t m_cfg;
+    std::map<Label, std::vector<Assertion>> m_assertions{{Label::entry, {}}, {Label::exit, {}}};
+    Cfg m_cfg;
 
-    // TODO: add program_info field
+    // TODO: add ProgramInfo field
 
   public:
-    const cfg_t& cfg() const { return m_cfg; }
+    const Cfg& cfg() const { return m_cfg; }
 
     //! return a view of the labels, including entry and exit
     [[nodiscard]]
@@ -32,28 +32,28 @@ class Program {
         return m_cfg.labels();
     }
 
-    const Instruction& instruction_at(const label_t& label) const {
+    const Instruction& instruction_at(const Label& label) const {
         if (!m_instructions.contains(label)) {
             CRAB_ERROR("Label ", to_string(label), " not found in the CFG: ");
         }
         return m_instructions.at(label);
     }
 
-    Instruction& instruction_at(const label_t& label) {
+    Instruction& instruction_at(const Label& label) {
         if (!m_instructions.contains(label)) {
             CRAB_ERROR("Label ", to_string(label), " not found in the CFG: ");
         }
         return m_instructions.at(label);
     }
 
-    std::vector<Assertion> assertions_at(const label_t& label) const {
+    std::vector<Assertion> assertions_at(const Label& label) const {
         if (!m_assertions.contains(label)) {
             CRAB_ERROR("Label ", to_string(label), " not found in the CFG: ");
         }
         return m_assertions.at(label);
     }
 
-    static Program from_sequence(const InstructionSeq& inst_seq, const program_info& info,
+    static Program from_sequence(const InstructionSeq& inst_seq, const ProgramInfo& info,
                                  const ebpf_verifier_options_t& options);
 };
 
@@ -62,12 +62,12 @@ class InvalidControlFlow final : public std::runtime_error {
     explicit InvalidControlFlow(const std::string& what) : std::runtime_error(what) {}
 };
 
-std::vector<Assertion> get_assertions(Instruction ins, const program_info& info, const std::optional<label_t>& label);
+std::vector<Assertion> get_assertions(Instruction ins, const ProgramInfo& info, const std::optional<Label>& label);
 
 std::vector<std::string> stats_headers();
 std::map<std::string, int> collect_stats(const Program& prog);
 
-using printfunc = std::function<void(std::ostream&, const label_t& label)>;
+using printfunc = std::function<void(std::ostream&, const Label& label)>;
 void print_program(const Program& prog, std::ostream& os, bool simplify, const printfunc& prefunc,
                    const printfunc& postfunc);
 void print_program(const Program& prog, std::ostream& os, bool simplify);

--- a/src/spec_type_descriptors.hpp
+++ b/src/spec_type_descriptors.hpp
@@ -56,7 +56,7 @@ struct btf_line_info_t {
     uint32_t column_number{};
 };
 
-struct program_info {
+struct ProgramInfo {
     const struct ebpf_platform_t* platform{};
     std::vector<EbpfMapDescriptor> map_descriptors{};
     EbpfProgramType type{};
@@ -64,18 +64,18 @@ struct program_info {
     std::map<int, btf_line_info_t> line_info{};
 };
 
-struct raw_program {
+struct RawProgram {
     std::string filename{};
     std::string section_name{};
     uint32_t insn_off{}; // Byte offset in section of first instruction in this program.
     std::string function_name{};
-    std::vector<ebpf_inst> prog{};
-    program_info info{};
+    std::vector<EbpfInst> prog{};
+    ProgramInfo info{};
 };
 
 void print_map_descriptors(const std::vector<EbpfMapDescriptor>& descriptors, std::ostream& o);
 
 std::ostream& operator<<(std::ostream& os, const btf_line_info_t& line_info);
 
-extern thread_local lazy_allocator<program_info> thread_local_program_info;
+extern thread_local LazyAllocator<ProgramInfo> thread_local_program_info;
 } // namespace prevail

--- a/src/string_constraints.hpp
+++ b/src/string_constraints.hpp
@@ -12,15 +12,15 @@
 #include "crab/linear_constraint.hpp"
 
 namespace prevail {
-struct string_invariant {
+struct StringInvariant {
     std::optional<std::set<std::string>> maybe_inv{};
 
-    string_invariant() = default;
+    StringInvariant() = default;
 
-    explicit string_invariant(std::set<std::string> inv) : maybe_inv(std::move(inv)) {};
+    explicit StringInvariant(std::set<std::string> inv) : maybe_inv(std::move(inv)) {};
 
-    string_invariant(const string_invariant& inv) = default;
-    string_invariant& operator=(const string_invariant& inv) = default;
+    StringInvariant(const StringInvariant& inv) = default;
+    StringInvariant& operator=(const StringInvariant& inv) = default;
 
     [[nodiscard]]
     bool is_bottom() const {
@@ -31,8 +31,8 @@ struct string_invariant {
         return maybe_inv && maybe_inv->empty();
     }
 
-    static string_invariant top() { return string_invariant{{}}; }
-    static string_invariant bottom() { return string_invariant{}; }
+    static StringInvariant top() { return StringInvariant{{}}; }
+    static StringInvariant bottom() { return StringInvariant{}; }
 
     [[nodiscard]]
     const std::set<std::string>& value() const {
@@ -42,19 +42,19 @@ struct string_invariant {
         return *maybe_inv;
     }
 
-    string_invariant operator-(const string_invariant& b) const;
-    string_invariant operator+(const string_invariant& b) const;
+    StringInvariant operator-(const StringInvariant& b) const;
+    StringInvariant operator+(const StringInvariant& b) const;
 
-    bool operator==(const string_invariant& other) const { return maybe_inv == other.maybe_inv; }
+    bool operator==(const StringInvariant& other) const { return maybe_inv == other.maybe_inv; }
 
     [[nodiscard]]
     bool contains(const std::string& item) const {
         return maybe_inv.value().contains(item);
     }
 
-    friend std::ostream& operator<<(std::ostream&, const string_invariant& inv);
+    friend std::ostream& operator<<(std::ostream&, const StringInvariant& inv);
 };
 
-std::vector<linear_constraint_t> parse_linear_constraints(const std::set<std::string>& constraints,
-                                                          std::vector<interval_t>& numeric_ranges);
+std::vector<LinearConstraint> parse_linear_constraints(const std::set<std::string>& constraints,
+                                                       std::vector<Interval>& numeric_ranges);
 } // namespace prevail

--- a/src/test/ebpf_yaml.hpp
+++ b/src/test/ebpf_yaml.hpp
@@ -12,9 +12,9 @@ namespace prevail {
 struct TestCase {
     std::string name;
     ebpf_verifier_options_t options{};
-    string_invariant assumed_pre_invariant;
+    StringInvariant assumed_pre_invariant;
     InstructionSeq instruction_seq;
-    string_invariant expected_post_invariant;
+    StringInvariant expected_post_invariant;
     std::set<std::string> expected_messages;
 };
 
@@ -28,7 +28,7 @@ struct Diff {
 };
 
 struct Failure {
-    Diff<string_invariant> invariant;
+    Diff<StringInvariant> invariant;
     Diff<std::set<std::string>> messages;
 };
 
@@ -38,7 +38,7 @@ std::optional<Failure> run_yaml_test_case(TestCase test_case, bool debug = false
 
 struct ConformanceTestResult {
     bool success{};
-    interval_t r0_value = interval_t::top();
+    Interval r0_value = Interval::top();
 };
 
 ConformanceTestResult run_conformance_test_case(const std::vector<std::byte>& memory_bytes,

--- a/src/test/test_print.cpp
+++ b/src/test/test_print.cpp
@@ -24,7 +24,7 @@ using namespace prevail;
 void verify_printed_string(const std::string& file) {
     std::stringstream generated_output;
     auto raw_progs = read_elf(std::string(TEST_OBJECT_FILE_DIRECTORY) + file + ".o", "", {}, &g_ebpf_platform_linux);
-    const raw_program& raw_prog = raw_progs.back();
+    const RawProgram& raw_prog = raw_progs.back();
     std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog);
     auto program = std::get_if<InstructionSeq>(&prog_or_error);
     REQUIRE(program != nullptr);

--- a/src/test/test_sign_extension.cpp
+++ b/src/test/test_sign_extension.cpp
@@ -11,106 +11,106 @@ using namespace prevail;
 
 TEST_CASE("sign_extend 1 bit positive-positive", "[sign_extension]") {
     // no actual sign extension needed
-    REQUIRE(interval_t{0b0'0, 0b0'0}.sign_extend(1) == interval_t{0, 0});
+    REQUIRE(Interval{0b0'0, 0b0'0}.sign_extend(1) == Interval{0, 0});
 }
 
 TEST_CASE("sign_extend 1 bit negative-negative", "[sign_extension]") {
     // straight-forward sign extension on both ends; order is preserved
-    REQUIRE(interval_t{0b0'1, 0b0'1}.sign_extend(1) == interval_t{-1, -1});
+    REQUIRE(Interval{0b0'1, 0b0'1}.sign_extend(1) == Interval{-1, -1});
 }
 
 TEST_CASE("sign_extend 1 bit positive-negative", "[sign_extension]") {
     // 0b1 is in the range (<=ub)
     // 0b0 is in the range (>=lb)
     // so the convex hull is [-1, 0]
-    REQUIRE(interval_t{0b0'0, 0b0'1}.sign_extend(1) == interval_t{-1, 0});
+    REQUIRE(Interval{0b0'0, 0b0'1}.sign_extend(1) == Interval{-1, 0});
 }
 
 // === 2 bits ===
 
 TEST_CASE("sign_extend 2 bits positive-positive", "[sign_extension]") {
     // no actual sign extension needed
-    REQUIRE(interval_t{0b0'00, 0b0'00}.sign_extend(2) == interval_t{0, 0});
-    REQUIRE(interval_t{0b0'00, 0b0'01}.sign_extend(2) == interval_t{0, 1});
+    REQUIRE(Interval{0b0'00, 0b0'00}.sign_extend(2) == Interval{0, 0});
+    REQUIRE(Interval{0b0'00, 0b0'01}.sign_extend(2) == Interval{0, 1});
 
-    REQUIRE(interval_t{0b0'01, 0b0'01}.sign_extend(2) == interval_t{1, 1});
+    REQUIRE(Interval{0b0'01, 0b0'01}.sign_extend(2) == Interval{1, 1});
 }
 
 TEST_CASE("sign_extend 2 bits negative-negative", "[sign_extension]") {
     // straight-forward sign extension on both ends; order is preserved
-    REQUIRE(interval_t{0b0'10, 0b0'10}.sign_extend(2) == interval_t{-2, -2});
-    REQUIRE(interval_t{0b0'10, 0b0'11}.sign_extend(2) == interval_t{-2, -1});
+    REQUIRE(Interval{0b0'10, 0b0'10}.sign_extend(2) == Interval{-2, -2});
+    REQUIRE(Interval{0b0'10, 0b0'11}.sign_extend(2) == Interval{-2, -1});
 
-    REQUIRE(interval_t{0b0'11, 0b0'11}.sign_extend(2) == interval_t{-1, -1});
+    REQUIRE(Interval{0b0'11, 0b0'11}.sign_extend(2) == Interval{-1, -1});
 }
 
 TEST_CASE("sign_extend 2 bits positive-negative", "[sign_extension]") {
     // 0b10 is in the range (<=ub)
     // 0b01 is in the range (>=lb)
     // so the convex hull is [-2, 1]
-    REQUIRE(interval_t{0b0'00, 0b0'10}.sign_extend(2) == interval_t{-2, 1});
-    REQUIRE(interval_t{0b0'00, 0b0'11}.sign_extend(2) == interval_t{-2, 1});
+    REQUIRE(Interval{0b0'00, 0b0'10}.sign_extend(2) == Interval{-2, 1});
+    REQUIRE(Interval{0b0'00, 0b0'11}.sign_extend(2) == Interval{-2, 1});
 
-    REQUIRE(interval_t{0b0'01, 0b0'10}.sign_extend(2) == interval_t{-2, 1});
-    REQUIRE(interval_t{0b0'01, 0b0'11}.sign_extend(2) == interval_t{-2, 1});
+    REQUIRE(Interval{0b0'01, 0b0'10}.sign_extend(2) == Interval{-2, 1});
+    REQUIRE(Interval{0b0'01, 0b0'11}.sign_extend(2) == Interval{-2, 1});
 }
 // === 3 bits ===
 
 TEST_CASE("sign_extend 3 bits positive-positive", "[sign_extension]") {
     // no actual sign extension needed
-    REQUIRE(interval_t{0b0'000, 0b0'000}.sign_extend(3) == interval_t{0, 0});
-    REQUIRE(interval_t{0b0'000, 0b0'001}.sign_extend(3) == interval_t{0, 1});
-    REQUIRE(interval_t{0b0'000, 0b0'010}.sign_extend(3) == interval_t{0, 2});
-    REQUIRE(interval_t{0b0'000, 0b0'011}.sign_extend(3) == interval_t{0, 3});
+    REQUIRE(Interval{0b0'000, 0b0'000}.sign_extend(3) == Interval{0, 0});
+    REQUIRE(Interval{0b0'000, 0b0'001}.sign_extend(3) == Interval{0, 1});
+    REQUIRE(Interval{0b0'000, 0b0'010}.sign_extend(3) == Interval{0, 2});
+    REQUIRE(Interval{0b0'000, 0b0'011}.sign_extend(3) == Interval{0, 3});
 
-    REQUIRE(interval_t{0b0'001, 0b0'001}.sign_extend(3) == interval_t{1, 1});
-    REQUIRE(interval_t{0b0'001, 0b0'010}.sign_extend(3) == interval_t{1, 2});
-    REQUIRE(interval_t{0b0'001, 0b0'011}.sign_extend(3) == interval_t{1, 3});
+    REQUIRE(Interval{0b0'001, 0b0'001}.sign_extend(3) == Interval{1, 1});
+    REQUIRE(Interval{0b0'001, 0b0'010}.sign_extend(3) == Interval{1, 2});
+    REQUIRE(Interval{0b0'001, 0b0'011}.sign_extend(3) == Interval{1, 3});
 
-    REQUIRE(interval_t{0b0'010, 0b0'010}.sign_extend(3) == interval_t{2, 2});
-    REQUIRE(interval_t{0b0'010, 0b0'011}.sign_extend(3) == interval_t{2, 3});
+    REQUIRE(Interval{0b0'010, 0b0'010}.sign_extend(3) == Interval{2, 2});
+    REQUIRE(Interval{0b0'010, 0b0'011}.sign_extend(3) == Interval{2, 3});
 
-    REQUIRE(interval_t{0b0'011, 0b0'011}.sign_extend(3) == interval_t{3, 3});
+    REQUIRE(Interval{0b0'011, 0b0'011}.sign_extend(3) == Interval{3, 3});
 }
 
 TEST_CASE("sign_extend 3 bits negative-negative", "[sign_extension]") {
     // straight-forward sign extension on both ends; order is preserved
-    REQUIRE(interval_t{0b0'100, 0b0'100}.sign_extend(3) == interval_t{-4, -4});
-    REQUIRE(interval_t{0b0'100, 0b0'101}.sign_extend(3) == interval_t{-4, -3});
-    REQUIRE(interval_t{0b0'100, 0b0'110}.sign_extend(3) == interval_t{-4, -2});
-    REQUIRE(interval_t{0b0'100, 0b0'111}.sign_extend(3) == interval_t{-4, -1});
+    REQUIRE(Interval{0b0'100, 0b0'100}.sign_extend(3) == Interval{-4, -4});
+    REQUIRE(Interval{0b0'100, 0b0'101}.sign_extend(3) == Interval{-4, -3});
+    REQUIRE(Interval{0b0'100, 0b0'110}.sign_extend(3) == Interval{-4, -2});
+    REQUIRE(Interval{0b0'100, 0b0'111}.sign_extend(3) == Interval{-4, -1});
 
-    REQUIRE(interval_t{0b0'101, 0b0'101}.sign_extend(3) == interval_t{-3, -3});
-    REQUIRE(interval_t{0b0'101, 0b0'110}.sign_extend(3) == interval_t{-3, -2});
-    REQUIRE(interval_t{0b0'101, 0b0'111}.sign_extend(3) == interval_t{-3, -1});
+    REQUIRE(Interval{0b0'101, 0b0'101}.sign_extend(3) == Interval{-3, -3});
+    REQUIRE(Interval{0b0'101, 0b0'110}.sign_extend(3) == Interval{-3, -2});
+    REQUIRE(Interval{0b0'101, 0b0'111}.sign_extend(3) == Interval{-3, -1});
 
-    REQUIRE(interval_t{0b0'110, 0b0'110}.sign_extend(3) == interval_t{-2, -2});
-    REQUIRE(interval_t{0b0'110, 0b0'111}.sign_extend(3) == interval_t{-2, -1});
+    REQUIRE(Interval{0b0'110, 0b0'110}.sign_extend(3) == Interval{-2, -2});
+    REQUIRE(Interval{0b0'110, 0b0'111}.sign_extend(3) == Interval{-2, -1});
 
-    REQUIRE(interval_t{0b0'111, 0b0'111}.sign_extend(3) == interval_t{-1, -1});
+    REQUIRE(Interval{0b0'111, 0b0'111}.sign_extend(3) == Interval{-1, -1});
 }
 
 TEST_CASE("sign_extend 3 bits positive-negative", "[sign_extension]") {
     // 0b100 is in the range (<=ub)
     // 0b011 is in the range (>=lb)
     // so the convex hull is [-4, 3]
-    REQUIRE(interval_t{0b0'000, 0b0'100}.sign_extend(3) == interval_t{-4, 3});
-    REQUIRE(interval_t{0b0'000, 0b0'101}.sign_extend(3) == interval_t{-4, 3});
-    REQUIRE(interval_t{0b0'000, 0b0'110}.sign_extend(3) == interval_t{-4, 3});
-    REQUIRE(interval_t{0b0'000, 0b0'111}.sign_extend(3) == interval_t{-4, 3});
+    REQUIRE(Interval{0b0'000, 0b0'100}.sign_extend(3) == Interval{-4, 3});
+    REQUIRE(Interval{0b0'000, 0b0'101}.sign_extend(3) == Interval{-4, 3});
+    REQUIRE(Interval{0b0'000, 0b0'110}.sign_extend(3) == Interval{-4, 3});
+    REQUIRE(Interval{0b0'000, 0b0'111}.sign_extend(3) == Interval{-4, 3});
 
-    REQUIRE(interval_t{0b0'001, 0b0'100}.sign_extend(3) == interval_t{-4, 3});
-    REQUIRE(interval_t{0b0'001, 0b0'101}.sign_extend(3) == interval_t{-4, 3});
-    REQUIRE(interval_t{0b0'001, 0b0'110}.sign_extend(3) == interval_t{-4, 3});
-    REQUIRE(interval_t{0b0'001, 0b0'111}.sign_extend(3) == interval_t{-4, 3});
+    REQUIRE(Interval{0b0'001, 0b0'100}.sign_extend(3) == Interval{-4, 3});
+    REQUIRE(Interval{0b0'001, 0b0'101}.sign_extend(3) == Interval{-4, 3});
+    REQUIRE(Interval{0b0'001, 0b0'110}.sign_extend(3) == Interval{-4, 3});
+    REQUIRE(Interval{0b0'001, 0b0'111}.sign_extend(3) == Interval{-4, 3});
 
-    REQUIRE(interval_t{0b0'010, 0b0'100}.sign_extend(3) == interval_t{-4, 3});
-    REQUIRE(interval_t{0b0'010, 0b0'101}.sign_extend(3) == interval_t{-4, 3});
-    REQUIRE(interval_t{0b0'010, 0b0'110}.sign_extend(3) == interval_t{-4, 3});
-    REQUIRE(interval_t{0b0'010, 0b0'111}.sign_extend(3) == interval_t{-4, 3});
+    REQUIRE(Interval{0b0'010, 0b0'100}.sign_extend(3) == Interval{-4, 3});
+    REQUIRE(Interval{0b0'010, 0b0'101}.sign_extend(3) == Interval{-4, 3});
+    REQUIRE(Interval{0b0'010, 0b0'110}.sign_extend(3) == Interval{-4, 3});
+    REQUIRE(Interval{0b0'010, 0b0'111}.sign_extend(3) == Interval{-4, 3});
 
-    REQUIRE(interval_t{0b0'011, 0b0'100}.sign_extend(3) == interval_t{-4, 3});
-    REQUIRE(interval_t{0b0'011, 0b0'101}.sign_extend(3) == interval_t{-4, 3});
-    REQUIRE(interval_t{0b0'011, 0b0'110}.sign_extend(3) == interval_t{-4, 3});
-    REQUIRE(interval_t{0b0'011, 0b0'111}.sign_extend(3) == interval_t{-4, 3});
+    REQUIRE(Interval{0b0'011, 0b0'100}.sign_extend(3) == Interval{-4, 3});
+    REQUIRE(Interval{0b0'011, 0b0'101}.sign_extend(3) == Interval{-4, 3});
+    REQUIRE(Interval{0b0'011, 0b0'110}.sign_extend(3) == Interval{-4, 3});
+    REQUIRE(Interval{0b0'011, 0b0'111}.sign_extend(3) == Interval{-4, 3});
 }

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -26,7 +26,7 @@ FAIL_LOAD_ELF("invalid", "badsymsize.o", "xdp_redirect_map")
     TEST_CASE("Try unmarshalling bad program: " dirname "/" filename " " sectionname, "[unmarshal]") {            \
         auto raw_progs = read_elf("ebpf-samples/" dirname "/" filename, sectionname, {}, &g_ebpf_platform_linux); \
         REQUIRE(raw_progs.size() == 1);                                                                           \
-        raw_program raw_prog = raw_progs.back();                                                                  \
+        RawProgram raw_prog = raw_progs.back();                                                                   \
         std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog);                            \
         REQUIRE(std::holds_alternative<std::string>(prog_or_error));                                              \
     }
@@ -39,7 +39,7 @@ FAIL_UNMARSHAL("invalid", "invalid-lddw.o", ".text")
     TEST_CASE("Try analyze bad program: " dirname "/" filename " " sectionname, "[cfg]") {                        \
         auto raw_progs = read_elf("ebpf-samples/" dirname "/" filename, sectionname, {}, &g_ebpf_platform_linux); \
         REQUIRE(raw_progs.size() == 1);                                                                           \
-        raw_program raw_prog = raw_progs.back();                                                                  \
+        RawProgram raw_prog = raw_progs.back();                                                                   \
         std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog);                            \
         const auto inst_seq = std::get_if<InstructionSeq>(&prog_or_error);                                        \
         REQUIRE(inst_seq != nullptr);                                                                             \
@@ -119,7 +119,7 @@ FAIL_ANALYZE("build", "badmapptr.o", "test")
         platform.supported_conformance_groups &= ~bpf_conformance_groups_t::packet;                  \
         auto raw_progs = read_elf("ebpf-samples/" dirname "/" filename, sectionname, {}, &platform); \
         REQUIRE(raw_progs.size() == 1);                                                              \
-        raw_program raw_prog = raw_progs.back();                                                     \
+        RawProgram raw_prog = raw_progs.back();                                                      \
         std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog);               \
         REQUIRE(std::holds_alternative<std::string>(prog_or_error));                                 \
     }
@@ -607,7 +607,7 @@ TEST_SECTION_LEGACY("cilium", "bpf_lxc.o", "2/10")
 TEST_SECTION("cilium", "bpf_lxc.o", "2/11")
 TEST_SECTION("cilium", "bpf_lxc.o", "2/12")
 
-void test_analyze_thread(const Program* prog, program_info* info, bool* res) {
+void test_analyze_thread(const Program* prog, ProgramInfo* info, bool* res) {
     thread_local_program_info.set(*info);
     *res = verify(*prog);
 }
@@ -616,7 +616,7 @@ void test_analyze_thread(const Program* prog, program_info* info, bool* res) {
 TEST_CASE("multithreading", "[verify][multithreading]") {
     auto raw_progs1 = read_elf("ebpf-samples/bpf_cilium_test/bpf_netdev.o", "2/1", {}, &g_ebpf_platform_linux);
     REQUIRE(raw_progs1.size() == 1);
-    raw_program raw_prog1 = raw_progs1.back();
+    RawProgram raw_prog1 = raw_progs1.back();
     auto prog_or_error1 = unmarshal(raw_prog1);
     auto inst_seq1 = std::get_if<InstructionSeq>(&prog_or_error1);
     REQUIRE(inst_seq1 != nullptr);
@@ -624,7 +624,7 @@ TEST_CASE("multithreading", "[verify][multithreading]") {
 
     auto raw_progs2 = read_elf("ebpf-samples/bpf_cilium_test/bpf_netdev.o", "2/2", {}, &g_ebpf_platform_linux);
     REQUIRE(raw_progs2.size() == 1);
-    raw_program raw_prog2 = raw_progs2.back();
+    RawProgram raw_prog2 = raw_progs2.back();
     auto prog_or_error2 = unmarshal(raw_prog2);
     auto inst_seq2 = std::get_if<InstructionSeq>(&prog_or_error2);
     REQUIRE(inst_seq2 != nullptr);

--- a/src/test/test_wto.cpp
+++ b/src/test/test_wto.cpp
@@ -10,15 +10,15 @@ using namespace prevail;
 TEST_CASE("wto figure 1", "[wto]") {
     // Construct the example graph in figure 1 of Bourdoncle,
     // "Efficient chaotic iteration strategies with widenings", 1993.
-    const wto_t wto(cfg_from_adjacency_list({{label_t::entry, {label_t{1}}},
-                                             {label_t{1}, {label_t{2}}},
-                                             {label_t{2}, {label_t{3}}},
-                                             {label_t{3}, {label_t{4}}},
-                                             {label_t{4}, {label_t{5}, label_t{7}}},
-                                             {label_t{5}, {label_t{6}}},
-                                             {label_t{6}, {label_t{5}, label_t{7}}},
-                                             {label_t{7}, {label_t{3}, label_t{8}}},
-                                             {label_t{8}, {label_t::exit}}}));
+    const Wto wto(cfg_from_adjacency_list({{Label::entry, {Label{1}}},
+                                           {Label{1}, {Label{2}}},
+                                           {Label{2}, {Label{3}}},
+                                           {Label{3}, {Label{4}}},
+                                           {Label{4}, {Label{5}, Label{7}}},
+                                           {Label{5}, {Label{6}}},
+                                           {Label{6}, {Label{5}, Label{7}}},
+                                           {Label{7}, {Label{3}, Label{8}}},
+                                           {Label{8}, {Label::exit}}}));
 
     std::ostringstream os;
     os << wto;
@@ -28,12 +28,12 @@ TEST_CASE("wto figure 1", "[wto]") {
 TEST_CASE("wto figure 2a", "[wto]") {
     // Construct the example graph in figure 2a of Bourdoncle,
     // "Efficient chaotic iteration strategies with widenings", 1993.
-    const wto_t wto(cfg_from_adjacency_list({{label_t::entry, {label_t{1}}},
-                                             {label_t{1}, {label_t{2}, label_t{4}}},
-                                             {label_t{2}, {label_t{3}}},
-                                             {label_t{3}, {label_t::exit}},
-                                             {label_t{4}, {label_t{3}, label_t{5}}},
-                                             {label_t{5}, {label_t{4}}}}));
+    const Wto wto(cfg_from_adjacency_list({{Label::entry, {Label{1}}},
+                                           {Label{1}, {Label{2}, Label{4}}},
+                                           {Label{2}, {Label{3}}},
+                                           {Label{3}, {Label::exit}},
+                                           {Label{4}, {Label{3}, Label{5}}},
+                                           {Label{5}, {Label{4}}}}));
 
     std::ostringstream os;
     os << wto;
@@ -43,11 +43,11 @@ TEST_CASE("wto figure 2a", "[wto]") {
 TEST_CASE("wto figure 2b", "[wto]") {
     // Construct the example graph in figure 2b of Bourdoncle,
     // "Efficient chaotic iteration strategies with widenings", 1993.
-    const wto_t wto(cfg_from_adjacency_list({{label_t::entry, {label_t{1}}},
-                                             {label_t{1}, {label_t{2}, label_t{4}}},
-                                             {label_t{2}, {label_t{3}}},
-                                             {label_t{3}, {label_t{1}, label_t::exit}},
-                                             {label_t{4}, {label_t{3}}}}));
+    const Wto wto(cfg_from_adjacency_list({{Label::entry, {Label{1}}},
+                                           {Label{1}, {Label{2}, Label{4}}},
+                                           {Label{2}, {Label{3}}},
+                                           {Label{3}, {Label{1}, Label::exit}},
+                                           {Label{4}, {Label{3}}}}));
 
     std::ostringstream os;
     os << wto;


### PR DESCRIPTION
Added a script for automatic renaming, to help with the code churn.

closes #860


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a script to automate class renaming throughout the codebase, supporting dry-run mode and detailed reporting.

- **Refactor**
  - Updated the codebase to use consistent PascalCase naming for types and classes (e.g., `label_t` → `Label`, `interval_t` → `Interval`, `ebpf_inst` → `EbpfInst`, etc.).
  - Standardized method and function signatures to reflect new type names across all modules, including core logic, utilities, and test files.
  - Improved naming clarity for data structures and enums, enhancing code readability and maintainability.

- **Style**
  - Harmonized naming conventions across the entire project for improved consistency.

- **Documentation**
  - Updated type references in public interfaces and documentation to match new naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->