### PR TITLE
Add parallel test runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Run unit tests
         if: ${{matrix.target == 'tests'}}
-        run: ./tests -d yes
+        run: scripts/run-tests-parallel.sh -d yes
 
       - name: Test for memory leaks
         if: ${{matrix.target == 'tests'}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,4 +88,4 @@ jobs:
 
       - name: Run unit tests
         if: ${{matrix.target == 'tests'}}
-        run: ./${{env.BUILD_CONFIGURATION}}/tests -d yes
+        run: ./scripts/run-tests-parallel.ps1 -d yes

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,7 +40,7 @@ jobs:
           cmake --build build -j $(nproc) --config ${{env.BUILD_CONFIGURATION}}
 
       - name: Run unit tests
-        run: ./tests --abort --reporter compact
+        run: scripts/run-tests-parallel.sh --abort --reporter compact
 
       # Comment only change to test coverage report to coveralls
       - name: Generate code coverage report

--- a/README.md
+++ b/README.md
@@ -153,6 +153,20 @@ dot -Tpdf cfg.dot > cfg.pdf
 
 </details>
 
+## Running unit tests
+
+Build with `VERIFIER_ENABLE_TESTS=ON` to produce the `tests` binary. Run the
+suite sequentially using:
+```bash
+./tests -d yes
+```
+
+For faster execution, `scripts/run-tests-parallel.sh` splits the Catch2 suite
+across available CPUs and runs the shards concurrently:
+```bash
+scripts/run-tests-parallel.sh -d yes
+```
+
 ## Testing the Linux verifier
 
 To run the Linux verifier, you must use `sudo`:

--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ across available CPUs and runs the shards concurrently:
 ```bash
 scripts/run-tests-parallel.sh -d yes
 ```
+The equivalent PowerShell script for Windows is `scripts/run-tests-parallel.ps1`:
+```powershell
+scripts/run-tests-parallel.ps1 -d yes
+```
 
 ## Testing the Linux verifier
 

--- a/scripts/run-tests-parallel.ps1
+++ b/scripts/run-tests-parallel.ps1
@@ -14,11 +14,18 @@ if (-not (Test-Path $testBin)) {
     exit 1
 }
 
-$jobs = [int](if ($env:NUM_JOBS) { $env:NUM_JOBS } else { [Environment]::ProcessorCount })
+$jobs = if ($env:NUM_JOBS) {
+    [int]$env:NUM_JOBS
+} else {
+    [Environment]::ProcessorCount
+}
 
 $procs = @()
 for ($i = 0; $i -lt $jobs; $i++) {
-    $arguments = "--shard-count $jobs --shard-index $i" + (if ($args) { ' ' + ($args -join ' ') } else { '' })
+    $arguments = "--shard-count $jobs --shard-index $i"
+    if ($args.Count -gt 0) {
+        $arguments += " " + ($args -join ' ')
+    }
     $procs += Start-Process -FilePath $testBin -ArgumentList $arguments -NoNewWindow -PassThru
 }
 

--- a/scripts/run-tests-parallel.ps1
+++ b/scripts/run-tests-parallel.ps1
@@ -1,0 +1,30 @@
+# Copyright (c) Prevail Verifier contributors.
+# SPDX-License-Identifier: MIT
+
+# Run Catch2 based tests in parallel using sharding.
+# Any arguments passed to this script are forwarded to each test shard.
+
+$ErrorActionPreference = 'Stop'
+
+$root = (git rev-parse --show-toplevel).Trim()
+$testBin = Join-Path $root "$env:BUILD_CONFIGURATION\tests.exe"
+
+if (-not (Test-Path $testBin)) {
+    Write-Error "Test executable not found: $testBin"
+    exit 1
+}
+
+$jobs = [int](if ($env:NUM_JOBS) { $env:NUM_JOBS } else { [Environment]::ProcessorCount })
+
+$procs = @()
+for ($i = 0; $i -lt $jobs; $i++) {
+    $arguments = "--shard-count $jobs --shard-index $i" + (if ($args) { ' ' + ($args -join ' ') } else { '' })
+    $procs += Start-Process -FilePath $testBin -ArgumentList $arguments -NoNewWindow -PassThru
+}
+
+$exitCode = 0
+foreach ($p in $procs) {
+    $p.WaitForExit()
+    if ($p.ExitCode -ne 0) { $exitCode = $p.ExitCode }
+}
+exit $exitCode

--- a/scripts/run-tests-parallel.sh
+++ b/scripts/run-tests-parallel.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Prevail Verifier contributors.
+# SPDX-License-Identifier: MIT
+
+# Run Catch2 based tests in parallel using sharding.
+# Any arguments passed to this script are forwarded to each test shard.
+
+set -o errexit
+set -o pipefail
+
+root=$(git rev-parse --show-toplevel)
+test_bin="${root}/tests"
+
+if [[ ! -x "${test_bin}" ]]; then
+    echo "Test executable not found: ${test_bin}" >&2
+    exit 1
+fi
+
+jobs=${NUM_JOBS:-$(nproc)}
+
+pids=()
+for ((i=0; i<jobs; i++)); do
+    "${test_bin}" --shard-count "${jobs}" --shard-index "${i}" "$@" &
+    pids+=("$!")
+done
+
+trap 'kill "${pids[@]}"' INT TERM
+ret=0
+for pid in "${pids[@]}"; do
+    wait "$pid" || ret=1
+done
+exit ${ret}


### PR DESCRIPTION
## Summary
- add `scripts/run-tests-parallel.sh` helper to run the Catch2 suite concurrently
- document how to use the script in README
- use the new script in GitHub Actions to run tests in parallel on Linux builds and coverage job

## Testing
- `NUM_JOBS=2 scripts/run-tests-parallel.sh --list-tests | head -n 5` *(fails: Test executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a13e49de083298a30fd95bd6c063f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced scripts to run unit tests in parallel on both Linux and Windows, improving test execution speed by leveraging multiple CPU cores.
- **Documentation**
  - Added detailed instructions in the README for running unit tests sequentially and in parallel using the new scripts.
- **Chores**
  - Updated automated workflows to utilize the new parallel test execution scripts for running unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->