### PR TITLE
Tidy

### DIFF
--- a/scripts/rename_classes.py
+++ b/scripts/rename_classes.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) Prevail Verifier contributors.
+# SPDX-License-Identifier: MIT
 """
 Class Name Renaming Script
 
@@ -97,14 +99,9 @@ CLASS_MAPPING = {
     "g_e_neighbour_const_range": "GENeighbourConstRange",
     "g_neighbour_const_range": "GNeighbourConstRange",
     "neighbour_const_range": "NeighbourConstRange",
-    "neighbour_range": "NeighbourRange",
-    "fwd_edge_const_iter": "FwdEdgeConstIter",  # Iterator for forward edges
-    "fwd_edge_range": "FwdEdgeRange",
-    "rev_edge_const_iter": "RevEdgeConstIter",  # Iterator for reverse edges
-    "rev_edge_range": "RevEdgeRange",
     "rev_map_t": "RevMap",  # Mapping vertex ID to variable
-    "elt_iter_t": "EltIter",  # Iterator for elements in sparse map
-    "elt_range_t": "EltRange",
+    "elt_iter_t": "ValueIterator",  # Iterator for elements in sparse map
+    "elt_range_t": "ValueRange",
     "patricia_tree_t": "PatriciaTree",  # Underlying structure for OffsetMap
     "adj_const_iterator": "AdjConstIterator",
     "adj_iterator": "AdjIterator",
@@ -112,9 +109,9 @@ CLASS_MAPPING = {
     "const_adj_list": "ConstAdjList",
     "e_adj_const_iterator": "EAdjConstIterator",
     "e_adj_iterator": "EAdjIterator",
-    "elt_const_range_t": "EltConstRange",
+    "elt_const_range_t": "ValueConstRange",
     "key_const_range_t": "KeyConstRange",
-    "key_iter_t": "KeyIter",
+    "key_iter_t": "KeyIterator",
     "vert_const_range": "VertConstRange",
     "vert_set_wrap_t": "VertSetWrap",  # Wrapper for VertSet
 

--- a/src/asm_cfg.cpp
+++ b/src/asm_cfg.cpp
@@ -134,7 +134,7 @@ static void add_cfg_nodes(CfgBuilder& builder, const Label& caller_label, const 
     // Get the label of the node to go to on returning from the macro.
     Label exit_to_label = builder.prog.cfg().get_child(caller_label);
 
-    // Construct the variable prefix to use for the new stack frame,
+    // Construct the variable prefix to use for the new stack frame
     // and store a copy in the CallLocal instruction since the instruction-specific
     // labels may only exist until the CFG is simplified.
     const std::string stack_frame_prefix = to_string(caller_label);
@@ -219,7 +219,7 @@ static void add_cfg_nodes(CfgBuilder& builder, const Label& caller_label, const 
 static CfgBuilder instruction_seq_to_cfg(const InstructionSeq& insts, const bool must_have_exit) {
     CfgBuilder builder;
 
-    // First add all instructions to the CFG without connecting
+    // First, add all instructions to the CFG without connecting
     for (const auto& [label, inst, _] : insts) {
         if (std::holds_alternative<Undefined>(inst)) {
             continue;

--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -470,7 +470,7 @@ struct CommandPrinterVisitor {
 
     void print(Deref const& access) {
         const string sign = access.offset < 0 ? " - " : " + ";
-        int offset = std::abs(access.offset); // what about INT_MIN?
+        const int offset = std::abs(access.offset); // what about INT_MIN?
         os_ << "*(" << size(access.width) << " *)";
         os_ << "(" << access.basereg << sign << offset << ")";
     }

--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -48,7 +48,7 @@ static std::string make_opcode_message(const char* msg, const uint8_t opcode) {
     return oss.str();
 }
 
-struct InvalidInstruction : std::invalid_argument {
+struct InvalidInstruction final : std::invalid_argument {
     size_t pc;
     explicit InvalidInstruction(const size_t pc, const char* what) : std::invalid_argument{what}, pc{pc} {}
     InvalidInstruction(const size_t pc, const std::string& what) : std::invalid_argument{what}, pc{pc} {}
@@ -56,7 +56,7 @@ struct InvalidInstruction : std::invalid_argument {
         : std::invalid_argument{make_opcode_message("bad instruction", opcode)}, pc{pc} {}
 };
 
-struct UnsupportedMemoryMode : std::invalid_argument {
+struct UnsupportedMemoryMode final : std::invalid_argument {
     explicit UnsupportedMemoryMode(const char* what) : std::invalid_argument{what} {}
 };
 

--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -56,10 +56,6 @@ struct InvalidInstruction final : std::invalid_argument {
         : std::invalid_argument{make_opcode_message("bad instruction", opcode)}, pc{pc} {}
 };
 
-struct UnsupportedMemoryMode final : std::invalid_argument {
-    explicit UnsupportedMemoryMode(const char* what) : std::invalid_argument{what} {}
-};
-
 static auto getMemIsLoad(const uint8_t opcode) -> bool {
     switch (opcode & INST_CLS_MASK) {
     case INST_CLS_LD:

--- a/src/asm_unmarshal.hpp
+++ b/src/asm_unmarshal.hpp
@@ -23,5 +23,5 @@ std::variant<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog,
                                                     std::vector<std::vector<std::string>>& notes);
 std::variant<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog);
 
-Call make_call(int func, const ebpf_platform_t& platform);
+Call make_call(int imm, const ebpf_platform_t& platform);
 } // namespace prevail

--- a/src/cfg/wto.cpp
+++ b/src/cfg/wto.cpp
@@ -63,7 +63,7 @@ struct VisitArgs {
     std::weak_ptr<WtoCycle> containing_cycle;
 
     VisitArgs(const VisitTaskType t, Label v, WtoPartition& p, std::weak_ptr<WtoCycle> cc)
-        : type(t), vertex(std::move(v)), partition(p), containing_cycle(std::move(cc)) {};
+        : type(t), vertex(std::move(v)), partition(p), containing_cycle(std::move(cc)) {}
 };
 
 struct WtoVertexData {

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -855,8 +855,8 @@ ArrayDomain ArrayDomain::operator&(const ArrayDomain& other) const { return Arra
 
 ArrayDomain ArrayDomain::widen(const ArrayDomain& other) const { return ArrayDomain(num_bytes | other.num_bytes); }
 
-ArrayDomain ArrayDomain::widening_thresholds(const ArrayDomain& other, const Thresholds& ts) const {
-    return ArrayDomain(num_bytes | other.num_bytes);
+ArrayDomain ArrayDomain::widening_thresholds(const ArrayDomain& other, const Thresholds&) const {
+    return widen(other);
 }
 
 ArrayDomain ArrayDomain::narrow(const ArrayDomain& other) const { return ArrayDomain(num_bytes & other.num_bytes); }

--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -16,7 +16,7 @@ class BitsetDomain final {
   public:
     BitsetDomain() { non_numerical_bytes.set(); }
 
-    BitsetDomain(bits_t non_numerical_bytes) : non_numerical_bytes{non_numerical_bytes} {}
+    BitsetDomain(const bits_t& non_numerical_bytes) : non_numerical_bytes{non_numerical_bytes} {}
 
     void set_to_top() { non_numerical_bytes.set(); }
 

--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -60,7 +60,7 @@ class BitsetDomain final {
     }
 
     [[nodiscard]]
-    std::pair<bool, bool> uniformity(size_t lb, int width) const {
+    std::pair<bool, bool> uniformity(const size_t lb, int width) const {
         width = std::min(width, static_cast<int>(EBPF_TOTAL_STACK_SIZE - lb));
         bool only_num = true;
         bool only_non_num = true;
@@ -77,7 +77,7 @@ class BitsetDomain final {
 
     // Get the number of bytes, starting at lb, known to be numbers.
     [[nodiscard]]
-    int all_num_width(size_t lb) const {
+    int all_num_width(const size_t lb) const {
         size_t ub = lb;
         while ((ub < EBPF_TOTAL_STACK_SIZE) && !non_numerical_bytes[ub]) {
             ub++;
@@ -85,14 +85,14 @@ class BitsetDomain final {
         return static_cast<int>(ub - lb);
     }
 
-    void reset(size_t lb, int n) {
+    void reset(const size_t lb, int n) {
         n = std::min(n, static_cast<int>((EBPF_TOTAL_STACK_SIZE - lb)));
         for (int i = 0; i < n; i++) {
             non_numerical_bytes.reset(lb + i);
         }
     }
 
-    void havoc(size_t lb, int width) {
+    void havoc(const size_t lb, int width) {
         width = std::min(width, static_cast<int>(EBPF_TOTAL_STACK_SIZE - lb));
         for (int i = 0; i < width; i++) {
             non_numerical_bytes.set(lb + i);

--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -61,7 +61,7 @@ class BitsetDomain final {
 
     [[nodiscard]]
     std::pair<bool, bool> uniformity(size_t lb, int width) const {
-        width = std::min(width, (int)(EBPF_TOTAL_STACK_SIZE - lb));
+        width = std::min(width, static_cast<int>(EBPF_TOTAL_STACK_SIZE - lb));
         bool only_num = true;
         bool only_non_num = true;
         for (int j = 0; j < width; j++) {
@@ -82,18 +82,18 @@ class BitsetDomain final {
         while ((ub < EBPF_TOTAL_STACK_SIZE) && !non_numerical_bytes[ub]) {
             ub++;
         }
-        return (int)(ub - lb);
+        return static_cast<int>(ub - lb);
     }
 
     void reset(size_t lb, int n) {
-        n = std::min(n, (int)(EBPF_TOTAL_STACK_SIZE - lb));
+        n = std::min(n, static_cast<int>((EBPF_TOTAL_STACK_SIZE - lb)));
         for (int i = 0; i < n; i++) {
             non_numerical_bytes.reset(lb + i);
         }
     }
 
     void havoc(size_t lb, int width) {
-        width = std::min(width, (int)(EBPF_TOTAL_STACK_SIZE - lb));
+        width = std::min(width, static_cast<int>(EBPF_TOTAL_STACK_SIZE - lb));
         for (int i = 0; i < width; i++) {
             non_numerical_bytes.set(lb + i);
         }
@@ -106,8 +106,8 @@ class BitsetDomain final {
     bool all_num(int32_t lb, int32_t ub) const {
         assert(lb < ub);
         lb = std::max(lb, 0);
-        ub = std::min(ub, (int)EBPF_TOTAL_STACK_SIZE);
-        if (lb < 0 || ub > (int)non_numerical_bytes.size()) {
+        ub = std::min(ub, EBPF_TOTAL_STACK_SIZE);
+        if (lb < 0 || ub > static_cast<int>(non_numerical_bytes.size())) {
             return false;
         }
 

--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -99,7 +99,7 @@ class BitsetDomain final {
         }
     }
 
-    friend std::ostream& operator<<(std::ostream& o, const BitsetDomain& array);
+    friend std::ostream& operator<<(std::ostream& o, const BitsetDomain& b);
 
     // Test whether all values in the range [lb,ub) are numerical.
     [[nodiscard]]

--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -68,7 +68,7 @@ class BitsetDomain final {
             if (lb + j >= non_numerical_bytes.size()) {
                 throw std::runtime_error("bitset index out of range");
             }
-            bool b = non_numerical_bytes[lb + j];
+            const bool b = non_numerical_bytes[lb + j];
             only_num &= !b;
             only_non_num &= b;
         }

--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -16,7 +16,7 @@ class BitsetDomain final {
   public:
     BitsetDomain() { non_numerical_bytes.set(); }
 
-    BitsetDomain(const bits_t& non_numerical_bytes) : non_numerical_bytes{non_numerical_bytes} {}
+    explicit BitsetDomain(const bits_t& non_numerical_bytes) : non_numerical_bytes{non_numerical_bytes} {}
 
     void set_to_top() { non_numerical_bytes.set(); }
 
@@ -43,20 +43,26 @@ class BitsetDomain final {
 
     void operator|=(const BitsetDomain& other) { non_numerical_bytes |= other.non_numerical_bytes; }
 
-    BitsetDomain operator|(BitsetDomain&& other) const { return non_numerical_bytes | other.non_numerical_bytes; }
+    BitsetDomain operator|(BitsetDomain&& other) const {
+        return BitsetDomain{non_numerical_bytes | other.non_numerical_bytes};
+    }
 
-    BitsetDomain operator|(const BitsetDomain& other) const { return non_numerical_bytes | other.non_numerical_bytes; }
+    BitsetDomain operator|(const BitsetDomain& other) const {
+        return BitsetDomain{non_numerical_bytes | other.non_numerical_bytes};
+    }
 
-    BitsetDomain operator&(const BitsetDomain& other) const { return non_numerical_bytes & other.non_numerical_bytes; }
+    BitsetDomain operator&(const BitsetDomain& other) const {
+        return BitsetDomain{non_numerical_bytes & other.non_numerical_bytes};
+    }
 
     [[nodiscard]]
     BitsetDomain widen(const BitsetDomain& other) const {
-        return non_numerical_bytes | other.non_numerical_bytes;
+        return BitsetDomain{non_numerical_bytes | other.non_numerical_bytes};
     }
 
     [[nodiscard]]
     BitsetDomain narrow(const BitsetDomain& other) const {
-        return non_numerical_bytes & other.non_numerical_bytes;
+        return BitsetDomain{non_numerical_bytes & other.non_numerical_bytes};
     }
 
     [[nodiscard]]

--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -192,7 +192,7 @@ void EbpfChecker::operator()(const Comparable& s) const {
         // _Maybe_ different types, so r2 must be a number.
         // We checked in a previous assertion that r1 is a pointer or a number.
         require(m_inv, reg_pack(s.r2).type == T_NUM, "Cannot subtract pointers to different regions");
-    };
+    }
 }
 
 void EbpfChecker::operator()(const Addable& s) const {

--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -77,7 +77,6 @@ class EbpfChecker final {
     void check_access_shared(NumAbsDomain& inv, const LinearExpression& lb, const LinearExpression& ub,
                              Variable shared_region_size) const;
 
-  public:
   private:
     const Assertion assertion;
     const OnRequire on_require;

--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -270,7 +270,6 @@ void EbpfChecker::operator()(const ValidCall& s) const {
         const EbpfHelperPrototype proto = thread_local_program_info->platform->get_helper_prototype(s.func);
         if (proto.return_type == EBPF_RETURN_TYPE_INTEGER_OR_NO_RETURN_IF_SUCCEED) {
             require("tail call not supported in subprogram");
-            return;
         }
     }
 }

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -145,6 +145,10 @@ EbpfDomain EbpfDomain::widen(const EbpfDomain& other, const bool to_constants) c
     return res;
 }
 
+EbpfDomain EbpfDomain::widening_thresholds(const EbpfDomain& other, const Thresholds&) const {
+    return widen(other, false);
+}
+
 EbpfDomain EbpfDomain::narrow(const EbpfDomain& other) const {
     return EbpfDomain(m_inv.narrow(other.m_inv), stack & other.stack);
 }

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -59,7 +59,7 @@ class EbpfDomain final {
     EbpfDomain operator|(const EbpfDomain& other) &&;
     EbpfDomain operator&(const EbpfDomain& other) const;
     EbpfDomain widen(const EbpfDomain& other, bool to_constants) const;
-    EbpfDomain widening_thresholds(const EbpfDomain& other, const Thresholds& ts);
+    EbpfDomain widening_thresholds(const EbpfDomain& other, const Thresholds&) const;
     EbpfDomain narrow(const EbpfDomain& other) const;
 
     static EbpfDomain calculate_constant_limits();

--- a/src/crab/finite_domain.cpp
+++ b/src/crab/finite_domain.cpp
@@ -517,7 +517,7 @@ FiniteDomain::assume_unsigned_32bit_gt(const bool strict, const Variable left_sv
     } else {
         // We can't directly compare the uvalues since they may differ in high order bits.
         return {};
-    };
+    }
 }
 
 std::vector<LinearConstraint> FiniteDomain::assume_unsigned_cst_interval(Condition::Op op, bool is64,

--- a/src/crab/finite_domain.hpp
+++ b/src/crab/finite_domain.hpp
@@ -125,7 +125,7 @@ class FiniteDomain {
     void bitwise_and(Variable lhss, Variable lhsu, const Number& op2);
     void bitwise_or(Variable lhss, Variable lhsu, Variable op2, int finite_width);
     void bitwise_or(Variable lhss, Variable lhsu, const Number& op2);
-    void bitwise_xor(Variable lhsss, Variable lhsu, Variable op2, int finite_width);
+    void bitwise_xor(Variable lhss, Variable lhsu, Variable op2, int finite_width);
     void bitwise_xor(Variable lhss, Variable lhsu, const Number& op2);
     void shl_overflow(Variable lhss, Variable lhsu, Variable op2);
     void shl_overflow(Variable lhss, Variable lhsu, const Number& op2);

--- a/src/crab/interval.hpp
+++ b/src/crab/interval.hpp
@@ -173,7 +173,7 @@ class Interval final {
     }
 
     template <typename Thresholds>
-    Interval widening_thresholds(Interval x, const Thresholds& ts) {
+    Interval widening_thresholds(Interval x, const Thresholds& ts) const {
         if (is_bottom()) {
             return x;
         } else if (x.is_bottom()) {

--- a/src/crab/linear_expression.hpp
+++ b/src/crab/linear_expression.hpp
@@ -11,7 +11,7 @@ namespace prevail {
 
 // A linear expression is of the form: Ax + By + Cz + ... + N.
 // That is, a sum of terms where each term is either a
-// coefficient * variable, or simply a coefficient
+// coefficient * variable or simply a coefficient
 // (of which there is only one such term).
 class LinearExpression final {
 
@@ -30,7 +30,7 @@ class LinearExpression final {
         if (it == _variable_terms.end()) {
             return 0;
         }
-        return (*it).second;
+        return it->second;
     }
 
   public:

--- a/src/crab/linear_expression.hpp
+++ b/src/crab/linear_expression.hpp
@@ -26,7 +26,7 @@ class LinearExpression final {
     // Get the coefficient for a given variable, which is 0 if it has no term in the expression.
     [[nodiscard]]
     Number coefficient_of(const Variable& variable) const {
-        auto it = _variable_terms.find(variable);
+        const auto it = _variable_terms.find(variable);
         if (it == _variable_terms.end()) {
             return 0;
         }
@@ -155,7 +155,7 @@ inline std::ostream& operator<<(std::ostream& o, const LinearExpression& express
     expression.output_variable_terms(o);
 
     // Output the constant term.
-    Number constant = expression.constant_term();
+    const Number constant = expression.constant_term();
     if (constant < 0) {
         o << constant;
     } else if (constant > 0) {

--- a/src/crab/split_dbm.cpp
+++ b/src/crab/split_dbm.cpp
@@ -385,9 +385,9 @@ bool SplitDBM::operator<=(const SplitDBM& o) const {
     if (vert_map.size() < o.vert_map.size()) {
         return false;
     }
-
+    constexpr VertId INVALID_VERT = std::numeric_limits<VertId>::max();
     // Set up a mapping from o to this.
-    std::vector<unsigned int> vert_renaming(o.g.size(), -1);
+    std::vector vert_renaming(o.g.size(), INVALID_VERT);
     vert_renaming[0] = 0;
     for (const auto& [v, n] : o.vert_map) {
         if (o.g.succs(n).size() == 0 && o.g.preds(n).size() == 0) {
@@ -408,11 +408,11 @@ bool SplitDBM::operator<=(const SplitDBM& o) const {
             continue;
         }
 
-        assert(vert_renaming[ox] != (unsigned)-1);
+        assert(vert_renaming[ox] != INVALID_VERT);
         VertId x = vert_renaming[ox];
         for (const auto edge : o.g.e_succs(ox)) {
             VertId oy = edge.vert;
-            assert(vert_renaming[oy] != (unsigned)-1);
+            assert(vert_renaming[oy] != INVALID_VERT);
             VertId y = vert_renaming[oy];
             Weight ow = edge.val;
 

--- a/src/crab/split_dbm.hpp
+++ b/src/crab/split_dbm.hpp
@@ -134,7 +134,7 @@ class SplitDBM final {
         CrabStats::count("SplitDBM.count.copy");
         ScopedCrabStats __st__("SplitDBM.copy");
 
-        CRAB_LOG("zones-split-size", auto p = size();
+        CRAB_LOG("zones-split-size", const auto p = size();
                  std::cout << "#nodes = " << p.first << " #edges=" << p.second << "\n";);
 
         assert(g.size() > 0);

--- a/src/crab/thresholds.hpp
+++ b/src/crab/thresholds.hpp
@@ -34,7 +34,7 @@ class Thresholds final {
         return m_thresholds.size();
     }
 
-    void add(const ExtendedNumber& v1);
+    void add(const ExtendedNumber& v);
 
     friend std::ostream& operator<<(std::ostream& o, const Thresholds& t);
 };

--- a/src/crab_utils/adapt_sgraph.hpp
+++ b/src/crab_utils/adapt_sgraph.hpp
@@ -158,7 +158,7 @@ class AdaptGraph final {
     using Weight = Number; // previously template
     using VertId = unsigned int;
 
-    AdaptGraph() : edge_count(0) {}
+    AdaptGraph() = default;
 
     AdaptGraph(AdaptGraph&& o) noexcept = default;
 

--- a/src/crab_utils/adapt_sgraph.hpp
+++ b/src/crab_utils/adapt_sgraph.hpp
@@ -123,7 +123,7 @@ class TreeSMap final {
 
     [[nodiscard]]
     std::optional<Val> lookup(Key k) const {
-        auto v = map.find(k);
+        const auto v = map.find(k);
         if (v != map.end()) {
             return {v->second};
         }
@@ -353,7 +353,7 @@ class AdaptGraph final {
         edge_count -= _succs[v].size();
         _succs[v].clear();
 
-        for (TreeSMap::Key k : _preds[v].keys()) {
+        for (const TreeSMap::Key k : _preds[v].keys()) {
             _succs[k].remove(v);
         }
         edge_count -= _preds[v].size();
@@ -365,7 +365,7 @@ class AdaptGraph final {
 
     void clear_edges() {
         _ws.clear();
-        for (VertId v : verts()) {
+        for (const VertId v : verts()) {
             _succs[v].clear();
             _preds[v].clear();
         }
@@ -412,7 +412,7 @@ class AdaptGraph final {
     };
 
     bool lookup(VertId s, VertId d, MutValRef* w) {
-        if (auto idx = _succs[s].lookup(d)) {
+        if (const auto idx = _succs[s].lookup(d)) {
             *w = &_ws[*idx];
             return true;
         }
@@ -421,7 +421,7 @@ class AdaptGraph final {
 
     [[nodiscard]]
     std::optional<Weight> lookup(VertId s, VertId d) const {
-        if (auto idx = _succs[s].lookup(d)) {
+        if (const auto idx = _succs[s].lookup(d)) {
             return _ws[*idx];
         }
         return {};
@@ -444,7 +444,7 @@ class AdaptGraph final {
     }
 
     void update_edge(VertId s, Weight w, VertId d) {
-        if (auto idx = _succs[s].lookup(d)) {
+        if (const auto idx = _succs[s].lookup(d)) {
             _ws[*idx] = std::min(_ws[*idx], w);
         } else {
             add_edge(s, w, d);
@@ -452,7 +452,7 @@ class AdaptGraph final {
     }
 
     void set_edge(VertId s, Weight w, VertId d) {
-        if (auto idx = _succs[s].lookup(d)) {
+        if (const auto idx = _succs[s].lookup(d)) {
             _ws[*idx] = w;
         } else {
             add_edge(s, w, d);
@@ -463,7 +463,7 @@ class AdaptGraph final {
     friend std::ostream& operator<<(std::ostream& o, AdaptGraph& g) {
         o << "[|";
         bool first = true;
-        for (VertId v : g.verts()) {
+        for (const VertId v : g.verts()) {
             auto it = g.e_succs(v).begin();
             auto end = g.e_succs(v).end();
 

--- a/src/crab_utils/adapt_sgraph.hpp
+++ b/src/crab_utils/adapt_sgraph.hpp
@@ -460,7 +460,7 @@ class AdaptGraph final {
     }
 
     // XXX: g cannot be marked const for complicated reasons
-    friend std::ostream& operator<<(std::ostream& o, AdaptGraph& g) {
+    friend std::ostream& operator<<(std::ostream& o, const AdaptGraph& g) {
         o << "[|";
         bool first = true;
         for (const VertId v : g.verts()) {

--- a/src/crab_utils/adapt_sgraph.hpp
+++ b/src/crab_utils/adapt_sgraph.hpp
@@ -389,40 +389,17 @@ class AdaptGraph final {
 
     const Weight& edge_val(VertId s, VertId d) const { return _ws[*_succs[s].lookup(d)]; }
 
-    class MutValRef {
-      public:
-        MutValRef() : w(nullptr) {}
-        operator Weight() const {
-            assert(w);
-            return *w;
-        }
-        [[nodiscard]]
-        Weight get() const {
-            assert(w);
-            return *w;
-        }
-        void operator=(Weight* _w) { w = _w; }
-        void operator=(Weight _w) {
-            assert(w);
-            *w = _w;
-        }
-
-      private:
-        Weight* w;
-    };
-
-    bool lookup(VertId s, VertId d, MutValRef* w) {
+    Weight* lookup(VertId s, VertId d) {
         if (const auto idx = _succs[s].lookup(d)) {
-            *w = &_ws[*idx];
-            return true;
+            return &_ws[*idx];
         }
-        return false;
+        return {};
     }
 
     [[nodiscard]]
-    std::optional<Weight> lookup(VertId s, VertId d) const {
+    const Weight* lookup(VertId s, VertId d) const {
         if (const auto idx = _succs[s].lookup(d)) {
-            return _ws[*idx];
+            return &_ws[*idx];
         }
         return {};
     }

--- a/src/crab_utils/adapt_sgraph.hpp
+++ b/src/crab_utils/adapt_sgraph.hpp
@@ -18,26 +18,26 @@ class TreeSMap final {
     col map;
 
   public:
-    using EltIter = col::const_iterator;
+    using ValueIterator = col::const_iterator;
     [[nodiscard]]
     size_t size() const {
         return map.size();
     }
 
-    class KeyIter {
+    class KeyIterator {
       public:
-        KeyIter() = default;
-        explicit KeyIter(const col::const_iterator& _e) : e(_e) {}
+        KeyIterator() = default;
+        explicit KeyIterator(const col::const_iterator& _e) : e(_e) {}
 
         /// return canonical empty iterator
-        static KeyIter empty_iterator() {
-            static KeyIter empty_iter;
+        static KeyIterator empty_iterator() {
+            static KeyIterator empty_iter;
             return empty_iter;
         }
 
         Key operator*() const { return e->first; }
-        bool operator!=(const KeyIter& o) const { return e != o.e; }
-        KeyIter& operator++() {
+        bool operator!=(const KeyIterator& o) const { return e != o.e; }
+        KeyIterator& operator++() {
             ++e;
             return *this;
         }
@@ -47,7 +47,7 @@ class TreeSMap final {
 
     class KeyConstRange {
       public:
-        using iterator = KeyIter;
+        using iterator = KeyIterator;
 
         explicit KeyConstRange(const col& c) : c{c} {}
         [[nodiscard]]
@@ -56,20 +56,20 @@ class TreeSMap final {
         }
 
         [[nodiscard]]
-        KeyIter begin() const {
-            return KeyIter(c.cbegin());
+        KeyIterator begin() const {
+            return KeyIterator(c.cbegin());
         }
         [[nodiscard]]
-        KeyIter end() const {
-            return KeyIter(c.cend());
+        KeyIterator end() const {
+            return KeyIterator(c.cend());
         }
 
         const col& c;
     };
 
-    class EltRange {
+    class ValueRange {
       public:
-        EltRange(const col& c) : c{c} {}
+        explicit ValueRange(const col& c) : c{c} {}
         [[nodiscard]]
         size_t size() const {
             return c.size();
@@ -87,9 +87,9 @@ class TreeSMap final {
         const col& c;
     };
 
-    class EltConstRange {
+    class ValueConstRange {
       public:
-        EltConstRange(const col& c) : c{c} {}
+        explicit ValueConstRange(const col& c) : c{c} {}
         [[nodiscard]]
         size_t size() const {
             return c.size();
@@ -108,9 +108,10 @@ class TreeSMap final {
     };
 
     [[nodiscard]]
-    EltRange elts() const {
-        return EltRange(map);
+    ValueRange values() const {
+        return ValueRange(map);
     }
+
     [[nodiscard]]
     KeyConstRange keys() const {
         return KeyConstRange(map);
@@ -223,48 +224,48 @@ class AdaptGraph final {
         return VertConstRange{is_free};
     }
 
-    struct edge_const_iter {
+    struct EdgeConstIterator {
         struct EdgeRef {
             VertId vert{};
             Weight val;
         };
 
-        TreeSMap::EltIter it{};
+        TreeSMap::ValueIterator it{};
         const std::vector<Weight>* ws{};
 
-        edge_const_iter(const TreeSMap::EltIter& _it, const std::vector<Weight>& _ws) : it(_it), ws(&_ws) {}
-        edge_const_iter(const edge_const_iter& o) = default;
-        edge_const_iter& operator=(const edge_const_iter& o) = default;
-        edge_const_iter() = default;
+        EdgeConstIterator(const TreeSMap::ValueIterator& _it, const std::vector<Weight>& _ws) : it(_it), ws(&_ws) {}
+        EdgeConstIterator(const EdgeConstIterator& o) = default;
+        EdgeConstIterator& operator=(const EdgeConstIterator& o) = default;
+        EdgeConstIterator() = default;
 
         /// return canonical empty iterator
-        static edge_const_iter empty_iterator() {
-            static edge_const_iter empty_iter;
+        static EdgeConstIterator empty_iterator() {
+            static EdgeConstIterator empty_iter;
             return empty_iter;
         }
 
         EdgeRef operator*() const { return EdgeRef{it->first, (*ws)[it->second]}; }
-        edge_const_iter operator++() {
+        EdgeConstIterator operator++() {
             ++it;
             return *this;
         }
-        bool operator!=(const edge_const_iter& o) const { return it != o.it; }
+        bool operator!=(const EdgeConstIterator& o) const { return it != o.it; }
     };
 
-    struct edge_const_range_t {
-        using EltRange = TreeSMap::EltRange;
-        using iterator = edge_const_iter;
+    struct EdgeConstRange {
+        using ValueRange = TreeSMap::ValueRange;
+        using iterator = EdgeConstIterator;
 
-        EltRange r;
+        ValueRange r;
         const std::vector<Weight>& ws;
 
         [[nodiscard]]
-        edge_const_iter begin() const {
-            return edge_const_iter(r.begin(), ws);
+        EdgeConstIterator begin() const {
+            return EdgeConstIterator(r.begin(), ws);
         }
         [[nodiscard]]
-        edge_const_iter end() const {
-            return edge_const_iter(r.end(), ws);
+        EdgeConstIterator end() const {
+            return EdgeConstIterator(r.end(), ws);
         }
         [[nodiscard]]
         size_t size() const {
@@ -272,12 +273,8 @@ class AdaptGraph final {
         }
     };
 
-    using FwdEdgeConstIter = edge_const_iter;
-    using RevEdgeConstIter = edge_const_iter;
-
     using AdjRange = TreeSMap::KeyConstRange;
     using AdjConstRange = TreeSMap::KeyConstRange;
-    using NeighbourRange = AdjRange;
     using NeighbourConstRange = AdjConstRange;
 
     [[nodiscard]]
@@ -289,19 +286,16 @@ class AdaptGraph final {
         return _preds[v].keys();
     }
 
-    using FwdEdgeRange = edge_const_range_t;
-    using RevEdgeRange = edge_const_range_t;
-
     [[nodiscard]]
-    edge_const_range_t e_succs(VertId v) const {
-        return {_succs[v].elts(), _ws};
+    EdgeConstRange e_succs(VertId v) const {
+        return {_succs[v].values(), _ws};
     }
     [[nodiscard]]
-    edge_const_range_t e_preds(VertId v) const {
-        return {_preds[v].elts(), _ws};
+    EdgeConstRange e_preds(VertId v) const {
+        return {_preds[v].values(), _ws};
     }
 
-    using ENeighbourConstRange = edge_const_range_t;
+    using ENeighbourConstRange = EdgeConstRange;
 
     // Management
     [[nodiscard]]
@@ -346,7 +340,7 @@ class AdaptGraph final {
             return;
         }
 
-        for (const auto& [key, val] : _succs[v].elts()) {
+        for (const auto& [key, val] : _succs[v].values()) {
             free_widx.push_back(val);
             _preds[key].remove(v);
         }

--- a/src/crab_utils/graph_ops.hpp
+++ b/src/crab_utils/graph_ops.hpp
@@ -1101,7 +1101,7 @@ class GraphOps {
   public:
     static void close_over_edge(Graph& g, VertId ii, VertId jj) {
         assert(ii != 0 && jj != 0);
-        SubGraph<Graph> g_excl(g, 0);
+        SubGraph g_excl(g, 0);
 
         Weight c = g_excl.edge_val(ii, jj);
 

--- a/src/crab_utils/graph_ops.hpp
+++ b/src/crab_utils/graph_ops.hpp
@@ -675,7 +675,7 @@ class GraphOps {
         const size_t sz = x.size();
         grow_scratch(sz);
 
-        for (VertId v : x.verts()) {
+        for (const VertId v : x.verts()) {
             vert_marks->at(v) = 0;
         }
         for (VertId v : x.verts()) {
@@ -686,7 +686,7 @@ class GraphOps {
             }
         }
 
-        for (VertId v : x.verts()) {
+        for (const VertId v : x.verts()) {
             vert_marks->at(v) = 0;
         }
     }
@@ -722,7 +722,7 @@ class GraphOps {
             auto next_head = dual_queue->begin() + sz;
             auto next_tail = next_head;
 
-            for (VertId v : scc) {
+            for (const VertId v : scc) {
                 *qtail = v;
                 vert_marks->at(v) = BF_SCC | BF_QUEUED;
                 ++qtail;
@@ -738,7 +738,7 @@ class GraphOps {
                     Weight s_pot = potentials[s];
 
                     for (const auto e : g.e_succs(s)) {
-                        VertId d = e.vert;
+                        const VertId d = e.vert;
                         Weight sd_pot = s_pot + e.val;
                         if (sd_pot < potentials[d]) {
                             potentials[d] = sd_pot;
@@ -763,10 +763,10 @@ class GraphOps {
                 VertId s = *--qtail;
                 Weight s_pot = potentials[s];
                 for (const auto e : g.e_succs(s)) {
-                    VertId d = e.vert;
+                    const VertId d = e.vert;
                     if (s_pot + e.val < potentials[d]) {
                         // Cleanup vertex marks
-                        for (VertId v : g.verts()) {
+                        for (const VertId v : g.verts()) {
                             vert_marks->at(v) = BF_NONE;
                         }
                         return false;
@@ -984,7 +984,7 @@ class GraphOps {
         // assert(src < (int) sz && dest < (int) sz);
         grow_scratch(sz);
 
-        for (VertId vi : g.verts()) {
+        for (const VertId vi : g.verts()) {
             dists->at(vi) = Weight(0);
             dists_alt->at(vi) = p[vi];
         }
@@ -1004,7 +1004,7 @@ class GraphOps {
             dists_alt->at(es) = p[es] + dists->at(es);
 
             for (const auto e : g.e_succs(es)) {
-                VertId ed = e.vert;
+                const VertId ed = e.vert;
                 if (dists_alt->at(ed) == p[ed]) {
                     Weight gnext_ed = dists_alt->at(es) + e.val - dists_alt->at(ed);
                     if (gnext_ed < dists->at(ed)) {
@@ -1022,7 +1022,7 @@ class GraphOps {
             return false;
         }
 
-        for (VertId v : g.verts()) {
+        for (const VertId v : g.verts()) {
             p[v] = dists_alt->at(v);
         }
 
@@ -1056,7 +1056,7 @@ class GraphOps {
     static void close_after_assign_fwd(const auto& g, const PotentialFunction& p, VertId v,
                                        std::vector<std::tuple<VertId, Weight>>& aux) {
         // Initialize the queue and distances.
-        for (VertId u : g.verts()) {
+        for (const VertId u : g.verts()) {
             vert_marks->at(u) = 0;
         }
 
@@ -1065,7 +1065,7 @@ class GraphOps {
         auto adj_head = dual_queue->begin();
         auto adj_tail = adj_head;
         for (const auto e : g.e_succs(v)) {
-            VertId d = e.vert;
+            const VertId d = e.vert;
             vert_marks->at(d) = BF_QUEUED;
             dists->at(d) = e.val;
             //        assert(p(v) + dists->at(d) - p(d) >= Weight(0));
@@ -1083,7 +1083,7 @@ class GraphOps {
 
             Weight d_wt = dists->at(d);
             for (const auto edge : g.e_succs(d)) {
-                VertId e = edge.vert;
+                const VertId e = edge.vert;
                 Weight e_wt = d_wt + edge.val;
                 if (!vert_marks->at(e)) {
                     dists->at(e) = e_wt;

--- a/src/crab_utils/num_extended.hpp
+++ b/src/crab_utils/num_extended.hpp
@@ -126,7 +126,7 @@ class ExtendedNumber final {
     ExtendedNumber& operator*=(const ExtendedNumber& x) { return operator=(operator*(x)); }
 
   private:
-    ExtendedNumber AbsDiv(const ExtendedNumber& x, ExtendedNumber (*f)(Number, Number)) const {
+    ExtendedNumber AbsDiv(const ExtendedNumber& x, ExtendedNumber (*f)(const Number&, const Number&)) const {
         if (x._n == 0) {
             CRAB_ERROR("Bound: division by zero");
         }
@@ -144,30 +144,30 @@ class ExtendedNumber final {
 
   public:
     ExtendedNumber operator/(const ExtendedNumber& x) const {
-        return AbsDiv(x, [](Number dividend, Number divisor) { return ExtendedNumber{dividend / divisor}; });
+        return AbsDiv(x,
+                      [](const Number& dividend, const Number& divisor) { return ExtendedNumber{dividend / divisor}; });
     }
 
     ExtendedNumber operator%(const ExtendedNumber& x) const {
-        return AbsDiv(x, [](Number dividend, Number divisor) { return ExtendedNumber{dividend % divisor}; });
+        return AbsDiv(x,
+                      [](const Number& dividend, const Number& divisor) { return ExtendedNumber{dividend % divisor}; });
     }
 
     [[nodiscard]]
     ExtendedNumber udiv(const ExtendedNumber& x) const {
         using M = uint64_t;
-        return AbsDiv(x, [](Number dividend, Number divisor) {
-            dividend = dividend >= 0 ? dividend : Number{dividend.cast_to<M>()};
-            divisor = divisor >= 0 ? divisor : Number{divisor.cast_to<M>()};
-            return ExtendedNumber{dividend / divisor};
+        return AbsDiv(x, [](const Number& dividend, const Number& divisor) {
+            return ExtendedNumber{(dividend >= 0 ? dividend : Number{dividend.cast_to<M>()}) /
+                                  (divisor >= 0 ? divisor : Number{divisor.cast_to<M>()})};
         });
     }
 
     [[nodiscard]]
     ExtendedNumber urem(const ExtendedNumber& x) const {
         using M = uint64_t;
-        return AbsDiv(x, [](Number dividend, Number divisor) {
-            dividend = dividend >= 0 ? dividend : Number{dividend.cast_to<M>()};
-            divisor = divisor >= 0 ? divisor : Number{divisor.cast_to<M>()};
-            return ExtendedNumber{dividend % divisor};
+        return AbsDiv(x, [](const Number& dividend, const Number& divisor) {
+            return ExtendedNumber{(dividend >= 0 ? dividend : Number{dividend.cast_to<M>()}) %
+                                  (divisor >= 0 ? divisor : Number{divisor.cast_to<M>()})};
         });
     }
 

--- a/src/crab_utils/stats.cpp
+++ b/src/crab_utils/stats.cpp
@@ -35,7 +35,7 @@ long Stopwatch::systemTime() const {
 
     return (long)total_us;
 #else
-    struct rusage ru;
+    rusage ru;
     getrusage(RUSAGE_SELF, &ru);
     const long r = ru.ru_utime.tv_sec * 1000000L + ru.ru_utime.tv_usec;
     return r;

--- a/src/crab_utils/stats.cpp
+++ b/src/crab_utils/stats.cpp
@@ -78,7 +78,7 @@ void Stopwatch::Print(std::ostream& out) const {
     const long time = getTimeElapsed();
     const long h = time / 3600000000L;
     const long m = time / 60000000L - h * 60;
-    const float s = ((float)time / 1000000L) - m * 60 - h * 3600;
+    const float s = (static_cast<float>(time) / 1000000L) - m * 60 - h * 3600;
 
     if (h > 0) {
         out << h << "h";

--- a/src/linux/gpl/spec_prototypes.cpp
+++ b/src/linux/gpl/spec_prototypes.cpp
@@ -2085,7 +2085,7 @@ constexpr EbpfHelperPrototype bpf_loop_proto = {
 
 #define FN(x) bpf_##x##_proto
 // keep this on a round line
-const EbpfHelperPrototype prototypes[] = {
+constexpr EbpfHelperPrototype prototypes[] = {
     FN(unspec),
     FN(map_lookup_elem),
     FN(map_update_elem),

--- a/src/linux/gpl/spec_prototypes.cpp
+++ b/src/linux/gpl/spec_prototypes.cpp
@@ -2083,7 +2083,7 @@ constexpr EbpfHelperPrototype bpf_loop_proto = {
         },
 };
 
-#define FN(x) bpf_## x## _proto
+#define FN(x) bpf_##x##_proto
 // keep this on a round line
 constexpr EbpfHelperPrototype prototypes[] = {
     FN(unspec),
@@ -2276,7 +2276,7 @@ constexpr EbpfHelperPrototype prototypes[] = {
 };
 
 bool is_helper_usable_linux(const int32_t n) {
-    if (n >= static_cast<int>(sizeof(prototypes) / sizeof(prototypes[0])) || n < 0) {
+    if (n >= static_cast<int>(std::size(prototypes)) || n < 0) {
         return false;
     }
 

--- a/src/linux/gpl/spec_prototypes.cpp
+++ b/src/linux/gpl/spec_prototypes.cpp
@@ -2083,7 +2083,7 @@ constexpr EbpfHelperPrototype bpf_loop_proto = {
         },
 };
 
-#define FN(x) bpf_##x##_proto
+#define FN(x) bpf_## x## _proto
 // keep this on a round line
 constexpr EbpfHelperPrototype prototypes[] = {
     FN(unspec),
@@ -2276,7 +2276,7 @@ constexpr EbpfHelperPrototype prototypes[] = {
 };
 
 bool is_helper_usable_linux(const int32_t n) {
-    if (n >= (int)(sizeof(prototypes) / sizeof(prototypes[0])) || n < 0) {
+    if (n >= static_cast<int>(sizeof(prototypes) / sizeof(prototypes[0])) || n < 0) {
         return false;
     }
 

--- a/src/linux/linux_platform.cpp
+++ b/src/linux/linux_platform.cpp
@@ -183,7 +183,7 @@ void resolve_inner_map_references_linux(std::vector<EbpfMapDescriptor>& map_desc
 }
 
 #if __linux__
-static int do_bpf(const bpf_cmd cmd, union bpf_attr& attr) { return syscall(321, cmd, &attr, sizeof(attr)); }
+static int do_bpf(const bpf_cmd cmd, bpf_attr& attr) { return syscall(321, cmd, &attr, sizeof(attr)); }
 #endif
 
 /** Try to allocate a Linux map.
@@ -198,7 +198,7 @@ static int create_map_linux(const uint32_t map_type, const uint32_t key_size, co
     }
 
 #if __linux__
-    union bpf_attr attr{};
+    bpf_attr attr{};
     memset(&attr, '\0', sizeof(attr));
     attr.map_type = map_type;
     attr.key_size = key_size;

--- a/src/linux/linux_platform.cpp
+++ b/src/linux/linux_platform.cpp
@@ -133,7 +133,7 @@ static const EbpfMapType linux_map_types[] = {
 
 EbpfMapType get_map_type_linux(uint32_t platform_specific_type) {
     const uint32_t index = platform_specific_type;
-    if ((index == 0) || (index >= sizeof(linux_map_types) / sizeof(linux_map_types[0]))) {
+    if (index == 0 || index >= std::size(linux_map_types)) {
         return linux_map_types[0];
     }
     EbpfMapType type = linux_map_types[index];

--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -48,7 +48,7 @@ static std::optional<bpf_conformance_groups_t> _get_conformance_group_by_name(co
 
 static std::set<std::string> _get_conformance_group_names() {
     std::set<std::string> result;
-    for (const auto& [name, _] : _conformance_groups) {
+    for (const auto& name : _conformance_groups | std::views::keys) {
         result.insert(name);
     }
     return result;

--- a/src/main/linux_verifier.cpp
+++ b/src/main/linux_verifier.cpp
@@ -21,7 +21,7 @@ static int do_bpf(const bpf_cmd cmd, union bpf_attr& attr) { return syscall(321,
  */
 
 std::tuple<bool, double> bpf_verify_program(const EbpfProgramType& type, const std::vector<EbpfInst>& raw_prog,
-                                            ebpf_verifier_options_t* options) {
+                                            const ebpf_verifier_options_t* options) {
     std::vector<char> buf(options->verbosity_opts.print_failures ? 1000000 : 10);
     buf[0] = 0;
     std::memset(buf.data(), '\0', buf.size());

--- a/src/main/linux_verifier.cpp
+++ b/src/main/linux_verifier.cpp
@@ -13,7 +13,7 @@
 #include "spec_type_descriptors.hpp"
 
 namespace prevail {
-static int do_bpf(const bpf_cmd cmd, union bpf_attr& attr) { return syscall(321, cmd, &attr, sizeof(attr)); }
+static int do_bpf(const bpf_cmd cmd, bpf_attr& attr) { return syscall(321, cmd, &attr, sizeof(attr)); }
 
 /** Run the built-in Linux verifier on a raw eBPF program.
  *
@@ -26,7 +26,7 @@ std::tuple<bool, double> bpf_verify_program(const EbpfProgramType& type, const s
     buf[0] = 0;
     std::memset(buf.data(), '\0', buf.size());
 
-    union bpf_attr attr{};
+    bpf_attr attr{};
     std::memset(&attr, '\0', sizeof(attr));
     attr.prog_type = gsl::narrow<__u32>(type.platform_specific_data);
     attr.insn_cnt = gsl::narrow<__u32>(raw_prog.size());

--- a/src/main/linux_verifier.hpp
+++ b/src/main/linux_verifier.hpp
@@ -17,7 +17,7 @@ namespace prevail {
 int create_map_linux(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries,
                      ebpf_verifier_options_t options);
 std::tuple<bool, double> bpf_verify_program(const EbpfProgramType& type, const std::vector<EbpfInst>& raw_prog,
-                                            ebpf_verifier_options_t* options);
+                                            const ebpf_verifier_options_t* options);
 
 } // namespace prevail
 #else
@@ -26,7 +26,7 @@ namespace prevail {
 #define create_map_linux (nullptr)
 
 inline std::tuple<bool, double> bpf_verify_program(EbpfProgramType type, const std::vector<EbpfInst>& raw_prog,
-                                                   ebpf_verifier_options_t* options) {
+                                                   const ebpf_verifier_options_t* options) {
     std::cerr << "linux domain is unsupported on this machine\n";
     exit(64);
     return {{}, {}};

--- a/src/main/memsize_linux.hpp
+++ b/src/main/memsize_linux.hpp
@@ -11,16 +11,16 @@
 
 namespace prevail {
 inline long resident_set_size_kb() {
-    std::string _{};
-    unsigned long __{};
     long rss = 0;
     {
+        std::string _{};
+        unsigned long __{};
         std::ifstream stat_stream("/proc/self/stat", std::ios_base::in);
         stat_stream >> _ >> _ >> _ >> _ >> _ >> _ >> _ >> _ >> _ >> _ >> _ >> _ >> _ >> _ >> _ >> _ >> _ >> _ >> _ >>
             _ >> _ >> _ >> __ >> rss; // don't care about the rest
     }
 
-    long page_size_kb = sysconf(_SC_PAGE_SIZE) / 1024; // in case x86-64 is configured to use 2MB pages
+    const long page_size_kb = sysconf(_SC_PAGE_SIZE) / 1024; // in case x86-64 is configured to use 2MB pages
     return rss * page_size_kb;
 }
 } // namespace prevail

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -30,7 +30,7 @@ typedef int (*ebpf_create_map_fn)(uint32_t map_type, uint32_t key_size, uint32_t
 // In the future we may want to move map fd allocation after the verifier step.
 typedef void (*ebpf_parse_maps_section_fn)(std::vector<EbpfMapDescriptor>& map_descriptors, const char* data,
                                            size_t map_record_size, int map_count,
-                                           const struct ebpf_platform_t* platform, ebpf_verifier_options_t options);
+                                           const ebpf_platform_t* platform, ebpf_verifier_options_t options);
 typedef void (*ebpf_resolve_inner_map_references_fn)(std::vector<EbpfMapDescriptor>& map_descriptors);
 
 typedef EbpfMapDescriptor& (*ebpf_get_map_descriptor_fn)(int map_fd);

--- a/src/string_constraints.hpp
+++ b/src/string_constraints.hpp
@@ -17,7 +17,7 @@ struct StringInvariant {
 
     StringInvariant() = default;
 
-    explicit StringInvariant(std::set<std::string> inv) : maybe_inv(std::move(inv)) {};
+    explicit StringInvariant(std::set<std::string> inv) : maybe_inv(std::move(inv)) {}
 
     StringInvariant(const StringInvariant& inv) = default;
     StringInvariant& operator=(const StringInvariant& inv) = default;

--- a/src/test/test_conformance.cpp
+++ b/src/test/test_conformance.cpp
@@ -8,7 +8,7 @@
 
 static void test_conformance(const std::string& filename, const bpf_conformance_test_result_t& expected_result,
                              const std::string& expected_reason) {
-    std::vector<std::filesystem::path> test_files = {CONFORMANCE_TEST_PATH + filename};
+    const std::vector<std::filesystem::path> test_files = {CONFORMANCE_TEST_PATH + filename};
     boost::filesystem::path test_path = boost::dll::program_location();
     const boost::filesystem::path extension = test_path.extension();
     const std::filesystem::path plugin_path =

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -607,7 +607,7 @@ TEST_SECTION_LEGACY("cilium", "bpf_lxc.o", "2/10")
 TEST_SECTION("cilium", "bpf_lxc.o", "2/11")
 TEST_SECTION("cilium", "bpf_lxc.o", "2/12")
 
-void test_analyze_thread(const Program* prog, ProgramInfo* info, bool* res) {
+static void test_analyze_thread(const Program* prog, const ProgramInfo* info, bool* res) {
     thread_local_program_info.set(*info);
     *res = verify(*prog);
 }


### PR DESCRIPTION
Mostly cleanup; the commit titles should be self-explanatory.

One significant cleanup is replacing `MutValRef` class with a simple `Weight*`, and always returning Weight* from lookup functions instead of passing an out parameters. This also seems to be noticeably faster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved const-correctness and type safety across multiple components.
  - Updated function and method signatures for clarity and immutability.
  - Modernized array size checks and iteration methods.
  - Simplified and clarified internal APIs for edge weight lookups and domain operations.
  - Renamed iterators and ranges for clearer naming consistency.
  - Enhanced code clarity by removing redundant keywords and improving variable immutability.

- **Style**
  - Minor syntax and comment adjustments for consistency and readability.
  - Modernized code style with C++-style casts and removal of redundant struct keywords.
  - Updated iteration loops to use const variables.

- **Bug Fixes**
  - Corrected minor syntax errors to ensure proper compilation.

- **Tests**
  - Updated test utility functions for improved immutability and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->