### PR TITLE
Bump Catch2 to v3.11.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ get_target_property(GSL_INCLUDE_DIRS Microsoft.GSL::GSL INTERFACE_INCLUDE_DIRECT
 if (VERIFIER_ENABLE_TESTS)
     FetchContent_Declare(Catch2
             GIT_REPOSITORY "https://github.com/catchorg/Catch2.git"
-            GIT_TAG "v3.10.0"
+            GIT_TAG "v3.11.0"
             GIT_SHALLOW ON
     )
     FetchContent_MakeAvailable(Catch2)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the internal test framework to Catch2 v3.11.0, ensuring alignment with the latest minor release and improved stability during test runs.
  * No impact on product behavior or user-facing features.

* **Chores**
  * Refreshed test infrastructure dependency to the newer Catch2 version for consistent builds across environments.
  * Maintains existing test coverage and execution flow without functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->