### PR TITLE
Fix build on macOS/Darwin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,11 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
         "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(COMMON_FLAGS -Wall -Wfatal-errors -DSIZEOF_VOID_P=8 -DSIZEOF_LONG=8)
 
-    set(RELEASE_FLAGS -O2 -flto=auto -ffat-lto-objects)
+    if (NOT WIN32 AND NOT APPLE)
+        set(RELEASE_FLAGS -O2 -flto=auto -ffat-lto-objects)
+    else ()
+        set(RELEASE_FLAGS -O2 -flto=auto)
+    endif ()
 
     set(DEBUG_FLAGS -O0 -g3 -fno-omit-frame-pointer)
 

--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <sstream>
 #include <sys/stat.h>
 #include <vector>
 


### PR DESCRIPTION
 * `<sstream>` needs to be explicitly included when using libc++ STL
 * `-ffat-lto-objects` only works for ELF binaries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for Apple (macOS) and Windows platforms by adjusting compiler optimization settings.
  - Ensured proper compilation by adding a missing include for string stream functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->