### PR TITLE
Permit cycles when parsing BTF data

### DIFF
--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -236,7 +236,7 @@ static elf_global_data parse_btf_section(const parse_params_t& parse_params, con
     if (!btf_section) {
         return {};
     }
-    const libbtf::btf_type_data btf_data = vector_of<std::byte>(*btf_section);
+    const libbtf::btf_type_data btf_data(vector_of<std::byte>(*btf_section), false);
     if (parse_params.options.verbosity_opts.dump_btf_types_json) {
         dump_btf_types(btf_data, parse_params.path);
     }


### PR DESCRIPTION
Pickup latest libbtf and pass option to permit parsing BTF data with cycles in it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated an external library dependency to a newer version.

- **Refactor**
  - Improved the way type data objects are constructed for ELF section data, with no impact on application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->