### PR TITLE
Fix narrowing_error on 64-bit SUB with an INT_MIN immediate (#1229)

### DIFF
--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -105,7 +105,7 @@ class EbpfTransformer final {
     void do_mem_store(const Mem& b, const LinearExpression& val_svalue, const LinearExpression& val_uvalue,
                       const std::optional<Reg>& opt_val_reg);
 
-    void add(const Reg& dst_reg, int imm, int finite_width);
+    void add(const Reg& dst_reg, int64_t imm, int finite_width);
 
     void shl(const Reg& dst_reg, int imm, int finite_width);
 
@@ -1129,7 +1129,7 @@ void EbpfTransformer::recompute_stack_numeric_size(TypeToNumDomain& state, const
     recompute_stack_numeric_size(state, reg_type(reg));
 }
 
-void EbpfTransformer::add(const Reg& dst_reg, const int imm, const int finite_width) {
+void EbpfTransformer::add(const Reg& dst_reg, const int64_t imm, const int finite_width) {
     const auto dst = reg_pack(dst_reg);
     if (dom.state.may_have_type(dst_reg, T_NUM)) {
         dom.state.values->add_overflow(dst.svalue, dst.uvalue, imm, finite_width);
@@ -1258,13 +1258,15 @@ void EbpfTransformer::operator()(const Bin& bin) {
             if (imm == 0) {
                 return;
             }
-            add(bin.dst, gsl::narrow<int>(imm), finite_width);
+            add(bin.dst, imm, finite_width);
             break;
         case Bin::Op::SUB:
             if (imm == 0) {
                 return;
             }
-            add(bin.dst, gsl::narrow<int>(-imm), finite_width);
+            // Negate in 64 bits: imm is a sign-extended 32-bit value, so -INT32_MIN
+            // is representable here even though it does not fit in an int.
+            add(bin.dst, -imm, finite_width);
             break;
         case Bin::Op::MUL:
             dom.state.values->mul(dst.svalue, dst.uvalue, imm, finite_width);

--- a/test-data/add.yaml
+++ b/test-data/add.yaml
@@ -154,3 +154,17 @@ post:
   - r7.svalue-r2.uvalue<=5
   - r2.packet_offset-r7.packet_offset<=-3
   - r7.packet_offset-r2.packet_offset<=5
+
+---
+test-case: add INT_MIN immediate, 64-bit
+
+pre: ["r0.type=number", "r0.svalue=0", "r0.uvalue=0"]
+
+code:
+  <start>: |
+    r0 += -2147483648
+
+post:
+  - r0.type=number
+  - r0.svalue=-2147483648
+  - r0.uvalue=18446744071562067968

--- a/test-data/subtract.yaml
+++ b/test-data/subtract.yaml
@@ -1,6 +1,34 @@
 # Copyright (c) Prevail Verifier contributors.
 # SPDX-License-Identifier: MIT
 ---
+test-case: subtract INT_MIN immediate, 64-bit
+
+# https://github.com/vbpf/prevail/issues/1229: negating the immediate used to
+# overflow the int that carried it, so `-= INT_MIN` aborted with narrowing_error.
+pre: ["r0.type=number", "r0.svalue=0", "r0.uvalue=0"]
+
+code:
+  <start>: |
+    r0 -= -2147483648
+
+post:
+  - r0.type=number
+  - r0.svalue=2147483648
+  - r0.uvalue=2147483648
+---
+test-case: subtract INT_MIN immediate, 32-bit
+
+pre: ["r0.type=number", "r0.svalue=0", "r0.uvalue=0"]
+
+code:
+  <start>: |
+    w0 -= -2147483648
+
+post:
+  - r0.type=number
+  - r0.svalue=2147483648
+  - r0.uvalue=2147483648
+---
 test-case: subtract immediate from large singleton number
 
 pre: ["r0.type=number", "r0.svalue=2147483649", "r0.uvalue=2147483649"]


### PR DESCRIPTION
Fixes #1229.

`r0 -= -0x80000000` aborted the analysis with `error: narrowing_error`:

```
0:  b7 00 00 00 00 00 00 00 r0 = 0x0
1:  17 00 00 00 00 00 00 80 r0 -= -0x80000000
2:  95 00 00 00 00 00 00 00 exit
```

## Cause

`EbpfTransformer::add` took the immediate as an `int`, and the SUB case reached it through
`add(bin.dst, gsl::narrow<int>(-imm), ...)`. `imm` is an `int64_t` holding a sign-extended
32-bit immediate, so for `imm == INT32_MIN` the negation is 2147483648, one past `INT_MAX`,
and `gsl::narrow` threw. The value is otherwise ordinary: nothing downstream of `add` needs
a 32-bit parameter, since every use converts to `Number`.

## Fix

Widen the parameter to `int64_t` and negate there. `|imm| <= 2^31` on both paths — the
64-bit one carries a sign-extended imm32, the 32-bit one a `narrow_cast<int32_t>` — so the
negation cannot overflow.

## Testing

The reporter's object file now passes and leaves `r0.svalue = 2147483648`. The two new
`subtract.yaml` cases fail with `Exception: narrowing_error` when the source fix is
reverted; the `add.yaml` case pins the ADD side of the same boundary, which was already
correct.

Full suite: 640 cases, 639 passed + 1 skipped, all 417044 assertions passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nb7vGAy22VEik5PotYN92p
