### PR TITLE
Clamp the svalue read in assume_signed_32bit_eq to 64 bits (#1230)

### DIFF
--- a/src/crab/finite_domain.cpp
+++ b/src/crab/finite_domain.cpp
@@ -70,7 +70,13 @@ std::vector<LinearConstraint> FiniteDomain::assume_signed_32bit_eq(const Variabl
     using namespace dsl_syntax;
 
     if (const auto rn = right_interval.singleton()) {
-        const auto left_svalue_interval = eval_interval(left_svalue);
+        // The zone domain stores bounds as unbounded numbers, and its closure can derive a
+        // bound for an svalue from a difference constraint plus the other operand's bound.
+        // That sum is a sound but unrepresentable bound: it can land outside [INT64_MIN,
+        // INT64_MAX] even though the register itself always holds a 64-bit signed value.
+        // Read the 64-bit view, exactly as get_signed_intervals() hands one to every other
+        // assume helper, so the endpoints below can be taken as int64_t.
+        const auto left_svalue_interval = eval_interval(left_svalue).truncate_to<int64_t>();
         if (left_svalue_interval.finite_size()) {
             // Find the lowest 64-bit svalue whose low 32 bits match the singleton.
 

--- a/test-data/jump.yaml
+++ b/test-data/jump.yaml
@@ -1195,3 +1195,33 @@ post:
   - "_|_"
 messages:
   - "0: Lower bound must be at least r10.stack_offset - subprogram_stack_size (valid_access(r1.offset) for comparison/subtraction)"
+---
+test-case: 32-bit equality when a zone bound exceeds the 64-bit range
+
+# https://github.com/vbpf/prevail/issues/1230. The zone domain keeps
+# r0.svalue - r1.uvalue <= 2^64 - 8388608 across the outer loop; closing it
+# against r1.uvalue's upper bound gives r0.svalue <= 2^64 + 0x7f7f0000, a sound
+# bound that no int64_t can hold. Reading it raw aborted the analysis.
+pre: ["r1.type=ctx", "r1.ctx_offset=0", "r1.uvalue=[1, 2147418112]",
+      "r10.type=stack", "r10.stack_offset=4096", "r10.uvalue=[4096, 2147418112]",
+      "meta_offset=0", "packet_size=0"]
+
+code:
+  <start>: |
+    r0 = 0
+    r2 = 0
+  <loop>: |
+    r2 = -1
+  <self>: |
+    if w0 == 1 goto <self>
+    w0 ^= -65536
+    r1 = 8388607
+    if w0 >= 0 goto <loop>
+  <exit>: |
+    exit
+
+post:
+  - "_|_"
+
+messages:
+  - "6:7: Code becomes unreachable (assume r0 w< 0)"


### PR DESCRIPTION
Fixes #1230.

The reported program aborted the analysis with

```
CRAB ERROR: Number 18446744075848581120 does not fit into l
```

## Cause

18446744075848581120 is 2^64 + 0x7f7f0000. It is not a value any register can hold; it is
what the zone domain's closure derives for `r0.svalue` at the head of the outer loop, from
the two facts it does hold there:

```
r0.svalue - r1.uvalue <= 18446744073701163008   (2^64 - 8388608)
r1.uvalue <= 2147418112
```

Zone weights are unbounded `Number`s, so that sum is a legitimate, sound bound. It is
simply weaker than `INT64_MAX` and therefore not representable.

Every other consumer of a register interval gets a 64-bit view: both `get_signed_intervals()`
and `get_unsigned_intervals()` end with a `truncate_to<int64_t>()` / `truncate_to<uint64_t>()`.
`assume_signed_32bit_eq()` is the one helper that re-reads the raw interval, because it needs
the 64-bit svalue (it matches high 32 bits against the compared low 32 bits) rather than the
32-bit view its caller computed. It then took both endpoints as `int64_t` without checking,
and threw.

## Fix

Take the same 64-bit view before reading the endpoints. `truncate_to<int64_t>()` is
`sign_extend(64)`, which is the identity on any in-range interval and returns
`[INT64_MIN, INT64_MAX]` for one this wide, so the fix is inert except where the old code
aborted.

## Testing

The new `jump.yaml` case is the reporter's instruction sequence with the entry invariant its
ELF produces; it fails with the CRAB ERROR above when the source fix is reverted. The
reporter's object file now passes verification.

Full suite: 640 cases, 639 passed + 1 skipped, all 417044 assertions passing.

Related: #1233 fixes two more crash sites with the same cause, found while reducing this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nb7vGAy22VEik5PotYN92p
