### PR TITLE
Bump catch2 to 3.9.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ get_target_property(GSL_INCLUDE_DIRS Microsoft.GSL::GSL INTERFACE_INCLUDE_DIRECT
 if (VERIFIER_ENABLE_TESTS)
     FetchContent_Declare(Catch2
             GIT_REPOSITORY "https://github.com/catchorg/Catch2.git"
-            GIT_TAG "v3.9.0"
+            GIT_TAG "v3.9.1"
             GIT_SHALLOW ON
     )
     FetchContent_MakeAvailable(Catch2)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the unit testing framework to the latest patch release to align with upstream fixes and improve test stability.
* **Chores**
  * Performed routine maintenance on test-related dependencies to keep the build and verification pipeline current.
  * No changes to user-facing features or behavior; application functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->