### PR TITLE
Clamp the uvalue read in shl and lshr to 64 bits

### DIFF
--- a/src/crab/finite_domain.cpp
+++ b/src/crab/finite_domain.cpp
@@ -1029,7 +1029,11 @@ void FiniteDomain::shl(const Variable svalue, const Variable uvalue, const int i
         shl_overflow(svalue, uvalue, imm);
         return;
     }
-    auto [lb_n, ub_n] = uinterval.pair<uint64_t>();
+    // Zone weights are unbounded numbers, so closing a difference constraint against the
+    // other operand's bound can give uvalue a finite bound outside [0, UINT64_MAX], or a
+    // negative one that has not yet been re-established as non-negative. Both are sound
+    // but not representable, so read the 64-bit unsigned view of the endpoints.
+    auto [lb_n, ub_n] = uinterval.truncate_to<uint64_t>().pair<uint64_t>();
     const uint64_t uint_max = finite_width == 64 ? uint64_t{std::numeric_limits<uint64_t>::max()}
                                                  : uint64_t{std::numeric_limits<uint32_t>::max()};
     const int unpreserved_bit_count = finite_width - imm;
@@ -1055,7 +1059,8 @@ void FiniteDomain::shl(const Variable svalue, const Variable uvalue, const int i
 void FiniteDomain::lshr(const Variable svalue, const Variable uvalue, const int imm, const int finite_width) {
     const auto uinterval = eval_interval(uvalue);
     if (uinterval.finite_size()) {
-        auto [lb_n, ub_n] = uinterval.pair_number();
+        // See shl(): a finite stored bound need not be representable as a uint64_t.
+        auto [lb_n, ub_n] = uinterval.truncate_to<uint64_t>().pair_number();
         if (finite_width == 64) {
             lb_n = lb_n.cast_to<uint64_t>() >> imm;
             ub_n = ub_n.cast_to<uint64_t>() >> imm;

--- a/test-data/shift.yaml
+++ b/test-data/shift.yaml
@@ -1425,3 +1425,62 @@ post:
   - r3.type=number
   - r3.uvalue=0
   - r3.svalue=0
+---
+test-case: left shift when a zone bound exceeds the 64-bit range
+
+# Same root cause as the #1230 crash in assume_signed_32bit_eq: the zone domain
+# keeps r0.svalue - r1.uvalue <= 2^64 - 8388608 across the outer loop, and
+# closing it against r1.uvalue's upper bound gives r0.uvalue <= 2^64 +
+# 0x7f7f0000 -- sound, but wider than any uint64_t. shl() read that bound raw.
+pre: ["r1.type=ctx", "r1.ctx_offset=0", "r1.uvalue=[1, 2147418112]",
+      "r10.type=stack", "r10.stack_offset=4096", "r10.uvalue=[4096, 2147418112]",
+      "meta_offset=0", "packet_size=0"]
+
+code:
+  <start>: |
+    r0 = 0
+    r2 = 0
+  <loop>: |
+    r2 = -1
+  <self>: |
+    r0 <<= 1
+    if w0 == 1 goto <self>
+    w0 ^= -65536
+    r1 = 8388607
+    if w0 >= 0 goto <loop>
+  <exit>: |
+    exit
+
+post:
+  - "_|_"
+
+messages:
+  - "7:8: Code becomes unreachable (assume r0 w< 0)"
+
+---
+test-case: unsigned right shift when a zone bound exceeds the 64-bit range
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0", "r1.uvalue=[1, 2147418112]",
+      "r10.type=stack", "r10.stack_offset=4096", "r10.uvalue=[4096, 2147418112]",
+      "meta_offset=0", "packet_size=0"]
+
+code:
+  <start>: |
+    r0 = 0
+    r2 = 0
+  <loop>: |
+    r2 = -1
+  <self>: |
+    r0 >>= 1
+    if w0 == 1 goto <self>
+    w0 ^= -65536
+    r1 = 8388607
+    if w0 >= 0 goto <loop>
+  <exit>: |
+    exit
+
+post:
+  - "_|_"
+
+messages:
+  - "7:8: Code becomes unreachable (assume r0 w< 0)"


### PR DESCRIPTION
Two more crash sites of the kind #1230 reports, found while reducing it. They are not
filed as their own issue; they were not reachable from the reported program, only from
one-instruction mutations of it.

Adding one shift to that program aborts the analysis before it ever reaches
`assume_signed_32bit_eq`:

```
r0 <<= 1  ->  CRAB ERROR: Number 18446744075848581120 does not fit into m;
              function narrow, line 208
r0 >>= 1  ->  CRAB ERROR: Number 18446744075848581120 does not fit into m;
              function cast_to, line 258
```

## Cause

Same as #1230: the zone domain's closure derives `r0.uvalue <= 2^64 + 0x7f7f0000` from the
difference constraint it carries across the outer loop, and both shift transfer functions
take the endpoints of the stored interval as `uint64_t` without checking. `shl()` goes
through `Interval::pair<uint64_t>()`, which uses `Number::narrow` and throws outright;
`lshr()` goes through `Number::cast_to`, which also accepts the `int64_t` range but not this.

## Fix

Read the 64-bit unsigned view of the endpoints. The `finite_size()` test still runs on the
raw interval, so an unbounded uvalue keeps taking the `shl_overflow` / full-range paths and
nothing else changes: `truncate_to<uint64_t>()` is `zero_extend(64)`, the identity on any
interval already inside `[0, UINT64_MAX]`.

It also covers a case that failed quietly: a uvalue whose lower bound is still negative
after a relational join — the situation `Interval::bitwise_and()` already compensates for —
made `shl()` throw and made `lshr()` build an interval with `lb > ub`, i.e. bottom, from a
state that is not bottom. Zero-extending first turns both into the full unsigned range.

## Testing

Both new `shift.yaml` cases fail with the CRAB ERROR above when the source fix is reverted.

A mutation sweep around the #1230 program — 2057 variants, one instruction inserted or one
immediate/operator substituted, driven one YAML file at a time — crashes on 141 of them
against current `main` (128 `narrowing_error` from #1229, 2 in `assume_signed_32bit_eq`, 11
in `shl`/`lshr`) and on none of them with this PR, #1231 and #1232 applied together.

Full suite: 640 cases, 639 passed + 1 skipped, all 417044 assertions passing.

Independent of #1231 and #1232; all three branch from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nb7vGAy22VEik5PotYN92p
